### PR TITLE
feat: add number-only dice display option

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -60,10 +60,12 @@ async function main() {
   if (gameRenderer) {
     gameRenderer.setTheme(preferencesManager.get('theme'));
     gameRenderer.setColorBlindMode(preferencesManager.get('colorBlindMode'));
+    gameRenderer.setDiceDisplayMode(preferencesManager.get('diceDisplayMode'));
 
     preferencesManager.subscribe(prefs => {
       gameRenderer.setTheme(prefs.theme);
       gameRenderer.setColorBlindMode(prefs.colorBlindMode);
+      gameRenderer.setDiceDisplayMode(prefs.diceDisplayMode);
       // Sync body background for the HTML body element
       document.body.style.background = prefs.theme === 'light' ? '#e8e8f0' : '#1a1a2e';
     });

--- a/src/renderer/DiceRenderer.js
+++ b/src/renderer/DiceRenderer.js
@@ -9,7 +9,7 @@
  * @module renderer/DiceRenderer
  */
 
-import { Container, Graphics } from 'pixi.js';
+import { Container, Graphics, Text } from 'pixi.js';
 import {
   PLAYER_COLORS,
   COLORBLIND_PLAYER_COLORS,
@@ -34,6 +34,12 @@ const BACK_COLUMN_Y = -DICE_SIZE * 0.35;
 /** Container offset from the center cell's top-left corner. */
 const DICE_OFFSET_X = 4;
 const DICE_OFFSET_Y = 12;
+
+/** Count-badge geometry for number-only display mode (before map scaling). */
+const BADGE_CENTER_X = DICE_SIZE * 0.9;
+const BADGE_CENTER_Y = -DICE_SIZE * 0.55;
+const BADGE_RADIUS = DICE_SIZE * 0.95;
+const BADGE_FONT_SIZE = Math.round(DICE_SIZE * 1.25);
 
 /**
  * Darken a color by a factor (0-1).
@@ -175,6 +181,8 @@ export class DiceRenderer {
     this._diceContainers = [];
     /** @type {boolean} Color-blind mode */
     this._colorBlindMode = false;
+    /** @type {'dice' | 'number'} How dice counts are shown */
+    this._displayMode = 'dice';
   }
 
   /**
@@ -183,6 +191,14 @@ export class DiceRenderer {
    */
   setColorBlindMode(enabled) {
     this._colorBlindMode = enabled;
+  }
+
+  /**
+   * Set how dice counts are shown: stacked dice or a single count badge.
+   * @param {'dice' | 'number'} mode
+   */
+  setDiceDisplayMode(mode) {
+    this._displayMode = mode === 'number' ? 'number' : 'dice';
   }
 
   /**
@@ -233,8 +249,10 @@ export class DiceRenderer {
       return this._cellPos.y[centerA] - this._cellPos.y[centerB];
     });
 
-    // Remove all existing dice containers from parent
-    this.container.removeChildren();
+    // Remove and dispose existing dice containers (Graphics + Text) to avoid GPU leaks
+    for (const child of this.container.removeChildren()) {
+      child.destroy({ children: true });
+    }
 
     for (const areaId of sortedAreas) {
       const area = areas[areaId];
@@ -255,6 +273,23 @@ export class DiceRenderer {
     diceContainer.x = this._cellPos.x[centerCell] + DICE_OFFSET_X;
     diceContainer.y = this._cellPos.y[centerCell] + DICE_OFFSET_Y;
 
+    if (this._displayMode === 'number') {
+      this._drawCountBadge(diceContainer, area);
+    } else {
+      this._drawDiceStack(diceContainer, areaId, area);
+    }
+
+    this._diceContainers[areaId] = diceContainer;
+    this.container.addChild(diceContainer);
+  }
+
+  /**
+   * Draw the classic stacked-dice representation into an area container.
+   * @param {Container} container
+   * @param {number} areaId
+   * @param {import('../engine/types.js').Area} area
+   */
+  _drawDiceStack(container, areaId, area) {
     const color = dieBaseColor(this._getPlayerColor(area.owner));
     const pipColor = this._getPipColor(area.owner);
     const gfx = new Graphics();
@@ -283,10 +318,44 @@ export class DiceRenderer {
       drawDie(gfx, 0, y, color, pipColor, dieValue(i));
     }
 
-    diceContainer.addChild(gfx);
+    container.addChild(gfx);
+  }
 
-    this._diceContainers[areaId] = diceContainer;
-    this.container.addChild(diceContainer);
+  /**
+   * Draw a compact owner-colored badge showing the dice count, used when the
+   * display mode is 'number'. Reuses the dice palette and dark outline so the
+   * owner stays identifiable at a glance.
+   * @param {Container} container
+   * @param {import('../engine/types.js').Area} area
+   */
+  _drawCountBadge(container, area) {
+    const fillColor = dieBaseColor(this._getPlayerColor(area.owner));
+    const gfx = new Graphics();
+
+    // Drop shadow, matching the dice look
+    gfx.ellipse(BADGE_CENTER_X, DICE_SIZE * 0.3, DICE_SIZE * 1.05, DICE_SIZE * 0.38);
+    gfx.fill({ color: 0x000000, alpha: 0.3 });
+
+    // Owner-colored chip with the same dark outline as the dice
+    gfx.circle(BADGE_CENTER_X, BADGE_CENTER_Y, BADGE_RADIUS);
+    gfx.fill(fillColor);
+    gfx.stroke({ width: 1.5, color: BORDER_COLOR, join: 'round' });
+    container.addChild(gfx);
+
+    // White, dark-outlined numeral reads on every owner color
+    const label = new Text({
+      text: String(area.dice),
+      style: {
+        fontFamily: 'Anton, sans-serif',
+        fontSize: BADGE_FONT_SIZE,
+        fill: 0xffffff,
+        stroke: { color: BORDER_COLOR, width: 3 },
+      },
+      x: BADGE_CENTER_X,
+      y: BADGE_CENTER_Y,
+      anchor: { x: 0.5, y: 0.5 },
+    });
+    container.addChild(label);
   }
 
   /** Clean up. */

--- a/src/renderer/GameRenderer.js
+++ b/src/renderer/GameRenderer.js
@@ -35,6 +35,8 @@ export class GameRenderer {
     this._theme = null;
     /** @type {boolean} Color-blind mode */
     this._colorBlindMode = false;
+    /** @type {'dice' | 'number'} How dice counts are shown */
+    this._diceDisplayMode = 'dice';
     /** @type {{ x: number, y: number }} Saved root position for screen shake */
     this._rootOrigin = { x: 0, y: 0 };
     /** @type {boolean} Whether a screen shake is active */
@@ -204,6 +206,23 @@ export class GameRenderer {
     // Repaint if we have state
     if (this.hexGrid && this.hexGrid._lastState) {
       this.hexGrid.redrawAll();
+      this.dice.drawAll(this.hexGrid._lastState);
+    }
+  }
+
+  /**
+   * Set how dice counts are displayed: stacked dice or a single count badge.
+   * @param {'dice' | 'number'} mode
+   */
+  setDiceDisplayMode(mode) {
+    if (this._diceDisplayMode === mode) return;
+    this._diceDisplayMode = mode;
+    if (!this.initialized) return;
+
+    if (this.dice) this.dice.setDiceDisplayMode(mode);
+
+    // Repaint if we have state
+    if (this.hexGrid && this.hexGrid._lastState) {
       this.dice.drawAll(this.hexGrid._lastState);
     }
   }

--- a/src/store/GameStore.js
+++ b/src/store/GameStore.js
@@ -49,6 +49,7 @@ const DEFAULT_STATE = {
   preferences: {
     theme: 'dark',
     colorBlindMode: false,
+    diceDisplayMode: 'dice',
     animationSpeed: 1,
     reducedMotion: 'system',
   },

--- a/src/store/PreferencesManager.js
+++ b/src/store/PreferencesManager.js
@@ -12,6 +12,7 @@ const STORAGE_KEY = 'dicewars_prefs';
 export const DEFAULTS = {
   theme: 'dark',
   colorBlindMode: false,
+  diceDisplayMode: 'dice', // 'dice' | 'number'
   animationSpeed: 1,
   reducedMotion: 'system', // 'system' | 'on' | 'off'
   muted: false,
@@ -20,6 +21,7 @@ export const DEFAULTS = {
 const VALIDATORS = {
   theme: v => typeof v === 'string' && ['dark', 'light'].includes(v),
   colorBlindMode: v => typeof v === 'boolean',
+  diceDisplayMode: v => typeof v === 'string' && ['dice', 'number'].includes(v),
   animationSpeed: v => typeof v === 'number' && v > 0 && v <= 10,
   reducedMotion: v => typeof v === 'string' && ['system', 'on', 'off'].includes(v),
   muted: v => typeof v === 'boolean',

--- a/src/ui/SettingsPanel.jsx
+++ b/src/ui/SettingsPanel.jsx
@@ -24,6 +24,11 @@ const MOTION_OPTIONS = [
   { value: 'off', label: 'Off' },
 ];
 
+const DICE_DISPLAY_OPTIONS = [
+  { value: 'dice', label: 'Dice' },
+  { value: 'number', label: 'Number' },
+];
+
 const STYLE = {
   wrapper: {
     position: 'fixed',
@@ -225,6 +230,30 @@ export function SettingsPanel({ store, preferencesManager }) {
                 }}
               />
             </button>
+          </div>
+
+          {/* Dice display */}
+          <div style={STYLE.row}>
+            <span style={STYLE.label}>Dice display</span>
+            <div style={STYLE.btnGroup}>
+              {DICE_DISPLAY_OPTIONS.map(opt => {
+                const active = (prefs.diceDisplayMode || 'dice') === opt.value;
+                return (
+                  <button
+                    key={opt.value}
+                    style={{
+                      ...STYLE.optionBtn,
+                      background: active ? accent : 'transparent',
+                      color: active ? '#fff' : textColor,
+                      borderColor: active ? accent : borderColor,
+                    }}
+                    onClick={() => setPref('diceDisplayMode', opt.value)}
+                  >
+                    {opt.label}
+                  </button>
+                );
+              })}
+            </div>
           </div>
 
           {/* Mute sounds */}

--- a/tests/bridge/integration.test.js
+++ b/tests/bridge/integration.test.js
@@ -43,7 +43,14 @@ describe('Bridge Module Integration', () => {
     test('exposes AI functions to global scope', async () => {
       // Import the bridge module to trigger the code
       await import('../../src/bridge/ai.js');
-      await Promise.resolve();
+
+      // ai.js installs placeholders synchronously, then swaps in the real
+      // implementations from a fire-and-forget async IIFE (dynamic imports).
+      // A single microtask tick isn't enough under a busy event loop (CI),
+      // so wait for the replacement to actually land instead of racing it.
+      await vi.waitFor(() => {
+        expect(window.ai_default?.isPlaceholder).toBeFalsy();
+      });
 
       // Load ES6 implementations for comparison
       const ai_default = await getAIImplementation('ai_default');

--- a/tests/renderer/diceDisplayMode.test.js
+++ b/tests/renderer/diceDisplayMode.test.js
@@ -1,0 +1,77 @@
+/**
+ * Dice-display-mode live-apply seam tests.
+ *
+ * Covers the guard/delegation/repaint logic added for the "number-only dice
+ * display" feature. These methods are pure control flow over instance fields,
+ * so they're exercised via `prototype.<method>.call(stub, ...)` against
+ * hand-built stubs — no PixiJS Application or GPU required.
+ */
+
+import { GameRenderer } from '../../src/renderer/GameRenderer.js';
+import { DiceRenderer } from '../../src/renderer/DiceRenderer.js';
+
+describe('DiceRenderer.setDiceDisplayMode', () => {
+  const setMode = (stub, mode) => DiceRenderer.prototype.setDiceDisplayMode.call(stub, mode);
+
+  it("stores 'number' verbatim", () => {
+    const stub = { _displayMode: 'dice' };
+    setMode(stub, 'number');
+    expect(stub._displayMode).toBe('number');
+  });
+
+  it("stores 'dice' verbatim", () => {
+    const stub = { _displayMode: 'number' };
+    setMode(stub, 'dice');
+    expect(stub._displayMode).toBe('dice');
+  });
+
+  it("normalizes any non-'number' value to 'dice'", () => {
+    for (const bad of ['pips', '', undefined, null, 0, 'NUMBER']) {
+      const stub = { _displayMode: 'number' };
+      setMode(stub, bad);
+      expect(stub._displayMode).toBe('dice');
+    }
+  });
+});
+
+describe('GameRenderer.setDiceDisplayMode', () => {
+  const setMode = (stub, mode) => GameRenderer.prototype.setDiceDisplayMode.call(stub, mode);
+
+  const makeStub = (overrides = {}) => ({
+    _diceDisplayMode: 'dice',
+    initialized: true,
+    dice: { setDiceDisplayMode: vi.fn(), drawAll: vi.fn() },
+    hexGrid: { _lastState: { meta: 1 } },
+    ...overrides,
+  });
+
+  it('no-ops when the mode is unchanged', () => {
+    const stub = makeStub({ _diceDisplayMode: 'number' });
+    setMode(stub, 'number');
+    expect(stub.dice.setDiceDisplayMode).not.toHaveBeenCalled();
+    expect(stub.dice.drawAll).not.toHaveBeenCalled();
+  });
+
+  it('updates the field but does not touch the renderer before init', () => {
+    const stub = makeStub({ initialized: false });
+    setMode(stub, 'number');
+    expect(stub._diceDisplayMode).toBe('number');
+    expect(stub.dice.setDiceDisplayMode).not.toHaveBeenCalled();
+    expect(stub.dice.drawAll).not.toHaveBeenCalled();
+  });
+
+  it('delegates to the dice renderer and repaints when initialized with state', () => {
+    const stub = makeStub();
+    setMode(stub, 'number');
+    expect(stub._diceDisplayMode).toBe('number');
+    expect(stub.dice.setDiceDisplayMode).toHaveBeenCalledWith('number');
+    expect(stub.dice.drawAll).toHaveBeenCalledWith(stub.hexGrid._lastState);
+  });
+
+  it('delegates but skips repaint when there is no current state', () => {
+    const stub = makeStub({ hexGrid: { _lastState: null } });
+    setMode(stub, 'number');
+    expect(stub.dice.setDiceDisplayMode).toHaveBeenCalledWith('number');
+    expect(stub.dice.drawAll).not.toHaveBeenCalled();
+  });
+});

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,3 +1,20 @@
+// jsdom doesn't implement canvas 2d. PixiJS probes `canvas.getContext('2d')`
+// at import time (canvas blend-mode feature detection), which otherwise logs a
+// noisy "Not implemented" error whenever a test imports a renderer module.
+// A minimal context stub satisfies that probe (and any future renderer test).
+if (typeof HTMLCanvasElement !== 'undefined' && !HTMLCanvasElement.prototype.getContext.__stubbed) {
+  HTMLCanvasElement.prototype.getContext = function getContext() {
+    return {
+      fillStyle: '',
+      globalCompositeOperation: '',
+      fillRect: () => {},
+      drawImage: () => {},
+      getImageData: () => ({ data: [0, 0, 0, 0] }),
+    };
+  };
+  HTMLCanvasElement.prototype.getContext.__stubbed = true;
+}
+
 // Mock CreateJS
 const cjs = {
   Graphics: class Graphics {

--- a/tests/store/PreferencesManager.test.js
+++ b/tests/store/PreferencesManager.test.js
@@ -11,6 +11,7 @@ describe('PreferencesManager', () => {
       expect(pm.getAll()).toEqual({
         theme: 'dark',
         colorBlindMode: false,
+        diceDisplayMode: 'dice',
         animationSpeed: 1,
         reducedMotion: 'system',
         muted: false,
@@ -71,6 +72,17 @@ describe('PreferencesManager', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       pm.set('muted', 'yes');
       expect(pm.get('muted')).toBe(false);
+      warnSpy.mockRestore();
+      pm.destroy();
+    });
+
+    it('rejects invalid diceDisplayMode values', () => {
+      const pm = createPreferencesManager();
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      pm.set('diceDisplayMode', 'pips');
+      expect(pm.get('diceDisplayMode')).toBe('dice');
+      pm.set('diceDisplayMode', 'number');
+      expect(pm.get('diceDisplayMode')).toBe('number');
       warnSpy.mockRestore();
       pm.destroy();
     });
@@ -141,6 +153,7 @@ describe('PreferencesManager', () => {
       expect(pm.getAll()).toEqual({
         theme: 'dark',
         colorBlindMode: false,
+        diceDisplayMode: 'dice',
         animationSpeed: 1,
         reducedMotion: 'system',
         muted: false,

--- a/tests/ui/SettingsPanel.test.js
+++ b/tests/ui/SettingsPanel.test.js
@@ -17,6 +17,7 @@ function createMockPreferencesManager(initial = {}) {
   const prefs = {
     theme: 'dark',
     colorBlindMode: false,
+    diceDisplayMode: 'dice',
     animationSpeed: 1,
     reducedMotion: 'system',
     ...initial,
@@ -37,6 +38,7 @@ function renderPanel(storeOverrides = {}, prefsOverrides = {}) {
     preferences: {
       theme: 'dark',
       colorBlindMode: false,
+      diceDisplayMode: 'dice',
       animationSpeed: 1,
       reducedMotion: 'system',
       ...prefsOverrides,
@@ -145,6 +147,26 @@ describe('SettingsPanel', () => {
     act(() => cbBtn.click());
 
     expect(pm.set).toHaveBeenCalledWith('colorBlindMode', true);
+  });
+
+  /*
+   * -----------------------------------------------------------------------
+   * Dice display mode
+   * -----------------------------------------------------------------------
+   */
+
+  it('calls setPref to switch dice display to number', () => {
+    const { pm } = renderPanel();
+    const gearBtn = container.querySelector('button[aria-label="Settings"]');
+    act(() => gearBtn.click());
+
+    const buttons = Array.from(container.querySelectorAll('button'));
+    const numberBtn = buttons.find(b => b.textContent === 'Number');
+    expect(numberBtn).toBeTruthy();
+
+    act(() => numberBtn.click());
+
+    expect(pm.set).toHaveBeenCalledWith('diceDisplayMode', 'number');
   });
 
   /*


### PR DESCRIPTION
## Summary

Adds a **Dice display** setting with two modes:
- **Classic** — stacked isometric dice (default, unchanged)
- **Number** — a compact owner-colored count badge showing just the dice number

Wired exactly like the existing `colorBlindMode`/`theme` preferences: it persists to localStorage and applies **live** without a reload.

## Changes
- **PreferencesManager / GameStore**: new `diceDisplayMode` (`'dice' | 'number'`) default + validator
- **DiceRenderer**: `setDiceDisplayMode()`; split `_drawDiceStack` / new `_drawCountBadge` (Pixi `Text` badge); destroys old per-area containers on redraw to avoid Text-texture leaks
- **GameRenderer**: `setDiceDisplayMode()` with live redraw (guarded: no-op when unchanged/pre-init; repaints only when state exists)
- **main.jsx**: syncs the preference → renderer at init and on change
- **SettingsPanel**: "Dice display" button group (mirrors the Speed/Motion rows)

## Tests
- *(feature commit)* validator default + rejection, GameStore default, SettingsPanel toggle
- *(added)* renderer live-apply seam — `GameRenderer.setDiceDisplayMode` guard/delegation/repaint branches + `DiceRenderer.setDiceDisplayMode` normalization, GPU-free via `prototype.call` on stubs. Also stubs `HTMLCanvasElement.getContext` in `tests/setup.js` so renderer imports don't emit jsdom noise.

## Review
A multi-dimension review (correctness, PixiJS lifecycle, test adequacy, convention-consistency) with adversarial verification found **no defects** — the texture-leak handling holds up and the wiring matches the existing preference pattern. The only confirmed findings were the renderer test-coverage gaps, now closed by the added test commit.

## Validation
`npm run lint` / `build` / `test:coverage` all green locally — 1025 tests pass.