### PR TITLE
refactor: trim config.js to its live map-size exports (wave F)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -109,9 +109,6 @@ module.exports = {
     'bots/',
     'community-bots/',
 
-    // Source files excluded temporarily (will be improved gradually)
-    'src/utils/config.js',
-
     // Test setup (mock globals, not linted)
     'tests/setup.js',
 

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -33,11 +33,24 @@ export const DEFAULT_MAP_SIZE = 'medium';
 
 /**
  * Resolve a map-size preset key to concrete engine dimensions.
- * Unknown/invalid keys fall back to the default (medium) preset.
+ * Unknown/invalid keys fall back to the default (medium) preset — never throws,
+ * so a bad size token can't crash game creation. In dev builds the fallback is
+ * also logged, to surface a missing-preset mistake (see below).
  *
  * @param {string} size - Preset key ('small' | 'medium' | 'large')
  * @returns {{ mapWidth: number, mapHeight: number, maxAreas: number }}
  */
 export function resolveMapSize(size) {
-  return MAP_SIZE_PRESETS[size] ?? MAP_SIZE_PRESETS[DEFAULT_MAP_SIZE];
+  const preset = MAP_SIZE_PRESETS[size];
+  if (!preset && import.meta.env?.DEV) {
+    /*
+     * Dev-only signal. Selectable sizes (MAP_SIZE_OPTIONS in the title screen)
+     * must each have a matching preset key here; adding an option without its
+     * preset would otherwise silently ship a medium map with no indication.
+     * Guarded by `import.meta.env?.DEV` so production builds stay silent and the
+     * `?.` keeps it safe under plain Node (arena/CLI), where env is undefined.
+     */
+    console.warn(`resolveMapSize: unknown map size "${size}" — falling back to "${DEFAULT_MAP_SIZE}".`);
+  }
+  return preset ?? MAP_SIZE_PRESETS[DEFAULT_MAP_SIZE];
 }

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -1,58 +1,13 @@
 /**
- * Configuration Management Module
+ * Game configuration — map-size presets.
  *
- * Provides utilities for game configuration:
- * - Default game settings
- * - Configuration loading and saving
- * - Dynamic configuration options
+ * The live game uses only the map-size presets below: the title screen lets the
+ * player pick a size, and the controller resolves it to concrete engine
+ * dimensions via `resolveMapSize`. The earlier CreateJS/Webpack-era config
+ * plumbing (DEFAULT_CONFIG, getConfig/updateConfig/loadConfig/resetConfig/
+ * applyConfigToGame, and the `window.*` globals) has been removed — it had no
+ * remaining consumers.
  */
-
-import { createAIFunctionMapping } from '../ai/index.js';  // Import AI configuration utilities
-
-/**
- * Default game configuration
- */
-export const DEFAULT_CONFIG = {
-  // Game rules
-  playerCount: 7,         // Default number of players (including human)
-  humanPlayerIndex: 0,    // Index of human player (0-7)
-  averageDicePerArea: 3,  // Average dice per territory
-  maxDice: 8,             // Maximum dice per territory
-  
-  // AI configuration - imported from centralized AI config
-  aiAssignments: [
-    null,                // Player 0 (human by default)
-    'ai_defensive',      // Player 1
-    'ai_defensive',      // Player 2
-    'ai_adaptive',       // Player 3
-    'ai_default',        // Player 4
-    'ai_default',        // Player 5
-    'ai_claude',         // Player 6
-    'ai_codex'           // Player 7
-  ],
-
-  // Spectator mode settings
-  spectatorSpeedMultiplier: 1,
-  
-  // Display settings
-  mapWidth: 28,           // Width of map grid (cells)
-  mapHeight: 32,          // Height of map grid (cells)
-  territoriesCount: 32,   // Maximum number of territories
-  
-  // Graphics settings
-  displayScale: 1,        // Display scaling factor
-  soundEnabled: true,     // Sound effects enabled
-  
-  // Display dimensions
-  display: {
-    viewWidth: 840,       // Canvas width
-    viewHeight: 840,      // Canvas height
-    cellWidth: 27,        // Cell width before scaling
-    cellHeight: 18,       // Cell height before scaling
-    messageYPos: 688,     // Y-position for messages
-    armyYPos: 770         // Y-position for player status
-  }
-};
 
 /**
  * Map-size presets surfaced in the title-screen UI.
@@ -64,8 +19,8 @@ export const DEFAULT_CONFIG = {
  * exceeds the 8-player maximum, so every preset is guaranteed to generate a
  * playable map for any supported player count (no RangeError from pruning).
  *
- * `medium` intentionally mirrors DEFAULT_CONFIG (28×32, 32 territories) so the
- * default selection reproduces today's exact behaviour.
+ * `medium` reproduces the historical default (28×32, 32 territories) so the
+ * default selection preserves the original behaviour.
  */
 export const MAP_SIZE_PRESETS = {
   small: { mapWidth: 20, mapHeight: 24, maxAreas: 20 },
@@ -85,163 +40,4 @@ export const DEFAULT_MAP_SIZE = 'medium';
  */
 export function resolveMapSize(size) {
   return MAP_SIZE_PRESETS[size] ?? MAP_SIZE_PRESETS[DEFAULT_MAP_SIZE];
-}
-
-/**
- * Current active configuration
- */
-let activeConfig = { ...DEFAULT_CONFIG };
-
-// Merge in any legacy configuration provided before modules loaded
-if (typeof window !== 'undefined' && window.GAME_CONFIG) {
-  activeConfig = { ...activeConfig, ...window.GAME_CONFIG };
-}
-
-/**
- * Get the current game configuration
- * @returns {Object} The current configuration object
- */
-export function getConfig() {
-  return { ...activeConfig };
-}
-
-/**
- * Update the game configuration
- * @param {Object} newConfig - New configuration settings to apply
- * @returns {Object} The updated configuration
- */
-export function updateConfig(newConfig) {
-  activeConfig = {
-    ...activeConfig,
-    ...newConfig,
-    // Handle nested objects separately for deep merge
-    display: {
-      ...activeConfig.display,
-      ...(newConfig?.display ?? {})
-    }
-  };
-  
-  // Save to localStorage if available
-  try {
-    localStorage?.setItem('dicewarsConfig', JSON.stringify(activeConfig));
-  } catch (e) {
-    console.warn('Failed to save configuration to localStorage', e);
-  }
-  
-  return getConfig();
-}
-
-/**
- * Load configuration from localStorage if available
- * @returns {Object} The loaded or default configuration
- */
-export function loadConfig() {
-  try {
-    const savedConfig = localStorage?.getItem('dicewarsConfig');
-    if (savedConfig) {
-      updateConfig(JSON.parse(savedConfig));
-    }
-  } catch (e) {
-    console.warn('Failed to load configuration from localStorage', e);
-  }
-  return getConfig();
-}
-
-/**
- * Reset configuration to defaults
- * @returns {Object} The default configuration
- */
-export function resetConfig() {
-  activeConfig = { ...DEFAULT_CONFIG };
-  
-  // Clear from localStorage if available
-  try {
-    localStorage?.removeItem('dicewarsConfig');
-  } catch (e) {
-    console.warn('Failed to clear configuration from localStorage', e);
-  }
-  
-  return getConfig();
-}
-
-/**
- * Apply configuration to a game instance
- * @param {Game} game - The game instance to configure
- * @param {Object} [config=null] - Optional configuration to apply (uses active config if not provided)
- */
-export async function applyConfigToGame(game, config = null) {
-  const cfg = config ?? activeConfig;
-  
-  // Game rules
-  game.pmax = cfg.playerCount;
-  game.user = cfg.humanPlayerIndex;
-  game.put_dice = cfg.averageDicePerArea;
-  
-  // Map dimensions
-  game.XMAX = cfg.mapWidth;
-  game.YMAX = cfg.mapHeight;
-  game.AREA_MAX = cfg.territoriesCount;
-  
-  // AI configuration using the central configuration system
-  if (Array.isArray(cfg.aiAssignments) && game.ai) {
-    // Create a copy of aiAssignments to modify for the human player
-    const aiAssignments = [...cfg.aiAssignments];
-
-    // Ensure human player has null AI only if not in spectator mode
-    if (cfg.humanPlayerIndex !== null && cfg.humanPlayerIndex >= 0 && cfg.humanPlayerIndex < aiAssignments.length) {
-      aiAssignments[cfg.humanPlayerIndex] = null;
-    }
-
-    // Use the configureAI function if available (modern code pattern)
-    if (typeof game.configureAI === 'function') {
-      await game.configureAI(aiAssignments);
-    }
-    // Legacy compatibility approach
-    else {
-      // Get AI functions from the assignments
-      const aiFunctions = await createAIFunctionMapping(aiAssignments);
-
-      // Apply to the game's AI array
-      for (let i = 0; i < aiFunctions.length && i < game.ai.length; i++) {
-        game.ai[i] = aiFunctions[i];
-      }
-    }
-
-    // Log info about AI configuration for debugging
-    console.log(`Game configured with humanPlayerIndex: ${cfg.humanPlayerIndex}`);
-    console.log(`Player 0 AI function: ${game.ai[0] ? 'AI' : 'Human'}`);
-  }
-  // Legacy support for older config format
-  else if (Array.isArray(cfg.aiTypes) && game.ai) {
-    console.warn('Using legacy aiTypes configuration - consider upgrading to aiAssignments');
-
-    // Use aiTypes as aiAssignments
-    const aiAssignments = [...cfg.aiTypes];
-
-    // Ensure human player has null AI only if not in spectator mode
-    if (cfg.humanPlayerIndex !== null && cfg.humanPlayerIndex >= 0 && cfg.humanPlayerIndex < aiAssignments.length) {
-      aiAssignments[cfg.humanPlayerIndex] = null;
-    }
-
-    // Get AI functions from the assignments
-    const aiFunctions = await createAIFunctionMapping(aiAssignments);
-
-    // Apply to the game's AI array
-    for (let i = 0; i < aiFunctions.length && i < game.ai.length; i++) {
-      game.ai[i] = aiFunctions[i];
-    }
-  }
-  
-  return game;
-}
-
-// Initialize by loading any saved configuration
-loadConfig();
-
-// Export functions for global use
-if (typeof window !== 'undefined') {
-  window.applyGameConfig = applyConfigToGame;
-  window.getConfig = getConfig;
-  window.updateConfig = updateConfig;
-  window.resetConfig = resetConfig;
 }

--- a/tests/utils/config.test.js
+++ b/tests/utils/config.test.js
@@ -52,9 +52,17 @@ describe('config — map size presets', () => {
     });
 
     test('falls back to the default preset for unknown or invalid keys', () => {
+      /*
+       * The fallback is dev-only-loud: it logs (so a missing preset surfaces in
+       * dev) but never throws. Spy keeps the expected warnings out of test output.
+       */
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
       for (const bad of ['huge', '', undefined, null, 0, 'MEDIUM']) {
         expect(resolveMapSize(bad)).toEqual(MAP_SIZE_PRESETS[DEFAULT_MAP_SIZE]);
       }
+      // import.meta.env.DEV is true under vitest, so the dev warning fires.
+      expect(warn).toHaveBeenCalled();
+      warn.mockRestore();
     });
   });
 });

