### PR TITLE
chore: drop dead eslint createjs global + stale ignorePatterns (wave-D follow-up)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -93,8 +93,6 @@ module.exports = {
     'func-names': ['off'],
   },
   globals: {
-    // CreateJS library globals
-    createjs: 'readonly',
     // Global functions available in newer Node.js versions
     structuredClone: 'readonly',
   },
@@ -113,11 +111,6 @@ module.exports = {
 
     // Source files excluded temporarily (will be improved gradually)
     'src/utils/config.js',
-    '**/PlayerData.js', // Private field syntax not supported by current ESLint config
-
-    // Test files with parsing issues
-    'tests/models/enhanced/PlayerData.test.js',
-    'tests/state/ImmutableState.test.js',
 
     // Test setup (mock globals, not linted)
     'tests/setup.js',


### PR DESCRIPTION
The three deferred wave-D items (they were coupled to the then-unmerged A/B/C). Two are now cleanly unblocked; the third is deferred one more step (see below).

## Done here (`.eslintrc.cjs` only)
- **Remove the `createjs: 'readonly'` global.** Its only consumers (`src/ui/titleScreen.js`, `playerStatus.js`) were deleted in wave B. No linted code references the `createjs` identifier — verified: the `'createjs'` in `tests/engine/headless.test.js:81` is a string literal in a browser-globals list, and `tests/setup.js`'s `global.createjs` mock is in an ESLint-ignored file (runtime-only).
- **Remove three dangling `ignorePatterns`** whose files were deleted in wave C: `**/PlayerData.js`, `tests/models/enhanced/PlayerData.test.js`, `tests/state/ImmutableState.test.js`. Kept `src/utils/config.js` (still excluded pending the wave-F trim).

## Deferred (one item)
Removing the unused vite aliases `@utils`/`@ai`/`@engine` (zero imports in code — confirmed) requires re-editing **CLAUDE.md's path-alias line**, which the still-open **wave-E PR #24** also edits. Doing it now is the only thing in the whole series that would create a cross-PR conflict, so it lands as a trivial change once #24 merges (I'll fold it into the wave-F PR or a standalone).

## Validation
`npm run lint` → **0 errors** (24 warnings, all pre-existing). `npm run format:check` clean. Lint-config-only change; build/tests unaffected (CI reconfirms).