### PR TITLE
docs: fix stale architecture refs after pre-engine subtree removal (wave E)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,23 +129,15 @@ DiceWarsJS is a turn-based strategy game where players compete to conquer territ
 
 - **SoundManager** (src/audio/SoundManager.js): Web Audio API sound system replacing legacy CreateJS SoundJS. Lazy AudioContext creation, on-demand loading, volume control.
 
-- **Map Generation** (src/mechanics/mapGenerator.js): Creates the hexagonal grid and territories.
+- **Map Generation** (src/engine/MapGenerator.js): Creates the hexagonal grid and territories.
 
-- **Battle Resolution** (src/mechanics/battleResolution.js): Handles attack resolution and dice distribution.
-
-- **Models** (src/models/): Data structures for game entities (AreaData, PlayerData, Battle, HistoryData, JoinData).
-
-- **Enhanced Modules** (src/models/enhanced/, src/mechanics/enhanced/): Improved variants of core components with additional features like adjacency graphs, territory graphs, and disjoint sets.
-
-- **Error Handling** (src/mechanics/errors/): Custom error classes for different error types.
+- **Battle Resolution** (src/engine/BattleResolver.js): Handles attack resolution and dice distribution.
 
 ### Important Design Patterns
 
-1. **Immutable Data**: The state directory implements immutable data patterns for the game state.
+1. **Immutable State**: The engine never mutates state in place — `applyAction(...)` returns a new state object (see `src/engine/StateManager.js`).
 
 2. **Factory Functions**: Used throughout the codebase to create game objects.
-
-3. **Error Hierarchy**: Custom error classes (GameError, BattleError, TerritoryError, etc.) provide structured error handling.
 
 ### AI Implementation Notes
 
@@ -177,13 +169,13 @@ The full suite forks many workers; running several copies at once can exhaust RA
 
 1. **Code Style**: Follow existing code patterns and conventions
 2. **Documentation**: Update relevant documentation when making significant changes
-3. **Error Handling**: Use appropriate custom error classes from src/mechanics/errors/
+3. **Error Handling**: Validate inputs at boundaries and raise or return errors explicitly rather than failing silently
 4. **Testing**: Write tests for new functionality and ensure existing tests pass
 5. **Commit Messages**: Use conventional commit format (e.g., "feat:", "fix:", "test:", "docs:")
 
 ## Gotchas
 
-- **Path aliases**: `@utils`, `@ai`, `@models`, `@mechanics`, `@state` are configured in `vite.config.js` for both builds and tests. Source files use relative imports; aliases are available but prefer relative paths in new code.
+- **Path aliases**: `@utils`, `@ai`, `@engine` are configured in `vite.config.js` for both builds and tests. Source files use relative imports; aliases are available but prefer relative paths in new code.
 - **Husky pre-commit hook**: Runs `lint-staged` automatically, which applies ESLint fixes and Prettier formatting to staged `.js` and `.jsx` files.
 - **Vitest globals**: Tests use `globals: true` in vitest config, so `describe`, `it`, `expect`, `vi`, `beforeEach`, `afterEach` are available without imports. Use `import { vi } from 'vitest'` only if needed for explicit typing.
 - **Test environment is `node` by default**: To keep memory down, the suite runs under the lightweight Node environment, not jsdom. A test that touches `document`, `window`, `localStorage`, canvas, or renders a Preact component must declare `// @vitest-environment jsdom` as the first line of the file, or it will fail with `X is not defined`.
@@ -191,7 +183,7 @@ The full suite forks many workers; running several copies at once can exhaust RA
 ## Common Pitfalls to Avoid
 
 1. Always run tests before suggesting code is complete
-2. Ensure error events are properly emitted for error tracking
+2. Surface errors explicitly instead of silently swallowing them
 3. Keep AI functions pure and deterministic for testing
 
 ## Documentation Updates

--- a/README.md
+++ b/README.md
@@ -100,9 +100,7 @@ src/
 ├── store/        Observable GameStore (pub/sub shared state)
 ├── controller/   GameController (game loop orchestrator)
 ├── audio/        Web Audio sound manager