--- a/tests/utils/config.test.js
+++ b/tests/utils/config.test.js
@@ -1,325 +1,60 @@
-// @vitest-environment jsdom
 /**
- * Tests for Configuration Management Module
+ * Tests for the configuration module (map-size presets).
  */
-/*
- * Mock the AI module first
- * Now import the module under test
- */
-import {
-  DEFAULT_CONFIG,
-  MAP_SIZE_PRESETS,
-  DEFAULT_MAP_SIZE,
-  resolveMapSize,
-  getConfig,
-  updateConfig,
-  resetConfig,
-  applyConfigToGame,
-} from '../../src/utils/config.js';
+import { MAP_SIZE_PRESETS, DEFAULT_MAP_SIZE, resolveMapSize } from '../../src/utils/config.js';
 
-vi.mock('../../src/ai/index.js', () => {
-  const mockDefaultAI = vi.fn();
-  const mockDefensiveAI = vi.fn();
-  const mockExampleAI = vi.fn();
-  const mockAdaptiveAI = vi.fn();
-
-  return {
-    AI_STRATEGIES: {
-      ai_default: { loader: async () => mockDefaultAI, implementation: mockDefaultAI },
-      ai_defensive: { loader: async () => mockDefensiveAI, implementation: mockDefensiveAI },
-      ai_example: { loader: async () => mockExampleAI, implementation: mockExampleAI },
-      ai_adaptive: { loader: async () => mockAdaptiveAI, implementation: mockAdaptiveAI },
-    },
-    createAIFunctionMapping: vi.fn(async aiAssignments => {
-      const mapping = Array(8).fill(null);
-
-      if (!aiAssignments) return mapping;
-
-      aiAssignments.forEach((type, index) => {
-        if (type === 'ai_default') mapping[index] = mockDefaultAI;
-        else if (type === 'ai_defensive') mapping[index] = mockDefensiveAI;
-        else if (type === 'ai_example') mapping[index] = mockExampleAI;
-        else if (type === 'ai_adaptive') mapping[index] = mockAdaptiveAI;
-        else if (type !== null) mapping[index] = mockDefaultAI; // Fallback
-      });
-
-      return mapping;
-    }),
-    ai_default: mockDefaultAI,
-    ai_defensive: mockDefensiveAI,
-    ai_example: mockExampleAI,
-    ai_adaptive: mockAdaptiveAI,
-    DEFAULT_AI_ASSIGNMENTS: Array(8).fill('ai_default'),
-  };
-});
-
-// Mock localStorage
-const localStorageMock = (() => {
-  let store = {};
-  return {
-    getItem: vi.fn(key => store[key] || null),
-    setItem: vi.fn((key, value) => {
-      store[key] = String(value);
-    }),
-    removeItem: vi.fn(key => {
-      delete store[key];
-    }),
-    clear: vi.fn(() => {
-      store = {};
-    }),
-  };
-})();
-
-Object.defineProperty(window, 'localStorage', {
-  value: localStorageMock,
-});
-
-describe('Configuration Management', () => {
-  beforeEach(() => {
-    localStorageMock.clear();
-    vi.clearAllMocks();
+describe('config — map size presets', () => {
+  test('exposes small, medium, and large presets with engine dimensions', () => {
+    for (const key of ['small', 'medium', 'large']) {
+      const preset = MAP_SIZE_PRESETS[key];
+      expect(preset).toBeDefined();
+      expect(preset.mapWidth).toBeGreaterThan(0);
+      expect(preset.mapHeight).toBeGreaterThan(0);
+      expect(preset.maxAreas).toBeGreaterThan(0);
+    }
   });
 
-  describe('DEFAULT_CONFIG', () => {
-    test('has the expected default values', () => {
-      expect(DEFAULT_CONFIG.playerCount).toBe(7);
-      expect(DEFAULT_CONFIG.humanPlayerIndex).toBe(0);
-      expect(DEFAULT_CONFIG.averageDicePerArea).toBe(3);
-      expect(DEFAULT_CONFIG.aiAssignments).toHaveLength(8);
-      expect(DEFAULT_CONFIG.display).toBeDefined();
+  test('medium reproduces the historical default (28x32, 32 territories)', () => {
+    expect(MAP_SIZE_PRESETS.medium).toEqual({ mapWidth: 28, mapHeight: 32, maxAreas: 32 });
+  });
+
+  test('every preset is guaranteed to generate for up to 8 players', () => {
+    /*
+     * The engine prunes territories smaller than MIN_TERRITORY_SIZE (6 cells)
+     * and throws if valid territories < playerCount. Keep cells-per-territory
+     * well above 6 and maxAreas >= the 8-player maximum.
+     */
+    const MAX_PLAYERS = 8;
+    for (const key of ['small', 'medium', 'large']) {
+      const { mapWidth, mapHeight, maxAreas } = MAP_SIZE_PRESETS[key];
+      expect(maxAreas).toBeGreaterThanOrEqual(MAX_PLAYERS);
+      const cellsPerArea = (mapWidth * mapHeight) / maxAreas;
+      expect(cellsPerArea).toBeGreaterThan(6);
+    }
+  });
+
+  test('presets are ordered small < medium < large by cell count', () => {
+    const cells = key => MAP_SIZE_PRESETS[key].mapWidth * MAP_SIZE_PRESETS[key].mapHeight;
+    expect(cells('small')).toBeLessThan(cells('medium'));
+    expect(cells('medium')).toBeLessThan(cells('large'));
+  });
+
+  test('DEFAULT_MAP_SIZE points at an existing preset', () => {
+    expect(DEFAULT_MAP_SIZE).toBe('medium');
+    expect(MAP_SIZE_PRESETS[DEFAULT_MAP_SIZE]).toBeDefined();
+  });
+
+  describe('resolveMapSize', () => {
+    test('resolves each preset key to its dimensions', () => {
+      expect(resolveMapSize('small')).toEqual(MAP_SIZE_PRESETS.small);
+      expect(resolveMapSize('medium')).toEqual(MAP_SIZE_PRESETS.medium);
+      expect(resolveMapSize('large')).toEqual(MAP_SIZE_PRESETS.large);
     });
-  });
 
-  describe('map size presets', () => {
-    test('exposes small, medium, and large presets with engine dimensions', () => {
-      for (const key of ['small', 'medium', 'large']) {
-        const preset = MAP_SIZE_PRESETS[key];
-        expect(preset).toBeDefined();
-        expect(preset.mapWidth).toBeGreaterThan(0);
-        expect(preset.mapHeight).toBeGreaterThan(0);
-        expect(preset.maxAreas).toBeGreaterThan(0);
+    test('falls back to the default preset for unknown or invalid keys', () => {
+      for (const bad of ['huge', '', undefined, null, 0, 'MEDIUM']) {
+        expect(resolveMapSize(bad)).toEqual(MAP_SIZE_PRESETS[DEFAULT_MAP_SIZE]);
       }
-    });
-
-    test('medium mirrors DEFAULT_CONFIG so the default reproduces current behaviour', () => {
-      expect(MAP_SIZE_PRESETS.medium).toEqual({
-        mapWidth: DEFAULT_CONFIG.mapWidth,
-        mapHeight: DEFAULT_CONFIG.mapHeight,
-        maxAreas: DEFAULT_CONFIG.territoriesCount,
-      });
-    });
-
-    test('every preset is guaranteed to generate for up to 8 players', () => {
-      /*
-       * The engine prunes territories smaller than MIN_TERRITORY_SIZE (6 cells)
-       * and throws if valid territories < playerCount. Keep cells-per-territory
-       * well above 6 and maxAreas >= the 8-player maximum.
-       */
-      const MAX_PLAYERS = 8;
-      for (const key of ['small', 'medium', 'large']) {
-        const { mapWidth, mapHeight, maxAreas } = MAP_SIZE_PRESETS[key];
-        expect(maxAreas).toBeGreaterThanOrEqual(MAX_PLAYERS);
-        const cellsPerArea = (mapWidth * mapHeight) / maxAreas;
-        expect(cellsPerArea).toBeGreaterThan(6);
-      }
-    });
-
-    test('presets are ordered small < medium < large by cell count', () => {
-      const cells = key => MAP_SIZE_PRESETS[key].mapWidth * MAP_SIZE_PRESETS[key].mapHeight;
-      expect(cells('small')).toBeLessThan(cells('medium'));
-      expect(cells('medium')).toBeLessThan(cells('large'));
-    });
-
-    test('DEFAULT_MAP_SIZE points at an existing preset', () => {
-      expect(DEFAULT_MAP_SIZE).toBe('medium');
-      expect(MAP_SIZE_PRESETS[DEFAULT_MAP_SIZE]).toBeDefined();
-    });
-
-    describe('resolveMapSize', () => {
-      test('resolves each preset key to its dimensions', () => {
-        expect(resolveMapSize('small')).toEqual(MAP_SIZE_PRESETS.small);
-        expect(resolveMapSize('medium')).toEqual(MAP_SIZE_PRESETS.medium);
-        expect(resolveMapSize('large')).toEqual(MAP_SIZE_PRESETS.large);
-      });
-
-      test('falls back to the default preset for unknown or invalid keys', () => {
-        for (const bad of ['huge', '', undefined, null, 0, 'MEDIUM']) {
-          expect(resolveMapSize(bad)).toEqual(MAP_SIZE_PRESETS[DEFAULT_MAP_SIZE]);
-        }
-      });
-    });
-  });
-
-  describe('getConfig', () => {
-    test('returns a copy of the active config', () => {
-      const config = getConfig();
-      expect(config).toEqual(DEFAULT_CONFIG);
-      expect(config).not.toBe(DEFAULT_CONFIG); // Should be a different object (copy)
-    });
-  });
-
-  describe('updateConfig', () => {
-    test('updates existing config values', () => {
-      const newConfig = {
-        playerCount: 4,
-        humanPlayerIndex: 2,
-      };
-
-      updateConfig(newConfig);
-      const updatedConfig = getConfig();
-
-      expect(updatedConfig.playerCount).toBe(4);
-      expect(updatedConfig.humanPlayerIndex).toBe(2);
-      expect(updatedConfig.averageDicePerArea).toBe(DEFAULT_CONFIG.averageDicePerArea);
-    });
-
-    test('updates nested display object', () => {
-      const newConfig = {
-        display: {
-          viewWidth: 1024,
-          viewHeight: 768,
-        },
-      };
-
-      updateConfig(newConfig);
-      const updatedConfig = getConfig();
-
-      expect(updatedConfig.display.viewWidth).toBe(1024);
-      expect(updatedConfig.display.viewHeight).toBe(768);
-      expect(updatedConfig.display.cellWidth).toBe(DEFAULT_CONFIG.display.cellWidth);
-    });
-
-    test('saves to localStorage if available', () => {
-      const newConfig = { playerCount: 4 };
-      updateConfig(newConfig);
-
-      expect(localStorage.setItem).toHaveBeenCalled();
-      expect(localStorage.setItem.mock.calls[0][0]).toBe('dicewarsConfig');
-      expect(JSON.parse(localStorage.setItem.mock.calls[0][1])).toMatchObject(newConfig);
-    });
-  });
-
-  describe('resetConfig', () => {
-    test('resets config to default values', () => {
-      updateConfig({ playerCount: 4 });
-      expect(getConfig().playerCount).toBe(4);
-
-      resetConfig();
-      expect(getConfig()).toEqual(DEFAULT_CONFIG);
-    });
-
-    test('removes config from localStorage', () => {
-      updateConfig({ playerCount: 4 });
-      resetConfig();
-
-      expect(localStorage.removeItem).toHaveBeenCalledWith('dicewarsConfig');
-    });
-  });
-
-  describe('applyConfigToGame', () => {
-    test('applies config values to game object', async () => {
-      // Mock AI functions for testing
-      const mockDefaultAI = vi.fn();
-      const mockDefensiveAI = vi.fn();
-      const mockExampleAI = vi.fn();
-      const mockAdaptiveAI = vi.fn();
-
-      // Our mocks are already set up at the top of the file
-
-      const game = {
-        pmax: 0,
-        user: 0,
-        put_dice: 0,
-        XMAX: 0,
-        YMAX: 0,
-        AREA_MAX: 0,
-        ai: [null, null, null, null, null, null, null, null],
-        aiRegistry: {
-          ai_default: mockDefaultAI,
-          ai_defensive: mockDefensiveAI,
-          ai_example: mockExampleAI,
-          ai_adaptive: mockAdaptiveAI,
-        },
-        configureAI: vi.fn(function (aiAssignments) {
-          // Simple implementation to simulate the configureAI function
-          for (let i = 0; i < aiAssignments.length && i < this.ai.length; i++) {
-            if (aiAssignments[i] === 'ai_default') this.ai[i] = this.aiRegistry.ai_default;
-            else if (aiAssignments[i] === 'ai_defensive') this.ai[i] = this.aiRegistry.ai_defensive;
-            else if (aiAssignments[i] === 'ai_example') this.ai[i] = this.aiRegistry.ai_example;
-            else if (aiAssignments[i] === 'ai_adaptive') this.ai[i] = this.aiRegistry.ai_adaptive;
-            else if (aiAssignments[i] !== null) this.ai[i] = this.aiRegistry.ai_default;
-          }
-
-          return this;
-        }),
-      };
-
-      const config = {
-        playerCount: 5,
-        humanPlayerIndex: 2,
-        averageDicePerArea: 4,
-        mapWidth: 30,
-        mapHeight: 34,
-        territoriesCount: 36,
-        aiAssignments: [
-          null,
-          'ai_adaptive',
-          'ai_defensive',
-          'ai_example',
-          'ai_default',
-          null,
-          null,
-          null,
-        ],
-      };
-
-      await applyConfigToGame(game, config);
-
-      expect(game.pmax).toBe(5);
-      expect(game.user).toBe(2);
-      expect(game.put_dice).toBe(4);
-      expect(game.XMAX).toBe(30);
-      expect(game.YMAX).toBe(34);
-      expect(game.AREA_MAX).toBe(36);
-
-      /*
-       * For the purposes of this test, we only check if configureAI was called
-       * since the actual AI assignment happens in that function
-       */
-      expect(game.configureAI).toHaveBeenCalled();
-    });
-
-    test('handles unknown AI types gracefully', async () => {
-      // Create mock function
-      const mockDefaultAI = vi.fn();
-
-      const game = {
-        ai: [null, null],
-        aiRegistry: {
-          ai_default: mockDefaultAI,
-        },
-        configureAI: vi.fn(function (aiAssignments) {
-          // Simple implementation to simulate the configureAI function
-          for (let i = 0; i < aiAssignments.length && i < this.ai.length; i++) {
-            if (aiAssignments[i] === null) {
-              this.ai[i] = null;
-            } else {
-              // Default to ai_default for unknown types
-              this.ai[i] = this.aiRegistry.ai_default;
-            }
-          }
-          return this;
-        }),
-      };
-
-      const config = {
-        aiAssignments: [null, 'ai_unknown'],
-      };
-
-      await applyConfigToGame(game, config);
-
-      expect(game.ai[0]).toBeNull();
-      expect(game.ai[1]).toBe(game.aiRegistry.ai_default);
     });
   });
 });


### PR DESCRIPTION
The final in-place simplification. `src/utils/config.js` carried a large CreateJS/Webpack-era configuration layer with **no remaining runtime consumers** — the live game uses only the map-size presets.

## What the live app actually uses
- `src/ui/TitleScreen.jsx` → `DEFAULT_MAP_SIZE`
- `src/controller/GameController.js` → `resolveMapSize`

(Both via relative imports. The `getConfig`/`updateConfig` reference in `src/README.md` is a doc that wave-E PR #24 already removes.)

## Removed (zero live consumers — verified across src/, scripts/, tests/, public/, index.html, incl. `window.*` globals)
- `DEFAULT_CONFIG` + the module-level `activeConfig` + the `window.GAME_CONFIG` merge
- `getConfig` / `updateConfig` / `loadConfig` / `resetConfig` / `applyConfigToGame`
- the `createAIFunctionMapping` import and the `window.applyGameConfig/getConfig/updateConfig/resetConfig` assignments
- the import-time `loadConfig()` side effect

## Kept (self-contained)
`MAP_SIZE_PRESETS`, `DEFAULT_MAP_SIZE`, `resolveMapSize`.

## Test
`tests/utils/config.test.js` pruned to the kept exports — drops the `// @vitest-environment jsdom` docblock, the `ai/index.js` mock, and the `localStorage` scaffolding (all only needed by the removed functions). It now runs in the lighter node env.

## Result
`config.js`: **248 → 42 lines**. Its coverage is now **100%** (was ~85%).

## Validation
- `npm run build` ✓
- `npm run lint` ✓ (0 errors)
- `npm run test:coverage` ✓ — 48 files / 656 tests; `src/utils` 100%; global 69% stmts / 90% branches (all floors clear)

## Review follow-ups (added after review)

- **`chore(eslint)` `3d97bcf`** — drop the now-clean `src/utils/config.js` `ignorePatterns` entry (`eslint src/utils/config.js` → 0 problems). The adjacent `**/PlayerData.js` exclusion is left for #25. ⚠️ **Confirmed via `git merge-tree`:** this collides with #25's edits to the same `ignorePatterns` block, so whichever of #25/#26 merges **second** gets a *trivial* conflict — resolution is **keep both deletions** (final block excludes none of `createjs`, `config.js`, `PlayerData.js`, or the two test patterns; the now-empty "excluded temporarily" comment can be dropped). This commit can be reverted instead, to keep the two PRs conflict-free and do the un-ignore as a post-merge follow-up.
- **`feat(config)` `14f34ac`** — `resolveMapSize` now emits a **dev-only** `console.warn` on the unknown-key fallback (gated on `import.meta.env?.DEV`, `?.`-safe under plain Node / the arena CLI). Runtime behavior is unchanged — it still never throws — but a missing-preset mistake (e.g. a new `MAP_SIZE_OPTIONS` entry in the title screen without a matching preset) is now visible in dev instead of silently shipping a medium map. The test asserts the warning fires and suppresses the expected output.

## Notes / not in scope
- The optional `AIAdapter`/`legacyBotAdapter` legacy-view dedup (both LIVE keepers, medium-risk) is intentionally **not** bundled here — happy to do it as a separate focused PR if wanted.
