### PR TITLE
fix: set Vite base path for GitHub Pages subpath deploy

### DIFF
--- a/src/audio/SoundManager.js
+++ b/src/audio/SoundManager.js
@@ -8,15 +8,20 @@
  * @module audio/SoundManager
  */
 
+/*
+ * Prefix with Vite's base URL so sounds resolve under the deploy subpath
+ * (e.g. /dicewarsjs/sound/...). BASE_URL always ends with a slash.
+ */
+const BASE = import.meta.env.BASE_URL;
 const SOUND_PATHS = {
-  button: '/sound/button.wav',
-  clear: '/sound/clear.wav',
-  click: '/sound/click.wav',
-  dice: '/sound/dice.wav',
-  fail: '/sound/fail.wav',
-  myturn: '/sound/myturn.wav',
-  over: '/sound/over.wav',
-  success: '/sound/success.wav',
+  button: `${BASE}sound/button.wav`,
+  clear: `${BASE}sound/clear.wav`,
+  click: `${BASE}sound/click.wav`,
+  dice: `${BASE}sound/dice.wav`,
+  fail: `${BASE}sound/fail.wav`,
+  myturn: `${BASE}sound/myturn.wav`,
+  over: `${BASE}sound/over.wav`,
+  success: `${BASE}sound/success.wav`,
 };
 
 /**

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,7 +2,13 @@ import { defineConfig } from 'vite';
 import preact from '@preact/preset-vite';
 import path from 'path';
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
+  /*
+   * GitHub Pages serves this project at https://ivanlay.com/dicewarsjs/, so the
+   * production build must emit subpath-relative asset URLs. Dev/test stay at '/'.
+   */
+  base: command === 'build' ? '/dicewarsjs/' : '/',
+
   plugins: [preact({ devToolsEnabled: false })],
 
   resolve: {
@@ -84,4 +90,4 @@ export default defineConfig({
       },
     },
   },
-});
+}));


### PR DESCRIPTION
## Severity: the live site is currently down

`https://ivanlay.com/dicewarsjs/` serves a **blank page** — the core JS bundles 404. The deployed `index.html` references them at root (`/assets/index-*.js`), but GitHub Pages serves this project under `/dicewarsjs/`, so the real files live at `/dicewarsjs/assets/...`. The app never mounts → no game, no leaderboard, no dice option. Confirmed in-browser (blank canvas, two 404s in console) and via curl:

```
/dicewarsjs/assets/index-*.js -> 200
/assets/index-*.js            -> 404
```

Root cause: `vite.config.js` never set `base`, so it defaulted to `/`. This predates recent work but means everything we've deployed has been invisible.

## Fix
- **vite.config.js**: `base: command === 'build' ? '/dicewarsjs/' : '/'` — production build emits subpath-relative asset URLs; dev server and Vitest stay at `/` (so `import.meta.env.BASE_URL` is `/` in tests, no test churn).
- **SoundManager.js**: prefix `/sound/*.wav` with `import.meta.env.BASE_URL` — these are runtime `fetch()`es that would otherwise 404 under the subpath.

The leaderboard/replay fetches are already *relative* (`fetch('data/...')`), so they resolve correctly under the subpath — left as-is.

## Validation
- Built `dist/index.html` now references `/dicewarsjs/assets/...`; bundle sound paths are `${BASE}sound/...`; both serve 200.
- Full CI-equivalent green locally: `format:check` / `lint` / `test:coverage` (1025 tests, SoundManager tests included) all pass.
- Note: I could not browser-verify against local `vite preview` — the Playwright sandbox can't reach my machine's localhost (only public URLs). **The definitive check is the post-deploy public URL**, which I'll run as soon as this merges + deploys.