### PR TITLE
docs: rewrite TESTING.md for the Vitest suite

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,162 +1,170 @@
 # Testing Strategy for Dice Wars JS
 
-This document outlines the testing strategy for the Dice Wars JS project as part of its modernization to ES6 modules.
-
-## Overview
-
-Our testing approach focuses on ensuring the reliability and correctness of the project's ES6 module codebase. We've implemented a comprehensive testing strategy using Jest as our testing framework.
+This document describes how the DiceWarsJS test suite is organized and run. The
+project is fully modernized (Vite + PixiJS + Preact on a pure `src/engine/`), and
+the suite runs on **Vitest**.
 
 ## Testing Framework
 
-We use **Jest** as our primary testing framework because it provides:
+We use **Vitest** (configured in the `test` block of `vite.config.js`, so the test
+runner shares the build's module resolution). It provides:
 
-- A comprehensive test runner with parallel test execution
-- Built-in assertion library
-- Mocking capabilities for modules and browser APIs
-- Coverage reporting
+- A fast Vite-native test runner with parallel, worker-based execution
+- A Jest-compatible assertion API (`expect`) and mocking (`vi`)
+- Coverage reporting via the V8 provider
 - Watch mode for development
+
+`globals: true` is enabled, so `describe`, `it`, `test`, `expect`, `vi`,
+`beforeEach`, and `afterEach` are available without importing them. Add
+`import { vi } from 'vitest'` only when you want explicit types.
+
+## Test Environment: `node` by default, `jsdom` opt-in
+
+To keep memory down, the suite defaults to the lightweight **`node`** environment
+rather than booting a full DOM in every worker. Most of the suite is pure
+engine/AI/arena logic that never touches the DOM.
+
+A test that touches `document`, `window`, `localStorage`, canvas, or renders a
+Preact component must declare jsdom on the **first line of the file**:
+
+```javascript
+// @vitest-environment jsdom
+```
+
+Without that docblock, DOM globals are undefined and the test fails with errors
+like `window is not defined`.
 
 ## Directory Structure
 
-Tests are organized to mirror the source code structure:
+Tests live under `tests/`, mirroring the `src/` layout, plus shared fixtures in
+`tests/mocks/`:
 
 ```
-/tests
-  /mocks          # Mock files for testing
-  /utils          # Tests for utility modules
-    gameUtils.test.js
-    render.test.js
-    sound.test.js
-    config.test.js
-  /models         # Tests for data models
-  /ai             # Tests for AI strategies
-  setup.js        # Global test setup
+tests/
+├── ai/            # Built-in AI strategies
+├── arena/         # Bot SDK: validation, execution, ELO, tournaments, replays
+├── audio/         # SoundManager
+├── controller/    # GameController, KeyboardController
+├── engine/        # Pure engine: state, map gen, battles, turns, RNG
+├── renderer/      # PixiJS rendering (hex grid, dice, themes, layout)
+├── store/         # GameStore, PreferencesManager
+├── ui/            # Preact components and hooks
+├── utils/         # Configuration (map-size presets)
+├── scripts/       # CLI tooling (arena, bot validation)
+├── benchmarks/    # AI performance benchmarks (*.benchmark.js)
+├── mocks/         # Shared test fixtures (e.g. areaData.js, gameMock.js)
+└── setup.js       # Global setup (registered via setupFiles)
 ```
+
+Vitest collects `tests/**/*.test.{js,cjs}`, `src/**/*.test.js`, and
+`tests/benchmarks/*.benchmark.js` (see `include` in `vite.config.js`).
+
+`tests/setup.js` installs the global stubs needed under jsdom — notably a minimal
+canvas 2D context, because PixiJS probes `canvas.getContext('2d')` at import time
+and would otherwise log noisy "Not implemented" errors.
 
 ## Test Types
 
-### 1. Unit Tests
-
-Unit tests focus on testing individual functions and modules in isolation. These tests verify that each unit of code behaves as expected.
-
-Examples:
-
-- Testing game utility functions (dice rolling, attack probability)
-- Testing rendering functions
-- Testing configuration management
-
-### 2. Integration Tests
-
-Integration tests verify that different modules work together correctly.
-
-Examples:
-
-- Testing interactions between game state and rendering
-
-### 3. Functional Tests
-
-Functional tests verify that the application works correctly from a user's perspective. These tests ensure that the game's features work as expected.
-
-Examples:
-
-- Testing game initialization
-- Testing game mechanics (attacks, turns)
-- Testing AI behavior
+- **Unit** — individual functions/modules in isolation (e.g. battle resolution,
+  map generation, an AI's move selection, map-size preset resolution).
+- **Integration** — modules working together (e.g. the controller driving the
+  engine, the store notifying subscribers).
+- **Benchmarks** — comparative AI performance under `tests/benchmarks/`, run
+  separately from the correctness suite.
 
 ## Mocking Strategy
 
-We use various mocking techniques to isolate the code being tested:
-
-1. **Browser APIs**: We mock browser APIs like `localStorage` and the canvas/audio APIs
-2. **Module Dependencies**: We mock module dependencies to isolate units of code
-3. **DOM Elements**: We use the JSDOM environment provided by Jest
-
-## Code Coverage
-
-We track code coverage to ensure our tests are comprehensive. Our goal is to maintain:
-
-- 80%+ line coverage for utility modules
-- 70%+ line coverage for game logic
-
-To run tests with coverage:
-
-```bash
-npm test -- --coverage
-```
+- **Module dependencies**: `vi.mock('../path')` to isolate the unit under test.
+- **Functions/spies**: `vi.fn()` and `vi.spyOn(obj, 'method')`; restore with
+  `vi.restoreAllMocks()` / `mockRestore()` (e.g. silencing a `console.warn`).
+- **DOM / browser APIs**: opt into jsdom (see above); `localStorage`, canvas, and
+  similar are then available or stubbed via `tests/setup.js`.
 
 ## Running Tests
 
-To run all tests:
-
 ```bash
+# Run the whole suite (serialized through a machine-wide lock)
 npm test
-```
 
-To run tests in watch mode during development:
-
-```bash
+# Watch mode during development
 npm run test:watch
+
+# With coverage
+npm run test:coverage
+
+# AI benchmarks only
+npm run test:benchmark
+
+# A single file or directory (fastest while iterating)
+npx vitest run tests/engine/BattleResolver.test.js
+npx vitest run tests/ai/
+
+# Filter by test name
+npx vitest run -t "map size presets"
 ```
 
-To run specific tests:
+### Running tests safely (resource limits)
 
-```bash
-npm test -- -t "Game Utilities"
-```
+Each forked worker can hold a jsdom instance worth hundreds of MB, so running
+several full suites at once can exhaust RAM. Two guardrails are in place:
+
+1. `maxWorkers: '50%'` in `vite.config.js` caps a single run's worker count.
+2. `npm test` and `npm run test:coverage` go through a machine-wide lock
+   (`scripts/test-lock.sh`), so only one run executes at a time — concurrent
+   callers queue rather than pile up.
+
+When work is split across multiple agents, **do not** have each one run the full
+`npm test`. Run only the relevant files with `npx vitest run <path>`, and let a
+single final `npm test` validate the whole suite.
+
+## Code Coverage
+
+Coverage uses the V8 provider over `src/**/*.{js,jsx}`. Thresholds are enforced in
+`vite.config.js` (the authoritative source); current floors:
+
+| Scope         | Statements | Branches | Functions | Lines |
+| ------------- | ---------- | -------- | --------- | ----- |
+| Global        | 55         | 50       | 60        | 55    |
+| `src/engine/` | 70         | 50       | 70        | 70    |
+| `src/arena/`  | 70         | 50       | 70        | 70    |
+| `src/utils/`  | 30         | 25       | 30        | 30    |
+
+These are floors set to current reality; raise them as coverage improves. Generate
+a local report with `npm run test:coverage` (HTML output lands in `coverage/`).
 
 ## Writing Tests
 
-Guidelines for writing tests:
+1. **Descriptive names** — say what behavior is verified, not which function runs.
+2. **AAA** — structure each test as Arrange, Act, Assert.
+3. **Isolation** — no test may depend on another's state; reset shared state in
+   `beforeEach`.
+4. **Determinism** — seed any randomness; avoid wall-clock and order dependence.
+5. **Behavior over implementation** — assert on observable outcomes.
+6. **Pick the right environment** — keep pure-logic tests in `node`; add the jsdom
+   docblock only when a test genuinely needs the DOM.
 
-1. **Test Names**: Use descriptive names that indicate what is being tested
-2. **AAA Pattern**: Structure tests with Arrange, Act, Assert
-3. **Isolation**: Ensure tests are isolated and do not depend on other tests
-4. **Mocks**: Prefer explicit mocks over global mocks
-5. **Assertions**: Use specific assertions that clearly indicate what's being verified
-
-Example of a well-structured test:
+Example (pure logic, `node` environment, using Vitest globals):
 
 ```javascript
-test('calculates attack probability correctly for advantage scenario', () => {
-  // Arrange
-  const attackerDice = 5;
-  const defenderDice = 2;
+import { resolveMapSize } from '../../src/utils/config.js';
 
-  // Act
-  const probability = calculateAttackProbability(attackerDice, defenderDice);
+describe('resolveMapSize', () => {
+  test('falls back to the default preset for an unknown size', () => {
+    // Arrange
+    const unknown = 'enormous';
 
-  // Assert
-  expect(probability).toBeGreaterThan(0.5);
-  expect(probability).toBeLessThan(0.95);
+    // Act
+    const preset = resolveMapSize(unknown);
+
+    // Assert — medium is the default
+    expect(preset).toEqual({ mapWidth: 28, mapHeight: 32, maxAreas: 32 });
+  });
 });
 ```
 
 ## Continuous Integration
 
-Tests are integrated into our build process:
-
-1. Tests run before building the production version
-2. Pull requests require passing tests
-3. Test coverage reports are generated and reviewed
-
-## Best Practices
-
-1. **Test Behavior, Not Implementation**: Focus on testing what the code does, not how it's implemented
-2. **Small, Focused Tests**: Keep tests small and focused on a single behavior
-3. **Maintainable Tests**: Write tests that are easy to understand and maintain
-4. **Fast Tests**: Ensure tests run quickly to maintain a good development workflow
-5. **Independent Tests**: Make tests independent of each other
-6. **Deterministic Tests**: Avoid non-deterministic tests that sometimes pass and sometimes fail
-
-## Future Improvements
-
-As we continue the migration to ES6 modules, we plan to:
-
-1. Add more integration tests for game mechanics
-2. Implement component testing for UI elements
-3. Add performance testing for critical game operations
-4. Implement end-to-end testing for complete game scenarios
-
-## Future Testing Plans
-
-The project will migrate from Jest to Vitest as part of the modernization. See [MODERNIZATION_ROADMAP.md](./MODERNIZATION_ROADMAP.md) for details on the testing strategy across all phases.
+Tests run in CI on every pull request as part of the single `build-and-test` job,
+which runs format checking, linting, the build, `test:coverage`, and
+`test:benchmark`. A PR must be green to merge. See
+[`CI_CD.md`](./CI_CD.md) for the full pipeline.


### PR DESCRIPTION
## What

Rewrites `docs/TESTING.md`, which still documented a **Jest** suite from the ES6-migration era.

Stale content removed:
- Jest framed as the test framework (it's **Vitest**)
- A directory listing with files deleted in waves B/C (`gameUtils.test.js`, `render.test.js`, `sound.test.js`)
- Jest-style commands (`npm test -- --coverage`, `npm test -- -t`)
- An example calling the deleted `calculateAttackProbability` from `gameUtils`
- A "Future Testing Plans: migrate from Jest to Vitest" section — long since done

## Now accurately documents

- **Vitest**, configured in the `test` block of `vite.config.js`
- **`node` env by default, `jsdom` opt-in** via the `// @vitest-environment jsdom` docblock (the suite's most important gotcha)
- `globals: true` (no need to import `describe`/`it`/`expect`/`vi`)
- The real `tests/` layout mirroring `src/`, plus `tests/mocks/` fixtures and `setup.js`'s canvas stub
- The machine-wide test lock (`scripts/test-lock.sh`) + `maxWorkers: '50%'` guardrails, and the "don't run the full suite in every agent" rule
- The actual coverage thresholds (global 55/50/60/55; `engine`/`arena` 70; `utils` 30), pointing at `vite.config.js` as authoritative
- A current `resolveMapSize` example

## Verification

Docs-only. Every referenced path (`tests/engine/BattleResolver.test.js`, `tests/mocks/areaData.js`/`gameMock.js`) and test name (`-t "map size presets"`) verified to exist. CI steps in the doc cross-checked against the workflow. Prettier-clean (`format:check`).