### PR TITLE
feat: map-size selection (Small/Medium/Large) on the title screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Built on the original [Dice Wars](https://www.gamedesign.jp/games/dicewars/) by 
 ## Features
 
 - **Play or spectate** — play against AI opponents or watch bots battle each other
+- **Configurable map size** — pick Small (20×24), Medium (28×32, default) or Large (36×40) before each game
 - **Bot SDK** — write a bot in a single function and compete in the arena
 - **Arena mode** — run tournaments with ELO ratings and match replays
 - **4 built-in AI strategies** — from random to adaptive

--- a/docs/GAME_RULES.md
+++ b/docs/GAME_RULES.md
@@ -5,6 +5,7 @@ DiceWarsJS is a turn-based territory conquest game played on a hexagonal grid. P
 ## Setup
 
 - The board is a hexagonal grid divided into **territories** (default: up to 32)
+- **Map size** is chosen on the title screen before each game — Small (20×24, up to 20 territories), Medium (28×32, up to 32 — the default), or Large (36×40, up to 48). This is a per-game choice and resets to Medium on reload.
 - Each territory is assigned to a random player
 - Each territory starts with a random number of dice (1-8)
 - There are **7 players** by default (configurable from 2-8)
@@ -49,14 +50,15 @@ If no player has been eliminated after 500 turns (the default limit, configurabl
 
 ## Key Numbers
 
-| Constant                | Value         |
-| ----------------------- | ------------- |
-| Max dice per territory  | 8             |
-| Max reinforcement stock | 64            |
-| Default player count    | 7             |
-| Default max territories | 32            |
-| Default grid size       | 28 x 32 cells |
-| Stalemate turn limit    | 500           |
+| Constant                | Value                                    |
+| ----------------------- | ---------------------------------------- |
+| Max dice per territory  | 8                                        |
+| Max reinforcement stock | 64                                       |
+| Default player count    | 7                                        |
+| Default max territories | 32                                       |
+| Default grid size       | 28 x 32 cells (Medium)                   |
+| Map size presets        | Small 20×24 / Medium 28×32 / Large 36×40 |
+| Stalemate turn limit    | 500                                      |
 
 ## Strategy Tips
 

--- a/src/controller/GameController.js
+++ b/src/controller/GameController.js
@@ -18,7 +18,7 @@ import {
 import { runAI } from '../engine/AIAdapter.js';
 import { getAIImplementation } from '../ai/aiConfig.js';
 import { createReplayFromState } from '../arena/replayFormat.js';
-import { DEFAULT_CONFIG } from '../utils/config.js';
+import { resolveMapSize } from '../utils/config.js';
 
 /**
  * Create a game controller.
@@ -108,7 +108,7 @@ export function createGameController(store, renderer, soundManager, preferencesM
   /**
    * Start a new game from the title screen.
    *
-   * @param {{ playerCount: number, spectator: boolean }} config
+   * @param {{ playerCount: number, spectator: boolean, mapSize?: string }} config
    */
   async function startNewGame(config) {
     aiAborted = true; // abort any running AI turn
@@ -128,10 +128,18 @@ export function createGameController(store, renderer, soundManager, preferencesM
 
     const playerCount = config.playerCount;
     const spectator = config.spectator;
+    /*
+     * Map size is a per-game choice from the title screen. Fall back to the
+     * store's current value if the caller omits it.
+     */
+    const mapSize = config.mapSize ?? store.getState().config.mapSize;
 
-    // Update store config
+    /*
+     * Update store config. Persist mapSize so a later rejectMap() regenerates
+     * at the same size the player chose.
+     */
     store.setState({
-      config: { ...store.getState().config, playerCount },
+      config: { ...store.getState().config, playerCount, mapSize },
       humanPlayerIndex: spectator ? null : 0,
     });
 
@@ -142,9 +150,7 @@ export function createGameController(store, renderer, soundManager, preferencesM
       // Create game via engine
       const gameState = createGame({
         playerCount,
-        mapWidth: DEFAULT_CONFIG.mapWidth,
-        mapHeight: DEFAULT_CONFIG.mapHeight,
-        maxAreas: DEFAULT_CONFIG.territoriesCount,
+        ...resolveMapSize(mapSize),
       });
 
       store.setState({
@@ -184,14 +190,13 @@ export function createGameController(store, renderer, soundManager, preferencesM
   async function rejectMap() {
     const storeState = store.getState();
     const playerCount = storeState.config.playerCount;
+    const mapSize = storeState.config.mapSize;
 
     let gameState;
     try {
       gameState = createGame({
         playerCount,
-        mapWidth: DEFAULT_CONFIG.mapWidth,
-        mapHeight: DEFAULT_CONFIG.mapHeight,
-        maxAreas: DEFAULT_CONFIG.territoriesCount,
+        ...resolveMapSize(mapSize),
       });
     } catch (err) {
       console.error('Failed to regenerate map:', err);

--- a/src/renderer/GameRenderer.js
+++ b/src/renderer/GameRenderer.js
@@ -151,10 +151,15 @@ export class GameRenderer {
     const canvasX = screenX - rect.left;
     const canvasY = screenY - rect.top;
 
-    // Account for root container position and scale
+    /*
+     * Invert two transforms: the root container's responsive scale, then the
+     * map container's fit-to-canvas scale (see HexGridRenderer.computeMapLayout).
+     * Returns unscaled grid-local coordinates for hit testing.
+     */
     const scale = this.root.scale.x;
-    const localX = (canvasX - this.root.x) / scale - this.hexGrid.container.x;
-    const localY = (canvasY - this.root.y) / scale - this.hexGrid.container.y;
+    const mapScale = this.hexGrid.container.scale.x || 1;
+    const localX = ((canvasX - this.root.x) / scale - this.hexGrid.container.x) / mapScale;
+    const localY = ((canvasY - this.root.y) / scale - this.hexGrid.container.y) / mapScale;
     return { x: localX, y: localY };
   }
 

--- a/src/renderer/HexGridRenderer.js
+++ b/src/renderer/HexGridRenderer.js
@@ -22,8 +22,36 @@ import {
   HEX_VERTEX_X,
   HEX_VERTEX_Y,
   BASE_WIDTH,
+  BASE_HEIGHT,
+  HUD_BAR_HEIGHT,
   MAP_TOP_MARGIN,
 } from './constants.js';
+
+/**
+ * Compute the scale and top-left position that centers a grid of the given cell
+ * dimensions inside the fixed base canvas (BASE_WIDTH × BASE_HEIGHT).
+ *
+ * Grids that would overflow the canvas (e.g. the Large preset, 36×40 → 972px
+ * wide vs. BASE_WIDTH 840) are scaled down uniformly so they never clip; grids
+ * that already fit (Small, Medium) return scale === 1, reproducing the original
+ * layout exactly. Pure function — exported for unit testing.
+ *
+ * @param {number} gridWidth  - Grid width in cells
+ * @param {number} gridHeight - Grid height in cells
+ * @returns {{ scale: number, x: number, y: number }}
+ */
+export function computeMapLayout(gridWidth, gridHeight) {
+  const mapPixelWidth = gridWidth * CELL_WIDTH;
+  const mapPixelHeight = gridHeight * CELL_HEIGHT;
+  // Odd rows are shifted half a cell right, so the real content is wider.
+  const contentWidth = mapPixelWidth + CELL_WIDTH / 2;
+  const availHeight = BASE_HEIGHT - MAP_TOP_MARGIN - HUD_BAR_HEIGHT;
+  const scale = Math.min(1, BASE_WIDTH / contentWidth, availHeight / mapPixelHeight);
+  // Center horizontally (matching the original offset when scale === 1).
+  const x = (BASE_WIDTH - mapPixelWidth * scale) / 2 - (CELL_WIDTH / 4) * scale;
+  const y = MAP_TOP_MARGIN;
+  return { scale, x, y };
+}
 
 /**
  * Precompute pixel positions for every cell in the grid.
@@ -228,10 +256,15 @@ export class HexGridRenderer {
       this.container.addChildAt(gfx, 0);
     }
 
-    // Position the map container to center it
-    const mapPixelWidth = grid.width * CELL_WIDTH;
-    this.container.x = BASE_WIDTH / 2 - mapPixelWidth / 2 - CELL_WIDTH / 4;
-    this.container.y = MAP_TOP_MARGIN;
+    /*
+     * Scale + position the container so any preset size fits the base canvas.
+     * Dice live inside this same container, so they scale/move with it. The
+     * matching inverse lives in GameRenderer.screenToMap (divide by this scale).
+     */
+    const layout = computeMapLayout(grid.width, grid.height);
+    this.container.scale.set(layout.scale);
+    this.container.x = layout.x;
+    this.container.y = layout.y;
 
     // Ensure highlights are on top
     this.container.setChildIndex(this._highlightFrom, this.container.children.length - 1);

--- a/src/store/GameStore.js
+++ b/src/store/GameStore.js
@@ -55,6 +55,7 @@ const DEFAULT_STATE = {
   },
   config: {
     playerCount: 7,
+    mapSize: 'medium',
     aiAssignments: [
       null,
       'ai_defensive',

--- a/src/ui/TitleScreen.jsx
+++ b/src/ui/TitleScreen.jsx
@@ -9,6 +9,18 @@
 import { useState } from 'preact/hooks';
 import { useGameStore } from './hooks/useGameStore.js';
 import { getTheme } from '../renderer/themes.js';
+import { DEFAULT_MAP_SIZE } from '../utils/config.js';
+
+/**
+ * Map-size options shown on the title screen. `value` keys must match
+ * MAP_SIZE_PRESETS in src/utils/config.js (the controller resolves them to
+ * concrete grid dimensions at game-creation time).
+ */
+const MAP_SIZE_OPTIONS = [
+  { value: 'small', label: 'Small' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'large', label: 'Large' },
+];
 
 const STYLE = {
   container: {
@@ -30,6 +42,20 @@ const STYLE = {
     marginBottom: '2rem',
   },
   playerRow: {
+    display: 'flex',
+    gap: '0.8rem',
+    marginBottom: '1.2rem',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+  },
+  sectionLabel: {
+    fontFamily: 'Roboto, sans-serif',
+    fontSize: '0.75rem',
+    letterSpacing: '0.12em',
+    textTransform: 'uppercase',
+    marginBottom: '0.5rem',
+  },
+  sizeRow: {
     display: 'flex',
     gap: '0.8rem',
     marginBottom: '2rem',
@@ -104,22 +130,23 @@ const STYLE = {
 /**
  * @param {Object} props
  * @param {string | null} [props.error] - Error message to display
- * @param {(config: { playerCount: number, spectator: boolean }) => void} props.onStart
+ * @param {(config: { playerCount: number, spectator: boolean, mapSize: string }) => void} props.onStart
  * @param {() => void} [props.onArena] - Navigate to arena screen
  * @param {() => void} [props.onTournament] - Navigate to tournament screen
  * @param {() => void} [props.onLeaderboard] - Navigate to online leaderboard screen
  */
 export function TitleScreen({ store, error, onStart, onArena, onTournament, onLeaderboard }) {
   const [playerCount, setPlayerCount] = useState(7);
+  const [mapSize, setMapSize] = useState(DEFAULT_MAP_SIZE);
   const themeName = useGameStore(store, s => s.preferences?.theme) || 'dark';
   const theme = getTheme(themeName);
 
   const handleStart = () => {
-    onStart({ playerCount, spectator: false });
+    onStart({ playerCount, spectator: false, mapSize });
   };
 
   const handleAIvsAI = () => {
-    onStart({ playerCount, spectator: true });
+    onStart({ playerCount, spectator: true, mapSize });
   };
 
   return (
@@ -139,10 +166,14 @@ export function TitleScreen({ store, error, onStart, onArena, onTournament, onLe
         </div>
       )}
 
+      <span style={{ ...STYLE.sectionLabel, color: theme.uiTextMuted }}>Players</span>
       <div style={STYLE.playerRow}>
         {[2, 3, 4, 5, 6, 7, 8].map(n => (
           <button
             key={n}
+            type="button"
+            aria-label={`Play with ${n} players`}
+            aria-pressed={n === playerCount}
             style={{
               ...STYLE.playerBtn,
               color: n === playerCount ? theme.uiAccent : theme.uiTextMuted,
@@ -151,6 +182,26 @@ export function TitleScreen({ store, error, onStart, onArena, onTournament, onLe
             onClick={() => setPlayerCount(n)}
           >
             {n} players
+          </button>
+        ))}
+      </div>
+
+      <span style={{ ...STYLE.sectionLabel, color: theme.uiTextMuted }}>Map size</span>
+      <div style={STYLE.sizeRow}>
+        {MAP_SIZE_OPTIONS.map(opt => (
+          <button
+            key={opt.value}
+            type="button"
+            aria-label={`${opt.label} map`}
+            aria-pressed={opt.value === mapSize}
+            style={{
+              ...STYLE.playerBtn,
+              color: opt.value === mapSize ? theme.uiAccent : theme.uiTextMuted,
+              borderColor: opt.value === mapSize ? theme.uiAccent : theme.uiBorder,
+            }}
+            onClick={() => setMapSize(opt.value)}
+          >
+            {opt.label}
           </button>
         ))}
       </div>

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -55,6 +55,39 @@ export const DEFAULT_CONFIG = {
 };
 
 /**
+ * Map-size presets surfaced in the title-screen UI.
+ *
+ * Each key resolves to concrete engine dimensions: a `mapWidth × mapHeight`
+ * hex grid plus `maxAreas` (the territory-count ceiling passed to the engine's
+ * createGame/generateMap). Sizes are chosen so that cells-per-territory stays
+ * comfortably above the engine's MIN_TERRITORY_SIZE (6) and `maxAreas` always
+ * exceeds the 8-player maximum, so every preset is guaranteed to generate a
+ * playable map for any supported player count (no RangeError from pruning).
+ *
+ * `medium` intentionally mirrors DEFAULT_CONFIG (28×32, 32 territories) so the
+ * default selection reproduces today's exact behaviour.
+ */
+export const MAP_SIZE_PRESETS = {
+  small: { mapWidth: 20, mapHeight: 24, maxAreas: 20 },
+  medium: { mapWidth: 28, mapHeight: 32, maxAreas: 32 },
+  large: { mapWidth: 36, mapHeight: 40, maxAreas: 48 },
+};
+
+/** Default map-size preset key. */
+export const DEFAULT_MAP_SIZE = 'medium';
+
+/**
+ * Resolve a map-size preset key to concrete engine dimensions.
+ * Unknown/invalid keys fall back to the default (medium) preset.
+ *
+ * @param {string} size - Preset key ('small' | 'medium' | 'large')
+ * @returns {{ mapWidth: number, mapHeight: number, maxAreas: number }}
+ */
+export function resolveMapSize(size) {
+  return MAP_SIZE_PRESETS[size] ?? MAP_SIZE_PRESETS[DEFAULT_MAP_SIZE];
+}
+
+/**
  * Current active configuration
  */
 let activeConfig = { ...DEFAULT_CONFIG };

--- a/tests/controller/GameController.test.js
+++ b/tests/controller/GameController.test.js
@@ -84,11 +84,15 @@ vi.mock('../../src/ai/aiConfig.js', () => ({
 }));
 
 vi.mock('../../src/utils/config.js', () => ({
-  DEFAULT_CONFIG: {
-    mapWidth: 28,
-    mapHeight: 32,
-    territoriesCount: 32,
-  },
+  // Mirror the real preset table so assertions on dimensions are meaningful.
+  resolveMapSize: vi.fn(size => {
+    const presets = {
+      small: { mapWidth: 20, mapHeight: 24, maxAreas: 20 },
+      medium: { mapWidth: 28, mapHeight: 32, maxAreas: 32 },
+      large: { mapWidth: 36, mapHeight: 40, maxAreas: 48 },
+    };
+    return presets[size] ?? presets.medium;
+  }),
 }));
 
 /*
@@ -245,6 +249,74 @@ describe('GameController', () => {
 
       await controller.rejectMap();
       expect(store.getState().screen).toBe('title');
+    });
+  });
+
+  /*
+   * -----------------------------------------------------------------------
+   * map size selection
+   * -----------------------------------------------------------------------
+   */
+
+  describe('map size selection', () => {
+    it('passes the resolved default (medium) dimensions to createGame', async () => {
+      const { createGame } = await import('../../src/engine/index.js');
+
+      await controller.startNewGame({ playerCount: 2, spectator: false });
+
+      expect(createGame).toHaveBeenCalledWith(
+        expect.objectContaining({ mapWidth: 28, mapHeight: 32, maxAreas: 32 })
+      );
+    });
+
+    it('resolves the chosen preset to engine dimensions (large)', async () => {
+      const { createGame } = await import('../../src/engine/index.js');
+
+      await controller.startNewGame({ playerCount: 2, spectator: false, mapSize: 'large' });
+
+      expect(createGame).toHaveBeenCalledWith(
+        expect.objectContaining({ playerCount: 2, mapWidth: 36, mapHeight: 40, maxAreas: 48 })
+      );
+    });
+
+    it('persists the chosen map size into store config', async () => {
+      await controller.startNewGame({ playerCount: 2, spectator: false, mapSize: 'small' });
+
+      expect(store.getState().config.mapSize).toBe('small');
+    });
+
+    it('rejectMap regenerates at the size the player chose', async () => {
+      const { createGame } = await import('../../src/engine/index.js');
+
+      await controller.startNewGame({ playerCount: 2, spectator: false, mapSize: 'small' });
+      createGame.mockClear();
+
+      await controller.rejectMap();
+
+      expect(createGame).toHaveBeenCalledWith(
+        expect.objectContaining({ mapWidth: 20, mapHeight: 24, maxAreas: 20 })
+      );
+    });
+
+    it('falls back to the store map size when the caller omits it', async () => {
+      const { createGame } = await import('../../src/engine/index.js');
+      store.setState({ config: { ...store.getState().config, mapSize: 'large' } });
+
+      await controller.startNewGame({ playerCount: 2, spectator: false });
+
+      expect(createGame).toHaveBeenCalledWith(
+        expect.objectContaining({ mapWidth: 36, mapHeight: 40, maxAreas: 48 })
+      );
+    });
+
+    it('threads map size in spectator (AI vs AI) mode', async () => {
+      const { createGame } = await import('../../src/engine/index.js');
+
+      await controller.startNewGame({ playerCount: 2, spectator: true, mapSize: 'large' });
+
+      expect(createGame).toHaveBeenCalledWith(
+        expect.objectContaining({ mapWidth: 36, mapHeight: 40, maxAreas: 48 })
+      );
     });
   });
 

--- a/tests/renderer/mapLayout.test.js
+++ b/tests/renderer/mapLayout.test.js
@@ -1,0 +1,61 @@
+/**
+ * Map fit-to-canvas layout tests.
+ *
+ * Locks the geometry that keeps every map-size preset inside the fixed base
+ * canvas. Regression guard for the bug where the Large preset (36×40 → 972px)
+ * overflowed BASE_WIDTH (840) and clipped on both edges. Pure math — no PixiJS.
+ */
+
+import { computeMapLayout } from '../../src/renderer/HexGridRenderer.js';
+import { BASE_WIDTH, BASE_HEIGHT, CELL_WIDTH, CELL_HEIGHT } from '../../src/renderer/constants.js';
+
+// Mirror MAP_SIZE_PRESETS (src/utils/config.js) — the dimensions that ship.
+const PRESETS = {
+  small: { width: 20, height: 24 },
+  medium: { width: 28, height: 32 },
+  large: { width: 36, height: 40 },
+};
+
+describe('computeMapLayout', () => {
+  for (const [name, { width, height }] of Object.entries(PRESETS)) {
+    describe(`${name} preset (${width}×${height})`, () => {
+      const layout = computeMapLayout(width, height);
+
+      it('produces a scale in (0, 1]', () => {
+        expect(layout.scale).toBeGreaterThan(0);
+        expect(layout.scale).toBeLessThanOrEqual(1);
+      });
+
+      it('never clips the left edge (x >= 0)', () => {
+        expect(layout.x).toBeGreaterThanOrEqual(0);
+      });
+
+      it('fits within BASE_WIDTH on the right edge (incl. odd-row overhang)', () => {
+        const renderedWidth = (width * CELL_WIDTH + CELL_WIDTH / 2) * layout.scale;
+        // Allow a hair of float slack.
+        expect(layout.x + renderedWidth).toBeLessThanOrEqual(BASE_WIDTH + 0.5);
+      });
+
+      it('fits vertically within the base canvas', () => {
+        const renderedHeight = height * CELL_HEIGHT * layout.scale;
+        expect(layout.y + renderedHeight).toBeLessThanOrEqual(BASE_HEIGHT + 0.5);
+      });
+    });
+  }
+
+  it('does not scale Small or Medium (scale === 1, original layout preserved)', () => {
+    expect(computeMapLayout(20, 24).scale).toBe(1);
+    expect(computeMapLayout(28, 32).scale).toBe(1);
+  });
+
+  it('scales the Large preset down below 1 so it fits', () => {
+    expect(computeMapLayout(36, 40).scale).toBeLessThan(1);
+  });
+
+  it('matches the original centering formula when scale === 1', () => {
+    // Medium fits without scaling, so x must equal the pre-fix formula.
+    const mapPixelWidth = 28 * CELL_WIDTH;
+    const expectedX = BASE_WIDTH / 2 - mapPixelWidth / 2 - CELL_WIDTH / 4;
+    expect(computeMapLayout(28, 32).x).toBeCloseTo(expectedX, 6);
+  });
+});

--- a/tests/ui/TitleScreen.test.js
+++ b/tests/ui/TitleScreen.test.js
@@ -1,0 +1,89 @@
+/**
+ * TitleScreen tests
+ *
+ * Covers the pre-game setup controls: player-count and the new map-size preset
+ * selector, plus that both START and AI-vs-AI thread the choices into onStart.
+ */
+
+import { h, render } from 'preact';
+import { act } from 'preact/test-utils';
+import { TitleScreen } from '../../src/ui/TitleScreen.jsx';
+import { createGameStore } from '../../src/store/GameStore.js';
+
+let container;
+
+function renderTitle(props = {}) {
+  const store = createGameStore();
+  const onStart = vi.fn();
+
+  container = document.createElement('div');
+  document.body.appendChild(container);
+
+  act(() => {
+    render(h(TitleScreen, { store, onStart, ...props }), container);
+  });
+
+  return { store, onStart };
+}
+
+const sizeBtn = label => container.querySelector(`button[aria-label="${label} map"]`);
+const startBtn = () =>
+  [...container.querySelectorAll('button')].find(b => b.textContent === 'START');
+const aiBtn = () =>
+  [...container.querySelectorAll('button')].find(b => b.textContent === 'AI vs AI');
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container));
+    if (container.parentNode) document.body.removeChild(container);
+    container = null;
+  }
+});
+
+describe('TitleScreen', () => {
+  it('renders the three map-size presets', () => {
+    renderTitle();
+    expect(sizeBtn('Small')).toBeTruthy();
+    expect(sizeBtn('Medium')).toBeTruthy();
+    expect(sizeBtn('Large')).toBeTruthy();
+  });
+
+  it('defaults to the Medium preset selected', () => {
+    renderTitle();
+    expect(sizeBtn('Medium').getAttribute('aria-pressed')).toBe('true');
+    expect(sizeBtn('Small').getAttribute('aria-pressed')).toBe('false');
+    expect(sizeBtn('Large').getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('updates the selected preset when a size button is clicked', () => {
+    renderTitle();
+    act(() => sizeBtn('Large').click());
+    expect(sizeBtn('Large').getAttribute('aria-pressed')).toBe('true');
+    expect(sizeBtn('Medium').getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('passes the default map size to onStart via START', () => {
+    const { onStart } = renderTitle();
+    act(() => startBtn().click());
+    expect(onStart).toHaveBeenCalledWith({ playerCount: 7, spectator: false, mapSize: 'medium' });
+  });
+
+  it('passes the chosen map size to onStart via START', () => {
+    const { onStart } = renderTitle();
+    act(() => sizeBtn('Small').click());
+    act(() => startBtn().click());
+    expect(onStart).toHaveBeenCalledWith({ playerCount: 7, spectator: false, mapSize: 'small' });
+  });
+
+  it('threads the chosen map size through the AI-vs-AI (spectator) path', () => {
+    const { onStart } = renderTitle();
+    act(() => sizeBtn('Large').click());
+    act(() => aiBtn().click());
+    expect(onStart).toHaveBeenCalledWith({ playerCount: 7, spectator: true, mapSize: 'large' });
+  });
+
+  it('renders an error banner when error prop is set', () => {
+    renderTitle({ error: 'Map generation failed' });
+    expect(container.textContent).toContain('Map generation failed');
+  });
+});

--- a/tests/utils/config.test.js
+++ b/tests/utils/config.test.js
@@ -7,6 +7,9 @@
  */
 import {
   DEFAULT_CONFIG,
+  MAP_SIZE_PRESETS,
+  DEFAULT_MAP_SIZE,
+  resolveMapSize,
   getConfig,
   updateConfig,
   resetConfig,
@@ -83,6 +86,66 @@ describe('Configuration Management', () => {
       expect(DEFAULT_CONFIG.averageDicePerArea).toBe(3);
       expect(DEFAULT_CONFIG.aiAssignments).toHaveLength(8);
       expect(DEFAULT_CONFIG.display).toBeDefined();
+    });
+  });
+
+  describe('map size presets', () => {
+    test('exposes small, medium, and large presets with engine dimensions', () => {
+      for (const key of ['small', 'medium', 'large']) {
+        const preset = MAP_SIZE_PRESETS[key];
+        expect(preset).toBeDefined();
+        expect(preset.mapWidth).toBeGreaterThan(0);
+        expect(preset.mapHeight).toBeGreaterThan(0);
+        expect(preset.maxAreas).toBeGreaterThan(0);
+      }
+    });
+
+    test('medium mirrors DEFAULT_CONFIG so the default reproduces current behaviour', () => {
+      expect(MAP_SIZE_PRESETS.medium).toEqual({
+        mapWidth: DEFAULT_CONFIG.mapWidth,
+        mapHeight: DEFAULT_CONFIG.mapHeight,
+        maxAreas: DEFAULT_CONFIG.territoriesCount,
+      });
+    });
+
+    test('every preset is guaranteed to generate for up to 8 players', () => {
+      /*
+       * The engine prunes territories smaller than MIN_TERRITORY_SIZE (6 cells)
+       * and throws if valid territories < playerCount. Keep cells-per-territory
+       * well above 6 and maxAreas >= the 8-player maximum.
+       */
+      const MAX_PLAYERS = 8;
+      for (const key of ['small', 'medium', 'large']) {
+        const { mapWidth, mapHeight, maxAreas } = MAP_SIZE_PRESETS[key];
+        expect(maxAreas).toBeGreaterThanOrEqual(MAX_PLAYERS);
+        const cellsPerArea = (mapWidth * mapHeight) / maxAreas;
+        expect(cellsPerArea).toBeGreaterThan(6);
+      }
+    });
+
+    test('presets are ordered small < medium < large by cell count', () => {
+      const cells = key => MAP_SIZE_PRESETS[key].mapWidth * MAP_SIZE_PRESETS[key].mapHeight;
+      expect(cells('small')).toBeLessThan(cells('medium'));
+      expect(cells('medium')).toBeLessThan(cells('large'));
+    });
+
+    test('DEFAULT_MAP_SIZE points at an existing preset', () => {
+      expect(DEFAULT_MAP_SIZE).toBe('medium');
+      expect(MAP_SIZE_PRESETS[DEFAULT_MAP_SIZE]).toBeDefined();
+    });
+
+    describe('resolveMapSize', () => {
+      test('resolves each preset key to its dimensions', () => {
+        expect(resolveMapSize('small')).toEqual(MAP_SIZE_PRESETS.small);
+        expect(resolveMapSize('medium')).toEqual(MAP_SIZE_PRESETS.medium);
+        expect(resolveMapSize('large')).toEqual(MAP_SIZE_PRESETS.large);
+      });
+
+      test('falls back to the default preset for unknown or invalid keys', () => {
+        for (const bad of ['huge', '', undefined, null, 0, 'MEDIUM']) {
+          expect(resolveMapSize(bad)).toEqual(MAP_SIZE_PRESETS[DEFAULT_MAP_SIZE]);
+        }
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Adds a per-game **map-size preset selector** to the title screen, next to the player-count buttons. The engine already accepted `mapWidth/mapHeight/maxAreas`, so this is purely a UI + wiring change — **no engine changes**.

| Preset | Grid | Territories |
|--------|------|-------------|
| Small | 20×24 | up to 20 |
| Medium (default) | 28×32 | up to 32 *(unchanged from today)* |
| Large | 36×40 | up to 48 |

It mirrors the existing player-count flow: a per-game choice that resets to Medium on reload (not persisted). The size threads `TitleScreen → onStart → GameController.startNewGame` **and** `rejectMap` (both `createGame` sites), persisted to `store.config.mapSize` so regenerating a map keeps the chosen size.

## Notable: an adversarial review caught a real rendering bug

The renderer centered the map assuming a fixed 840px canvas, so the **Large map (972px) clipped off both edges**. Fixed with a pure, exported `computeMapLayout()` that scales the container to fit (`scale=1` for Small/Medium — **Medium is byte-for-byte unchanged** — and `0.852` for Large). Dice are children of that container so they follow automatically; `GameRenderer.screenToMap` divides by the container scale so hit-testing stays correct.

## Verification

- **Empirical generation:** 840 combos (3 presets × 2–8 players × 40 seeds) → **0 failures**
- **Tests:** +23 (new `tests/renderer/mapLayout.test.js`, `tests/ui/TitleScreen.test.js`; config + controller incl. spectator path) — full suite green (1060 pass / 5 skipped)
- **Lint** 0 errors · **build** succeeds

## Other touch-ups
- `aria-label` + `aria-pressed` on both button rows; a "Players" section label for symmetry with "Map size".
- Docs: README feature bullet + GAME_RULES setup/key-numbers.

## Design note
`MAP_SIZE_PRESETS` uses the key `maxAreas` (the name `createGame` consumes) — intentionally **not** `territoriesCount`; renaming would make the engine ignore it and silently fall back to 32 areas for every preset.