-├── mechanics/    Shared game mechanics and error hierarchy
-├── models/       Data structures (AreaData, PlayerData, etc.)
-└── utils/        Configuration and helpers
+└── utils/        Game configuration (map size, player/AI assignments)
 ```
 
 See [Architecture](docs/ARCHITECTURE.md) for how data flows through the system.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ src/
 ├── store/        Observable GameStore (pub/sub shared state)
 ├── controller/   GameController (game loop orchestrator)
 ├── audio/        Web Audio sound manager
-└── utils/        Game configuration (map size, player/AI assignments)
+└── utils/        Game configuration — map-size presets
 ```
 
 See [Architecture](docs/ARCHITECTURE.md) for how data flows through the system.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -35,10 +35,7 @@ This document describes how the codebase is organized and how data flows through
 | `src/arena/`      | Bot SDK: bot validation, sandboxed execution, match running, ELO ratings, tournament formats, replay serialization.                                                    |
 | `src/ai/`         | Built-in AI strategies (example, default, defensive, adaptive, Claude, Codex) using the legacy game object interface. Adapted for the arena via `legacyBotAdapter.js`. |
 | `src/audio/`      | Web Audio API sound manager with lazy loading.                                                                                                                         |
-| `src/mechanics/`  | Shared game mechanics: event system, error handling, map generation utilities.                                                                                         |
-| `src/models/`     | Data structures (AreaData, PlayerData, Battle, etc.) used across the game engine and AI.                                                                               |
-| `src/utils/`      | Configuration, debug tools, and helper functions.                                                                                                                      |
-| `src/state/`      | Orphaned immutable state patterns — never integrated.                                                                                                                  |
+| `src/utils/`      | Game configuration (map size presets, player/AI assignments) with localStorage persistence.                                                                            |
 
 ## Data Flow: Playing a Game
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -35,7 +35,7 @@ This document describes how the codebase is organized and how data flows through
 | `src/arena/`      | Bot SDK: bot validation, sandboxed execution, match running, ELO ratings, tournament formats, replay serialization.                                                    |
 | `src/ai/`         | Built-in AI strategies (example, default, defensive, adaptive, Claude, Codex) using the legacy game object interface. Adapted for the arena via `legacyBotAdapter.js`. |
 | `src/audio/`      | Web Audio API sound manager with lazy loading.                                                                                                                         |
-| `src/utils/`      | Game configuration — map-size presets (`resolveMapSize`) surfaced in the title screen.                                                                                 |
+| `src/utils/`      | Game configuration — map-size presets surfaced in the title screen, resolved to engine dimensions by the controller (`resolveMapSize`).                                |
 
 ## Data Flow: Playing a Game
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -35,7 +35,7 @@ This document describes how the codebase is organized and how data flows through
 | `src/arena/`      | Bot SDK: bot validation, sandboxed execution, match running, ELO ratings, tournament formats, replay serialization.                                                    |
 | `src/ai/`         | Built-in AI strategies (example, default, defensive, adaptive, Claude, Codex) using the legacy game object interface. Adapted for the arena via `legacyBotAdapter.js`. |
 | `src/audio/`      | Web Audio API sound manager with lazy loading.                                                                                                                         |
-| `src/utils/`      | Game configuration (map size presets, player/AI assignments) with localStorage persistence.                                                                            |
+| `src/utils/`      | Game configuration — map-size presets (`resolveMapSize`) surfaced in the title screen.                                                                                 |
 
 ## Data Flow: Playing a Game
 

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -68,6 +68,6 @@ Planned improvements to the CI pipeline include:
 
 - Adding code coverage reporting
 - Performance regression monitoring
-- Bundle size monitoring via `npm run perf:check`
+- Bundle size monitoring
 - Deployment automation
 - Release packaging

--- a/docs/MODERNIZATION_ROADMAP.md
+++ b/docs/MODERNIZATION_ROADMAP.md
@@ -1,7 +1,7 @@
 # DiceWarsJS Modernization Roadmap
 
 > **Last Updated:** June 2026
