### PR TITLE
ci(tournament): publish results via admin PAT and trigger deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ name: CI
 on:
   push:
     branches: [master]
+    # The daily tournament pushes generated data to master; no need to re-run
+    # the full suite for those data-only commits (Deploy still fires).
+    paths-ignore:
+      - 'public/data/**'
   pull_request:
     branches: [master]
 

--- a/.github/workflows/tournament.yml
+++ b/.github/workflows/tournament.yml
@@ -24,6 +24,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Admin-scoped PAT so the results push bypasses the branch ruleset
+          # (default GITHUB_TOKEN is github-actions[bot], which isn't an admin).
+          token: ${{ secrets.TOURNAMENT_PAT }}
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -44,7 +48,11 @@ jobs:
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else
-            git commit -m "chore: update tournament results [skip ci]"
+            # No [skip ci]: this push to master must trigger Deploy so the
+            # live site rebuilds with the fresh leaderboard. CI is skipped for
+            # data-only commits via paths-ignore in ci.yml; tournament.yml does
+            # not watch public/data/**, so this won't re-trigger itself.
+            git commit -m "chore: update tournament results"
             push_ok=false
             for i in 1 2 3; do
               git pull --rebase origin master && git push && push_ok=true && break


### PR DESCRIPTION
## Problem

The daily **Online Tournament** workflow runs fine but can't publish its results:

1. **Push rejected.** It commits `public/data/` and pushes straight to `master` with the default `GITHUB_TOKEN` (`github-actions[bot]`). The branch ruleset requires a PR for everyone except repo admins, so the push is rejected (`GH013`).
2. **Wouldn't refresh anyway.** The commit carried `[skip ci]`, which skips *all* workflows including **Deploy**. Since the site serves `data/leaderboard.json` as a same-origin static file bundled at build time, the live leaderboard only updates when a deploy runs.

Net effect: the daily auto-refresh could never reach the live site.

## Fix

- **tournament.yml**: checkout with `secrets.TOURNAMENT_PAT` so the results push authenticates as an admin and bypasses the ruleset; drop `[skip ci]` so the data push triggers **Deploy** and the live site rebuilds with fresh results.
- **ci.yml**: `paths-ignore: ['public/data/**']` so data-only commits skip the full suite. Deploy still runs; tournament.yml doesn't watch `public/data/**`, so there's no self-trigger loop.

## Required before this helps

A repo secret **`TOURNAMENT_PAT`** — a fine-grained PAT scoped to this repo with **Contents: Read and write**, owned by an admin (so its pushes bypass the ruleset). Without it the checkout step will fail.

## Why no security change

The ruleset is untouched: humans still need a PR + 1 review. Only this one automated job, via an admin-owned token, can push generated data.