### PR TITLE
feat: default dice display to Number, rename setting to "Dice style"

### DIFF
--- a/src/renderer/GameRenderer.js
+++ b/src/renderer/GameRenderer.js
@@ -36,7 +36,7 @@ export class GameRenderer {
     /** @type {boolean} Color-blind mode */
     this._colorBlindMode = false;
     /** @type {'dice' | 'number'} How dice counts are shown */
-    this._diceDisplayMode = 'dice';
+    this._diceDisplayMode = 'number';
     /** @type {{ x: number, y: number }} Saved root position for screen shake */
     this._rootOrigin = { x: 0, y: 0 };
     /** @type {boolean} Whether a screen shake is active */
@@ -70,6 +70,13 @@ export class GameRenderer {
       // Create child renderers
       this.hexGrid = new HexGridRenderer(this.root);
       this.dice = new DiceRenderer(this.hexGrid.container);
+      /*
+       * Seed the freshly-created dice renderer with the current mode. `_diceDisplayMode`
+       * is the single source of truth; without this, a later setDiceDisplayMode() call
+       * with the same value short-circuits on the equality guard and the child keeps its
+       * own constructor default — leaving the two out of sync.
+       */
+      this.dice.setDiceDisplayMode(this._diceDisplayMode);
       this.battle = createBattleAnimation(this.app);
 
       // Responsive scaling

--- a/src/store/GameStore.js
+++ b/src/store/GameStore.js
@@ -49,7 +49,7 @@ const DEFAULT_STATE = {
   preferences: {
     theme: 'dark',
     colorBlindMode: false,
-    diceDisplayMode: 'dice',
+    diceDisplayMode: 'number',
     animationSpeed: 1,
     reducedMotion: 'system',
   },

--- a/src/store/PreferencesManager.js
+++ b/src/store/PreferencesManager.js
@@ -12,7 +12,7 @@ const STORAGE_KEY = 'dicewars_prefs';
 export const DEFAULTS = {
   theme: 'dark',
   colorBlindMode: false,
-  diceDisplayMode: 'dice', // 'dice' | 'number'
+  diceDisplayMode: 'number', // 'dice' | 'number'
   animationSpeed: 1,
   reducedMotion: 'system', // 'system' | 'on' | 'off'
   muted: false,

--- a/src/ui/SettingsPanel.jsx
+++ b/src/ui/SettingsPanel.jsx
@@ -232,12 +232,12 @@ export function SettingsPanel({ store, preferencesManager }) {
             </button>
           </div>
 
-          {/* Dice display */}
+          {/* Dice style */}
           <div style={STYLE.row}>
-            <span style={STYLE.label}>Dice display</span>
+            <span style={STYLE.label}>Dice style</span>
             <div style={STYLE.btnGroup}>
               {DICE_DISPLAY_OPTIONS.map(opt => {
-                const active = (prefs.diceDisplayMode || 'dice') === opt.value;
+                const active = (prefs.diceDisplayMode || 'number') === opt.value;
                 return (
                   <button
                     key={opt.value}

--- a/tests/renderer/GameRendererDiceSync.test.js
+++ b/tests/renderer/GameRendererDiceSync.test.js
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+/**
+ * Regression test for PR #19 — the dice display mode must reach the child
+ * DiceRenderer at startup.
+ *
+ * `GameRenderer._diceDisplayMode` is the single source of truth, but the child
+ * `DiceRenderer` carries its own constructor default (`'dice'`). When the
+ * configured mode equals the value main.jsx pushes at startup, the equality
+ * guard in `setDiceDisplayMode` short-circuits — so `init()` must seed the
+ * child directly. Without that seeding a fresh install (default `'number'`)
+ * kept rendering stacked dice because the child stayed on its own `'dice'`
+ * default.
+ *
+ * Only the GPU-touching PixiJS surface (`Application`, `Container`) and the
+ * unrelated child renderers are stubbed; the real `DiceRenderer` is exercised
+ * so the desync this guards against is reproduced faithfully.
+ */
+
+import { GameRenderer } from '../../src/renderer/GameRenderer.js';
+
+vi.mock('pixi.js', async importOriginal => {
+  const actual = await importOriginal();
+  class MockContainer {
+    constructor() {
+      this.children = [];
+      this.scale = { set: () => {} };
+      this.x = 0;
+      this.y = 0;
+    }
+
+    addChild(child) {
+      this.children.push(child);
+      return child;
+    }
+  }
+  return {
+    ...actual,
+    Container: MockContainer,
+    Application: class MockApplication {
+      constructor() {
+        this.stage = { addChild: () => {} };
+        this.screen = { width: 800, height: 600 };
+        this.ticker = { add: () => {}, remove: () => {} };
+      }
+
+      async init() {}
+
+      destroy() {}
+    },
+  };
+});
+
+vi.mock('../../src/renderer/HexGridRenderer.js', async () => {
+  const { Container } = await import('pixi.js');
+  return {
+    HexGridRenderer: class {
+      constructor() {
+        this.container = new Container();
+      }
+    },
+  };
+});
+
+vi.mock('../../src/renderer/BattleAnimation.js', () => ({
+  createBattleAnimation: () => ({ play: () => {}, destroy: () => {} }),
+}));
+
+describe('GameRenderer init() dice-display sync', () => {
+  it("seeds the child renderer with the default 'number' mode (regression for #19)", async () => {
+    const renderer = new GameRenderer();
+    expect(renderer._diceDisplayMode).toBe('number'); // constructor default
+
+    await renderer.init(document.createElement('canvas'));
+
+    /*
+     * Before the fix the child kept its own 'dice' constructor default, so a
+     * fresh install rendered stacked dice instead of number badges.
+     */
+    expect(renderer.dice._displayMode).toBe('number');
+  });
+
+  it('keeps the child in sync even when a later setDiceDisplayMode no-ops on the guard', async () => {
+    const renderer = new GameRenderer();
+    await renderer.init(document.createElement('canvas'));
+
+    /*
+     * main.jsx pushes the stored/default mode at startup; when it equals the
+     * GameRenderer default the equality guard short-circuits. The child must
+     * already be correct from init().
+     */
+    renderer.setDiceDisplayMode('number');
+    expect(renderer.dice._displayMode).toBe('number');
+  });
+
+  it('still propagates an explicit change that differs from the default', async () => {
+    const renderer = new GameRenderer();
+    await renderer.init(document.createElement('canvas'));
+
+    renderer.setDiceDisplayMode('dice');
+    expect(renderer.dice._displayMode).toBe('dice');
+  });
+});

--- a/tests/store/PreferencesManager.test.js
+++ b/tests/store/PreferencesManager.test.js
@@ -12,7 +12,7 @@ describe('PreferencesManager', () => {
       expect(pm.getAll()).toEqual({
         theme: 'dark',
         colorBlindMode: false,
-        diceDisplayMode: 'dice',
+        diceDisplayMode: 'number',
         animationSpeed: 1,
         reducedMotion: 'system',
         muted: false,
@@ -81,7 +81,7 @@ describe('PreferencesManager', () => {
       const pm = createPreferencesManager();
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       pm.set('diceDisplayMode', 'pips');
-      expect(pm.get('diceDisplayMode')).toBe('dice');
+      expect(pm.get('diceDisplayMode')).toBe('number');
       pm.set('diceDisplayMode', 'number');
       expect(pm.get('diceDisplayMode')).toBe('number');
       warnSpy.mockRestore();
@@ -154,7 +154,7 @@ describe('PreferencesManager', () => {
       expect(pm.getAll()).toEqual({
         theme: 'dark',
         colorBlindMode: false,
-        diceDisplayMode: 'dice',
+        diceDisplayMode: 'number',
         animationSpeed: 1,
         reducedMotion: 'system',
         muted: false,


### PR DESCRIPTION
## Summary

- Flip the **Dice display** default from stacked dice to **Number** — it reads more cleanly at a glance.
- Rename the setting **"Dice display" → "Dice style"** so the label no longer implies the dice option is the default. Options stay `Dice` / `Number`.

## Changes

- Default `diceDisplayMode` to `'number'` in `PreferencesManager`, `GameStore`, `GameRenderer`, and the `SettingsPanel` active-state fallback.
- Rename the settings label/comment in `SettingsPanel.jsx`.
- Update `PreferencesManager` tests that asserted the old `'dice'` default (including the invalid-value-keeps-current-default case).

## Testing

- `npm test` — 1057 passed (88 files)
- `npm run lint` — 0 errors