-> **Status:** Modernization complete — the legacy CreateJS code and the legacy↔modern bridge (`src/bridge/`, root `game.js`/`main.js`/`mc.js`/`areadice.js`/`config.js`, `src/adapters/`, `src/enhanced/Game.js`, and the legacy HTML entry points) have been deleted. The repo is now modern-only. Sections below that describe the bridge/legacy stack and plan its removal are retained as historical record.
+> **Status:** Modernization complete — the legacy CreateJS code and the legacy↔modern bridge (`src/bridge/`, root `game.js`/`main.js`/`mc.js`/`areadice.js`/`config.js`, `src/adapters/`, `src/enhanced/Game.js`, and the legacy HTML entry points) have been deleted. The repo is now modern-only. A follow-up June 2026 simplification pass additionally removed the orphaned pre-engine subtrees (`src/mechanics/`, `src/models/`, `src/state/`) and the dead CreateJS-era `src/utils/` layer — the live game now runs entirely on `src/engine/`. Sections below that describe the bridge/legacy stack, those subtrees, or plan their removal are retained as historical record.
 > **Developed by:** Claude Opus 4.6 in Claude Code
 
 ---

--- a/docs/ai/AI_CONFIG_NOTES.md
+++ b/docs/ai/AI_CONFIG_NOTES.md
@@ -4,7 +4,7 @@ This document provides additional details about the centralized AI configuration
 
 ## Overview
 
-The AI configuration system has been centralized in `src/ai/aiConfig.js` to provide consistent AI management across both legacy and modern ES6 code. This approach makes the code more maintainable and simplifies adding new AI strategies in the future.
+The AI configuration system is centralized in `src/ai/aiConfig.js` to provide consistent AI management across the game and the bot arena. This approach makes the code more maintainable and simplifies adding new AI strategies.
 
 ## Key Components
 
@@ -24,27 +24,20 @@ The AI configuration system has been centralized in `src/ai/aiConfig.js` to prov
 3. **Default Assignments**
    - `DEFAULT_AI_ASSIGNMENTS` - Default mapping of player indices to AI strategy IDs
 
-## Configuration System
+## Assigning AIs to Players
 
-The configuration system uses `aiAssignments` instead of the previous `aiTypes`:
+AI strategies are assigned per player with an `aiAssignments` array — one strategy ID per player index, with `null` marking a human player:
 
 ```javascript
-// Old approach
-config.aiTypes = [
-  null, // Player 0 (human)
-  'ai_defensive', // Player 1
-  'ai_defensive', // Player 2
-  // ...
-];
-
-// New approach
-config.aiAssignments = [
+const aiAssignments = [
   null, // Player 0 (human)
   'ai_defensive', // Player 1
   'ai_defensive', // Player 2
   // ...
 ];
 ```
+
+`createAIFunctionMapping(aiAssignments)` resolves these IDs to the actual AI functions the engine runs.
 
 ## Adding New AI Strategies
 
@@ -71,15 +64,11 @@ export const AI_STRATEGIES = {
 };
 ```
 
-3. Assign it to players in the configuration:
+3. Assign it to players in the `aiAssignments` array:
 
 ```javascript
-config.aiAssignments[3] = 'ai_myCustom'; // Assign to player 3
+aiAssignments[3] = 'ai_myCustom'; // Assign to player 3
 ```
-
-## Legacy Support
-
-For backward compatibility, the configuration system still supports the old `aiTypes` format, but will log a warning recommending upgrade to `aiAssignments`.
 
 ## Testing
 
@@ -88,12 +77,11 @@ When testing AI functionality, you can use:
 ```javascript
 import { createAIFunctionMapping } from '../ai/index.js';
 
-// Create AI assignments based on string identifiers
+// Map strategy IDs to AI functions — async, since strategies load on demand
 const aiAssignments = ['ai_default', 'ai_defensive', null, 'ai_adaptive'];
-const aiFunctions = createAIFunctionMapping(aiAssignments);
+const aiFunctions = await createAIFunctionMapping(aiAssignments);
 
-// Apply to game
-game.ai = aiFunctions;
+// aiFunctions[i] is the AI for player i (null = human)
 ```
 
 ## Performance

--- a/docs/ai/DEVELOPER_GUIDE.md
+++ b/docs/ai/DEVELOPER_GUIDE.md
@@ -256,8 +256,8 @@ When the AI Championship Platform is ready, you'll be able to submit your AI thr
 
 - Existing AI implementations in `src/ai/`
 - Centralized AI configuration in `src/ai/aiConfig.js`
-- Game mechanics in `src/mechanics/`
-- AI handling in `src/mechanics/aiHandler.js`
+- Game engine in `src/engine/`
+- AI integration in `src/engine/AIAdapter.js`
 - Test framework for AI performance testing in `tests/ai/`
 
 ## Future Enhancements

--- a/src/README.md
+++ b/src/README.md
@@ -1,172 +1,68 @@
-# DiceWarsJS Modular Structure
+# src/ — DiceWarsJS Source
 
-This directory contains the refactored version of DiceWarsJS using ES6 modules. The modular structure separates concerns and makes the codebase easier to maintain and extend.
+A modern ES module application: **Vite** build, **PixiJS v8** rendering, **Preact** UI, all running on a pure game engine in `src/engine/`.
 
 ## Directory Structure
 
 ```
 src/
