### PR TITLE
chore: remove unused @utils/@ai/@engine Vite aliases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,7 +175,7 @@ The full suite forks many workers; running several copies at once can exhaust RA
 
 ## Gotchas
 
-- **Path aliases**: `@utils`, `@ai`, `@engine` are configured in `vite.config.js` for both builds and tests. Source files use relative imports; aliases are available but prefer relative paths in new code.
+- **Imports**: Source files use relative paths — the project configures no path aliases. (The old `@utils`/`@ai`/`@engine` Vite aliases were unused and have been removed.)
 - **Husky pre-commit hook**: Runs `lint-staged` automatically, which applies ESLint fixes and Prettier formatting to staged `.js` and `.jsx` files.
 - **Vitest globals**: Tests use `globals: true` in vitest config, so `describe`, `it`, `expect`, `vi`, `beforeEach`, `afterEach` are available without imports. Use `import { vi } from 'vitest'` only if needed for explicit typing.
 - **Test environment is `node` by default**: To keep memory down, the suite runs under the lightweight Node environment, not jsdom. A test that touches `document`, `window`, `localStorage`, canvas, or renders a Preact component must declare `// @vitest-environment jsdom` as the first line of the file, or it will fail with `X is not defined`.

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,5 @@
 import { defineConfig } from 'vite';
 import preact from '@preact/preset-vite';
-import path from 'path';
 
 export default defineConfig(({ command }) => ({
   /*
@@ -10,14 +9,6 @@ export default defineConfig(({ command }) => ({
   base: command === 'build' ? '/dicewarsjs/' : '/',
 
   plugins: [preact({ devToolsEnabled: false })],
-
-  resolve: {
-    alias: {
-      '@utils': path.resolve(import.meta.dirname, 'src/utils'),
-      '@ai': path.resolve(import.meta.dirname, 'src/ai'),
-      '@engine': path.resolve(import.meta.dirname, 'src/engine'),
-    },
-  },
 
   server: {
     port: 3000,


### PR DESCRIPTION
## What

Removes the three remaining Vite path aliases (`@utils`, `@ai`, `@engine`) from `vite.config.js` — they have **zero importers** anywhere in `src/`, `tests/`, or `scripts/` (every module uses relative imports). Also drops the now-orphaned `import path from 'path'` (it was used only to resolve those alias paths) and rewords the `CLAUDE.md` path-aliases gotcha to match reality.

## Why

Final loose end of the June 2026 simplification sweep. The `@models`/`@mechanics`/`@state` aliases were already removed alongside their subtrees in wave C; these last three were dead config. Deferred until #24 merged to avoid colliding with its CLAUDE.md edit.

## Scope

- `vite.config.js` — drop `resolve.alias` block + unused `path` import
- `CLAUDE.md` — reword the now-false "Path aliases" gotcha

`docs/MODERNIZATION_ROADMAP.md` still mentions the old aliases in its **historical** phase-plan; left as-is, consistent with how that file is treated (historical record, not rewritten).

## Verification

- `npm run build` ✓ (no unresolved imports)
- `npm run lint` ✓ (0 errors)
- `npm test` ✓ (48 files / 665 tests)