-├── ai/                    # AI strategy implementations
-│   ├── ai_default.js      # Default balanced AI strategy
-│   ├── ai_defensive.js    # Defensive AI strategy
-│   ├── ai_example.js      # Simple example AI for learning
-│   ├── ai_adaptive.js     # Adaptive AI that changes strategy based on game state
-│   ├── ai_claude.js       # Exact expected-value AI
-│   ├── ai_codex.js        # Claude EV baseline with expectimax overrides
-│   ├── aiConfig.js        # Centralized AI configuration and registry
-│   └── index.js           # Exports all AI strategies and configuration
-├── models/                # Data structures and models
-│   ├── AreaData.js        # Territory data structure
-│   ├── Battle.js          # Battle animation data
-│   ├── HistoryData.js     # History tracking for replays
-│   ├── JoinData.js        # Adjacency information for grid cells
-│   ├── PlayerData.js      # Player state tracking
-│   └── index.js           # Exports all models
-├── utils/                 # Utility functions
-│   ├── config.js          # Configuration management
-│   ├── gameUtils.js       # Game logic helpers
-│   ├── render.js          # UI rendering utilities
-│   ├── sound.js           # Sound management
-│   └── index.js           # Exports all utilities
-├── main.jsx               # Application entry point (PixiJS + Preact bootstrap)
-└── README.md              # This documentation file
+├── engine/       # Pure game logic — state, map gen, battles, turns (no DOM)
+├── ai/           # Built-in AI strategies + registry (aiConfig.js)
+├── arena/        # Bot SDK — validation, execution, tournaments, ELO, replays
+├── renderer/     # PixiJS rendering (hex grid, dice, battle animations)
+├── ui/           # Preact components (screens, HUD, overlays)
+├── store/        # Observable GameStore (pub/sub shared state)
+├── controller/   # GameController — game loop orchestrator
+├── audio/        # Web Audio sound manager
+├── utils/        # Game configuration (config.js)
+├── main.jsx      # Application entry point (PixiJS + Preact bootstrap)
+└── README.md     # This file
 ```
 
-## Module Overview
+See [`docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md) for the full directory guide and data-flow diagrams.
 
-### Game Engine
+## Game Engine
 
-The core game logic lives in `src/engine/` (pure, no DOM) and manages:
+The core game logic lives in `src/engine/` (pure, no DOM) and covers map generation,
+state management, player turns, attack resolution, and replay history. State is
+immutable — transitions go through `applyAction(...)`, which returns a new state object
+rather than mutating in place. The engine runs in both the browser and Node.js, so the
+arena and CLI tooling can drive it headlessly.
 
-- Map generation and territory layout
-- Game state management
-- Player turns
-- Attack resolution and dice mechanics
-- History and replay functionality
+## AI Strategies
 
-### Models
+Built-in strategies live in `src/ai/`, registered with metadata in `aiConfig.js`:
 
-Separate data structure classes:
+- `ai_default` — balanced strategy from the original game
+- `ai_defensive` — conservative, focused on protecting vulnerable territories
+- `ai_example` — minimal example for learning
+- `ai_adaptive` — adapts to game conditions
+- `ai_claude` — exact expected-value using dice odds and connectivity economics
+- `ai_codex` — Claude EV baseline with shallow expectimax overrides
 
-- `AreaData`: Represents a territory on the map
-- `PlayerData`: Tracks player stats and resources
-- `JoinData`: Handles grid adjacency information
-- `HistoryData`: Records game actions for replay
-- `Battle`: Manages battle visualization data
+### Writing an AI
 
-### AI Strategies
-
-Modular AI implementations with centralized configuration:
-
-- `ai_default`: Balanced strategy from the original game
-- `ai_defensive`: Conservative strategy focused on territory protection
-- `ai_example`: Simple example for learning how to create custom AIs
-- `ai_adaptive`: Adaptive strategy that changes based on game conditions
-- `ai_claude`: Exact expected-value strategy using dice odds and connectivity economics
-- `ai_codex`: Claude EV baseline with high-confidence shallow expectimax overrides
-
-The AI system is managed through a centralized configuration in `aiConfig.js` that provides:
-
-- A registry of all available AI strategies with metadata
-- Helper functions for accessing and mapping AI implementations
-- Utility functions for creating player-to-AI mappings
-- Standardized AI registration for new strategies
-
-### Utility Modules
-
-Helper functions organized by purpose:
-
-- `config.js`: Manages game configuration settings and persistence
-- `gameUtils.js`: Game logic helper functions (attack probability, territory analysis)
-- `render.js`: UI rendering utilities for map, territories, and UI elements
-- `sound.js`: Sound management (loading, playing, volume control)
-
-## Creating Custom AI
-
-To create a custom AI:
-
-1. Create a new file in the `ai/` directory (e.g., `ai_custom.js`)
-2. Export a function that takes a `game` parameter
-3. Implement your AI logic to select attacks
-4. Add a dynamic loader and registry entry in `aiConfig.js`
-
-Example:
+A built-in AI is a function that receives the `game` object, sets `game.area_from` /
+`game.area_to` to launch an attack, and returns `0` to end its turn:
 
 ```javascript
-// ai/ai_custom.js
+// src/ai/ai_custom.js
 export function ai_custom(game) {
-  // Your AI logic here
-  // ...
+  // ...choose an attack...
+  if (noGoodMoves) return 0; // end turn
 
-  // Return 0 to end turn if no valid attacks
-  if (no_good_moves) return 0;
-
-  // Set your chosen attack
   game.area_from = attackerArea;
   game.area_to = targetArea;
 }
 ```
 
-## Configuration System
+Register it by adding a dynamic loader and registry entry in `aiConfig.js`.
 
-The configuration system allows customizing various aspects of the game:
+To write a **bot** for the arena — the modern, sandboxed `state → { from, to } | null`
+interface used for tournaments — see [`docs/BOT_GUIDE.md`](../docs/BOT_GUIDE.md).
 
-```javascript
-import { updateConfig, getConfig } from '@utils/config.js';
+## Further Reading
 
-// Change the number of players
-updateConfig({ playerCount: 4 });
-
-// Change the AI for player 3
-const config = getConfig();
-config.aiAssignments[3] = 'ai_defensive';
-updateConfig(config);
-
-// Save configuration to localStorage
-// (done automatically by updateConfig)
-```
-
-## Game Utilities
-
-The gameUtils module provides helpful functions for game logic:
-
-```javascript
-import { calculateAttackProbability, analyzeTerritory, findBestAttack } from '@utils/gameUtils.js';
-
-// Calculate probability of attack success
-const probability = calculateAttackProbability(5, 3); // 0.65
-
-// Analyze a territory for strategic value
-const analysis = analyzeTerritory(game, territoryId);
-console.log(analysis.vulnerabilityRating); // 0-100
-
-// Find best attack for AI
-const bestAttack = findBestAttack(game, playerId);
-if (bestAttack) {
-  game.area_from = bestAttack.from;
-  game.area_to = bestAttack.to;
-}
-```
-
-## Rendering Utilities
-
-The render module provides functions for UI elements:
-
-```javascript
-import { createButton, createText, drawTerritory, createDiceDisplay } from '@utils/render.js';
-
-// Create a button
-const button = createButton('End Turn', x, y, width, height, handleClick);
-stage.addChild(button);
-
-// Draw a territory
-drawTerritory(game, graphics, areaId, cellPositions, cellWidth, cellHeight);
-
-// Create player status display
-const statusDisplay = createPlayerStatus(game, playerId, x, y);
-stage.addChild(statusDisplay);
-```
-
-## Future Development
-
-See [`docs/MODERNIZATION_ROADMAP.md`](../docs/MODERNIZATION_ROADMAP.md) for the full modernization plan, including PixiJS rendering, a Bot SDK, and an arena system for bot competitions.
+- [`docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md) — codebase organization and data flow
+- [`docs/BOT_GUIDE.md`](../docs/BOT_GUIDE.md) — how to write a bot, full SDK reference
+- [`docs/MODERNIZATION_ROADMAP.md`](../docs/MODERNIZATION_ROADMAP.md) — project history

--- a/src/README.md
+++ b/src/README.md
@@ -14,7 +14,7 @@ src/
 ├── store/        # Observable GameStore (pub/sub shared state)
 ├── controller/   # GameController — game loop orchestrator
 ├── audio/        # Web Audio sound manager
-├── utils/        # Game configuration (config.js)
+├── utils/        # Game configuration — map-size presets
 ├── main.jsx      # Application entry point (PixiJS + Preact bootstrap)
 └── README.md     # This file
 ```


### PR DESCRIPTION
Follows the simplification series (#20–#23, all merged). Waves A–D deleted the orphaned `src/mechanics/`, `src/models/`, `src/state/` subtrees and the dead CreateJS-era `src/utils/` layer, but several **active docs still described them as live architecture**. This pass truths up the docs the user flagged.

## Changes

| File | Fix |
|------|-----|
| `CLAUDE.md` | Repoint Map Generation/Battle Resolution → `src/engine/MapGenerator.js`/`BattleResolver.js`; **remove** the deleted Models / Enhanced Modules / Error-Handling components and the `GameError`/`BattleError`/`TerritoryError` "Error Hierarchy" pattern (those classes no longer exist anywhere in `src/`); reframe "Immutable Data" around the engine's `applyAction`; list the real aliases (`@utils`/`@ai`/`@engine`). |
| `docs/ARCHITECTURE.md` | Remove the `src/mechanics/`, `src/models/`, `src/state/` directory-guide rows; fix the `src/utils/` row. |
| `README.md` | Drop `mechanics/` and `models/` from the `src/` tree; fix `utils/`. |
| `src/README.md` | Rewrite the stale pre-engine tree (it predated `engine/`/`arena/`/`renderer/`/`ui/`); remove the deleted `models/`, `gameUtils.js`, `render.js` sections and the `@utils` import examples; defer to ARCHITECTURE.md / BOT_GUIDE.md. |
| `docs/ai/DEVELOPER_GUIDE.md` | Repoint `src/mechanics/` → `src/engine/` (engine + `AIAdapter.js`). |
| `docs/CI_CD.md` | Drop the dead `npm run perf:check` reference. |
| `docs/MODERNIZATION_ROADMAP.md` | Extend the status banner to note the June 2026 subtree/utils removal. |

## Note on MODERNIZATION_ROADMAP.md
It's an explicitly **historical** document. Its §2 "Current State Assessment" and §11 "What We Keep vs. Rewrite" tables describe the *pre-modernization starting state* (`src/models/` "Complete, well-tested", `src/state/` "Orphaned", etc.) — that was true when written. Rewriting them would falsify the record, so instead the **status banner now states those subtrees were removed** and frames those sections as retained history. A reader hitting those rows is told up front the code no longer exists.

## Intentionally out of scope
- `docs/TESTING.md` — has its own pending Jest→Vitest rewrite item (one stray `gameUtils.test.js` ref there is left for that pass).
- `docs/archived/*` — correctly left as historical records.

## Review follow-ups (added after review)

- **`src/utils/` description reword** (`ecb3cb1`, `1cec5eb`) — `docs/ARCHITECTURE.md`, `README.md`, `src/README.md`. The initial "fix the `src/utils/` row" still carried wording ("player/AI assignments", "localStorage persistence") that the wave-F trim (#26) removes. Reworded to the durable, live responsibility — **map-size presets** (`resolveMapSize`, surfaced in the title screen and resolved by the controller) — which reads accurately both before and after #26 lands, under any merge order.
- **`docs/ai/AI_CONFIG_NOTES.md` truth-up** (`803a624`) — dropped the "Legacy Support" `aiTypes` section and the obsolete `aiTypes`→`aiAssignments` migration framing (that plumbing lived only in the removed `applyConfigToGame`), described the current per-player `aiAssignments` model, and fixed the `await` on the async `createAIFunctionMapping` example. The live AI registry (`src/ai/aiConfig.js`) is unchanged and remains accurate.

## Validation
Docs-only change. `npm run format:check` ✓. No code touched, so build/lint/test are unaffected (CI will reconfirm).
