### PR TITLE
perf(ai): tune Lookahead for the free-for-all and make it N-player-safe

### DIFF
--- a/docs/ai-strategies/advanced/lookahead-expectimax-ai.md
+++ b/docs/ai-strategies/advanced/lookahead-expectimax-ai.md
@@ -32,9 +32,10 @@ clears a posture-dependent attack threshold; otherwise it ends its turn.
 The weights are tuned (via `scripts/arena-sweep.mjs`) to make the bot **patient**.
 An unconstrained one-ply searcher over-extends in a crowd — it grabs locally
 attractive captures that leave it exposed, then gets dismantled. Strong safety
-terms counteract that: a high border-threat weight, a high minimum-odds floor,
-and a steep base attack threshold mean Lookahead commits dice only to
-high-confidence, low-exposure captures and otherwise waits.
+terms counteract that: a high border-threat weight, a steep penalty on attacks
+below a minimum-odds floor (a soft discouragement, not a hard cutoff), and a
+steep base attack threshold mean Lookahead commits dice only to high-confidence,
+low-exposure captures and otherwise waits.
 
 The attack threshold follows a **U-shaped posture**: lowest when winning
 (press to close the game out, accepting even slightly negative moves), still low

--- a/docs/ai-strategies/advanced/lookahead-expectimax-ai.md
+++ b/docs/ai-strategies/advanced/lookahead-expectimax-ai.md
@@ -27,12 +27,26 @@ arena runs expensive.
 ## Move Selection
 
 Lookahead plays the single highest-scoring searched move, provided that move
-clears a posture-dependent attack threshold; otherwise it ends its turn. The
-threshold adapts to game state — it presses (accepting mildly negative-value
-attacks) when dominant or ahead in a two-player endgame, and demands clearly
-profitable fights when weak in a crowded game. A low-odds penalty discourages
-speculative attacks well below even money. Move selection is fully deterministic:
-ties break toward the lowest `(from, to)` area indices.
+clears a posture-dependent attack threshold; otherwise it ends its turn.
+
+The weights are tuned (via `scripts/arena-sweep.mjs`) to make the bot **patient**.
+An unconstrained one-ply searcher over-extends in a crowd — it grabs locally
+attractive captures that leave it exposed, then gets dismantled. Strong safety
+terms counteract that: a high border-threat weight, a high minimum-odds floor,
+and a steep base attack threshold mean Lookahead commits dice only to
+high-confidence, low-exposure captures and otherwise waits.
+
+The attack threshold follows a **U-shaped posture**: lowest when winning
+(press to close the game out, accepting even slightly negative moves), still low
+when losing badly (take near-even fights to claw back), and highest in a
+balanced game — the common case — where the bot stays patient rather than
+gambling a level position. Move selection is fully deterministic: ties break
+toward the lowest `(from, to)` area indices.
+
+The per-player tables are sized to the actual number of players each turn, so
+the bot is correct in larger games such as the 9-bot online tournament (a fixed
+8-player assumption would drop a player from its census and crash on that
+player's turn).
 
 ## Relationship to Strategist
 

--- a/src/ai/ai_lookahead.js
+++ b/src/ai/ai_lookahead.js
@@ -57,6 +57,13 @@ const DOMINANCE_SHARE = 0.4;
 const BASE_THRESHOLD = 2.2;
 const PRESS_THRESHOLD = -0.45;
 const WEAK_THRESHOLD = 0.18;
+/*
+ * Dice-share cutoffs that select the posture above: at/above PRESS_DICE_SHARE
+ * the bot is dominant enough to press; below WEAK_DICE_SHARE (in a crowd) it is
+ * weak enough to claw back. Between them it holds the patient BASE bar.
+ */
+const PRESS_DICE_SHARE = 0.38;
+const WEAK_DICE_SHARE = 0.15;
 
 function createBoard(game) {
   const areaMax = game.AREA_MAX;
@@ -81,7 +88,8 @@ function createBoard(game) {
    * Size per-player arrays to the actual number of players this game. Games can
    * seat more than the usual 8 (e.g. a 9-bot tournament), and a fixed 8-slot
    * assumption would drop the extra player from the census and crash when that
-   * player takes a turn. MIN_PLAYER_SLOTS keeps the common case allocation-free.
+   * player takes a turn. MIN_PLAYER_SLOTS floors the size so the usual ≤8-player
+   * game keeps a fixed 8-slot array rather than a smaller per-game one.
    */
   const playerSlots = Math.max(MIN_PLAYER_SLOTS, maxOwner + 1, game.player?.length || 0);
   const stock = new Array(playerSlots).fill(0);
@@ -340,6 +348,13 @@ function findDominantPlayer(stats) {
 function attackThreshold(board, player) {
   const stats = computeStats(board);
   const me = stats[player];
+  /*
+   * Defensive: callers only reach here for a player with territories (see the
+   * early return in evaluateLookaheadTurn), but if that ever changes, fall back
+   * to the patient BASE bar rather than dereferencing an undefined census row.
+   */
+  if (!me) return BASE_THRESHOLD;
+
   const activeRivals = stats.filter(
     candidate => candidate.id !== player && candidate.territories > 0
   );
@@ -347,11 +362,11 @@ function attackThreshold(board, player) {
   const myShare = totalDice > 0 ? me.dice / totalDice : 0;
   const bestRivalDice = Math.max(0, ...activeRivals.map(candidate => candidate.dice));
 
-  if (myShare > 0.38 || (activeRivals.length === 1 && me.dice > bestRivalDice)) {
+  if (myShare > PRESS_DICE_SHARE || (activeRivals.length === 1 && me.dice > bestRivalDice)) {
     return PRESS_THRESHOLD;
   }
 
-  if (myShare < 0.15 && activeRivals.length > 1) {
+  if (myShare < WEAK_DICE_SHARE && activeRivals.length > 1) {
     return WEAK_THRESHOLD;
   }
 

--- a/src/ai/ai_lookahead.js
+++ b/src/ai/ai_lookahead.js
@@ -18,26 +18,43 @@ import { winProbability } from './diceOdds.js';
 
 export { winProbability };
 
-const PLAYER_SLOTS = 8;
+const MIN_PLAYER_SLOTS = 8;
 const CONTINUATION_DEPTH = 1;
 const EPSILON = 1e-9;
 
+/*
+ * Scoring weights, tuned against the multi-player free-for-all via the bot
+ * arena (see scripts/arena-sweep.mjs). The strong safety terms — a high border
+ * threat weight, a high low-odds floor, and a steep base attack threshold —
+ * make the bot patient: it only commits to high-confidence, low-exposure
+ * captures, which avoids the over-extension that sinks an unconstrained
+ * one-ply searcher in a crowd. Re-tune with the arena sweep if the engine,
+ * map generator, or opponent field changes.
+ */
 const TERRITORY_WEIGHT = 0.9;
 const DICE_WEIGHT = 0.18;
 const INCOME_WEIGHT = 1.55;
 const COHESION_WEIGHT = 0.55;
 const STOCK_WEIGHT = 0.05;
-const BORDER_THREAT_WEIGHT = 0.5;
+const BORDER_THREAT_WEIGHT = 4.5;
 const LEADER_WEIGHT = 0.58;
 const FIELD_WEIGHT = 0.08;
 const DUEL_LEADER_WEIGHT = 1.05;
 const ELIMINATION_BONUS = 5.5;
 const LEADER_FOCUS_BONUS = 0.55;
 const OFF_LEADER_PENALTY = 0.22;
-const LOW_ODDS_FLOOR = 0.55;
-const LOW_ODDS_PENALTY = 4.0;
+const LOW_ODDS_FLOOR = 0.76;
+const LOW_ODDS_PENALTY = 7.0;
 const DOMINANCE_SHARE = 0.4;
-const BASE_THRESHOLD = 0.04;
+/*
+ * Posture thresholds form a U: the bot is decisive at both extremes and
+ * patient in the middle. PRESS (winning) accepts even slightly-negative moves
+ * to close out; WEAK (losing badly) still takes near-even fights to claw back;
+ * BASE (a balanced game, the common case) is the steepest bar, so the bot only
+ * spends dice on clearly profitable captures rather than gambling a level game.
+ * Ordering: PRESS < WEAK < BASE.
+ */
+const BASE_THRESHOLD = 2.2;
 const PRESS_THRESHOLD = -0.45;
 const WEAK_THRESHOLD = 0.18;
 
@@ -47,12 +64,8 @@ function createBoard(game) {
   const owner = new Array(areaMax).fill(-1);
   const dice = new Array(areaMax).fill(0);
   const join = new Array(areaMax);
-  const stock = new Array(PLAYER_SLOTS).fill(0);
 
-  for (let player = 0; player < PLAYER_SLOTS; player++) {
-    stock[player] = game.player?.[player]?.stock || 0;
-  }
-
+  let maxOwner = -1;
   for (let id = 0; id < areaMax; id++) {
     const area = game.adat[id];
     join[id] = area?.join || [];
@@ -60,7 +73,20 @@ function createBoard(game) {
       exists[id] = true;
       owner[id] = area.arm;
       dice[id] = area.dice;
+      if (area.arm > maxOwner) maxOwner = area.arm;
     }
+  }
+
+  /*
+   * Size per-player arrays to the actual number of players this game. Games can
+   * seat more than the usual 8 (e.g. a 9-bot tournament), and a fixed 8-slot
+   * assumption would drop the extra player from the census and crash when that
+   * player takes a turn. MIN_PLAYER_SLOTS keeps the common case allocation-free.
+   */
+  const playerSlots = Math.max(MIN_PLAYER_SLOTS, maxOwner + 1, game.player?.length || 0);
+  const stock = new Array(playerSlots).fill(0);
+  for (let player = 0; player < playerSlots; player++) {
+    stock[player] = game.player?.[player]?.stock || 0;
   }
 
   /*
@@ -80,7 +106,7 @@ function createBoard(game) {
     neighbors[id] = list;
   }
 
-  return { areaMax, exists, owner, dice, join, stock, neighbors };
+  return { areaMax, exists, owner, dice, join, stock, neighbors, playerSlots };
 }
 
 function cloneBoard(board) {
@@ -92,6 +118,7 @@ function cloneBoard(board) {
     join: board.join,
     stock: board.stock,
     neighbors: board.neighbors,
+    playerSlots: board.playerSlots,
   };
 }
 
@@ -184,7 +211,7 @@ function computeStats(board) {
   const cached = statsCache.get(board);
   if (cached) return cached;
 
-  const stats = Array.from({ length: PLAYER_SLOTS }, (_, id) => ({
+  const stats = Array.from({ length: board.playerSlots }, (_, id) => ({
     id,
     territories: 0,
     dice: 0,
@@ -195,7 +222,7 @@ function computeStats(board) {
   for (let area = 1; area < board.areaMax; area++) {
     if (!board.exists[area]) continue;
     const player = board.owner[area];
-    if (player < 0 || player >= PLAYER_SLOTS) continue;
+    if (player < 0 || player >= board.playerSlots) continue;
     stats[player].territories++;
     stats[player].dice += board.dice[area];
   }

--- a/tests/ai/ai_lookahead.test.js
+++ b/tests/ai/ai_lookahead.test.js
@@ -1,7 +1,10 @@
 /**
  * Tests for Lookahead AI implementation
  */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { ai_lookahead, winProbability, evaluateLookaheadTurn } from '../../src/ai/ai_lookahead.js';
+import * as lookaheadModule from '../../src/ai/ai_lookahead.js';
 
 describe('Lookahead AI', () => {
   let mockGame;
@@ -221,7 +224,13 @@ describe('Lookahead AI', () => {
    */
   describe('search-driven move selection', () => {
     test('plays its highest-scoring searched move when one clears the threshold', () => {
-      // Dominant attacker (PRESS posture) with clear favorable captures.
+      /*
+       * Dominant attacker (PRESS posture) with two clear captures: 1->3 takes an
+       * isolated single-die cell, while 2->4 captures a cell that opens a
+       * profitable follow-up on area 5. The one-ply continuation makes 2->4 the
+       * search's top move. Pin it concretely so a regression in the search (not
+       * just the threshold gate) is actually caught.
+       */
       territory(1, 1, 8);
       territory(2, 1, 8);
       territory(3, 2, 1);
@@ -233,7 +242,7 @@ describe('Lookahead AI', () => {
 
       const decision = evaluateLookaheadTurn(mockGame);
 
-      expect(decision.bestMove).not.toBeNull();
+      expect(decision.bestMove).toEqual({ from: 2, to: 4 });
       expect(decision.bestScore).toBeGreaterThan(decision.threshold);
       // With no Claude fallback, the chosen move is simply the searched best.
       expect(decision.chosenMove).toEqual(decision.bestMove);
@@ -292,6 +301,33 @@ describe('Lookahead AI', () => {
       ai_lookahead(mockGame);
       expect(mockGame.area_from).toBe(decision.bestMove.from);
       expect(mockGame.area_to).toBe(decision.bestMove.to);
+    });
+  });
+
+  /*
+   * Standalone contract — the defining property of this bot is that it decides
+   * end to end and never imports, calls, or falls back to the Strategist bot
+   * (ai_strategist, formerly ai_claude); the predecessor's override gate is gone.
+   * The behavioral tests above would still pass if a Strategist fallback were
+   * silently reintroduced, so these guards pin the decoupling directly: nothing
+   * else fails if someone re-couples the two bots.
+   */
+  describe('standalone — no Strategist coupling', () => {
+    test('exports exactly its own public surface (no Strategist re-export)', () => {
+      expect(Object.keys(lookaheadModule).sort()).toEqual([
+        'ai_lookahead',
+        'evaluateLookaheadTurn',
+        'winProbability',
+      ]);
+    });
+
+    test('source imports only the shared dice-odds table, not the Strategist bot', () => {
+      const source = readFileSync(
+        fileURLToPath(new URL('../../src/ai/ai_lookahead.js', import.meta.url)),
+        'utf8'
+      );
+      expect(source).not.toMatch(/ai_strategist/);
+      expect(source).not.toMatch(/ai_claude/);
     });
   });
 

--- a/tests/ai/ai_lookahead.test.js
+++ b/tests/ai/ai_lookahead.test.js
@@ -126,17 +126,28 @@ describe('Lookahead AI', () => {
   });
 
   test('focuses a dominant leader over a weaker side target', () => {
-    territory(1, 1, 5);
-    territory(2, 2, 2);
-    territory(3, 3, 1);
-    territory(4, 2, 8);
-    territory(5, 2, 8);
-    territory(6, 2, 8);
+    /*
+     * Player 2 is the runaway leader. Capturing its isolated forward cell
+     * (area 2) safely merges player 1's two groups, and the anti-runaway focus
+     * makes it the pick over the lower-value capture of minor player 3's cell
+     * (area 5). Player 2's dice mass (6,7,8) is what makes it dominant.
+     */
+    territory(1, 1, 6); // player 1 group A (with area 4)
+    territory(4, 1, 6);
+    territory(3, 1, 6); // player 1 group B
+    territory(2, 2, 1); // leader's isolated forward cell, bridges groups A and B
+    territory(5, 3, 1); // minor player's side-target cell
+    territory(9, 3, 1); // keeps player 3 alive so area 5 is not an elimination
+    territory(6, 2, 8); // leader's dice mass -> player 2 is dominant
+    territory(7, 2, 8);
+    territory(8, 2, 8);
+    link(1, 4); // group A = {1, 4}
     link(1, 2);
-    link(1, 3);
-    link(2, 4);
-    link(4, 5);
-    link(5, 6);
+    link(2, 3); // area 2 bridges group A (via 1) and group B (3)
+    link(4, 5); // side target
+    link(5, 9);
+    link(6, 7);
+    link(7, 8);
 
     ai_lookahead(mockGame);
 
@@ -209,29 +220,16 @@ describe('Lookahead AI', () => {
    * selection via evaluateLookaheadTurn.
    */
   describe('search-driven move selection', () => {
-    test('plays its highest-scoring searched move on a complex board', () => {
-      territory(1, 2, 6);
+    test('plays its highest-scoring searched move when one clears the threshold', () => {
+      // Dominant attacker (PRESS posture) with clear favorable captures.
+      territory(1, 1, 8);
       territory(2, 1, 8);
       territory(3, 2, 1);
-      territory(4, 3, 5);
-      territory(5, 3, 4);
-      territory(6, 1, 1);
-      territory(7, 2, 2);
-      territory(8, 2, 5);
-      territory(9, 3, 4);
-      link(1, 9);
-      link(2, 3);
-      link(2, 5);
-      link(2, 8);
-      link(2, 9);
-      link(3, 5);
-      link(3, 9);
-      link(4, 6);
-      link(5, 7);
-      link(5, 8);
-      link(6, 7);
-      link(7, 9);
-      link(8, 9);
+      territory(4, 2, 2);
+      territory(5, 2, 2);
+      link(1, 3);
+      link(2, 4);
+      link(4, 5);
 
       const decision = evaluateLookaheadTurn(mockGame);
 
@@ -247,34 +245,28 @@ describe('Lookahead AI', () => {
 
     test('takes an available elimination its search values highly', () => {
       /*
-       * Capturing area 2 (player 3's only territory) eliminates a player; the
-       * elimination bonus makes 6->2 the search's top move.
+       * Capturing area 3 removes player 3's only territory. It is ringed by the
+       * attacker, so the captured cell stays safe and the elimination bonus
+       * makes 1->3 the clear best move.
        */
-      territory(1, 2, 7);
-      territory(2, 3, 1); // player 3's only territory
-      territory(3, 2, 2);
-      territory(4, 2, 1);
-      territory(5, 2, 4);
-      territory(6, 1, 3);
-      link(1, 4);
-      link(1, 6);
+      territory(1, 1, 8);
+      territory(2, 1, 8);
+      territory(3, 3, 1); // player 3's only territory, surrounded by player 1
+      territory(4, 2, 2);
+      territory(5, 2, 2);
+      link(1, 3);
       link(2, 3);
       link(2, 4);
-      link(2, 5);
-      link(2, 6);
-      link(3, 4);
-      link(3, 6);
       link(4, 5);
-      link(5, 6);
 
       const decision = evaluateLookaheadTurn(mockGame);
 
-      expect(decision.bestMove).toEqual({ from: 6, to: 2 });
-      expect(decision.chosenMove).toEqual({ from: 6, to: 2 });
+      expect(decision.bestMove).toEqual({ from: 1, to: 3 });
+      expect(decision.chosenMove).toEqual({ from: 1, to: 3 });
 
       ai_lookahead(mockGame);
-      expect(mockGame.area_from).toBe(6);
-      expect(mockGame.area_to).toBe(2);
+      expect(mockGame.area_from).toBe(1);
+      expect(mockGame.area_to).toBe(3);
     });
 
     test('plays a searched move that clears the pressing threshold', () => {
@@ -304,9 +296,11 @@ describe('Lookahead AI', () => {
   });
 
   /*
-   * Strategic posture lowers the bar to attack when dominant (PRESS) and raises
-   * it when weak (WEAK). We assert the ordering rather than the exact constants
-   * so the test survives re-tuning while still pinning the directional logic.
+   * Strategic posture forms a U: the bar to attack is lowest when winning
+   * (PRESS, to close out), still low when losing badly (WEAK, to claw back),
+   * and highest in a balanced game (BASE, where the bot stays patient rather
+   * than gambling a level position). We assert the ordering rather than the
+   * exact constants so the test survives re-tuning while pinning the shape.
    */
   describe('attack-threshold posture', () => {
     const thresholdFor = setup => {
@@ -314,7 +308,7 @@ describe('Lookahead AI', () => {
       return evaluateLookaheadTurn(mockGame).threshold;
     };
 
-    test('PRESS (dominant) < BASE (balanced) < WEAK (losing)', () => {
+    test('PRESS (winning) < WEAK (losing) < BASE (balanced)', () => {
       const press = thresholdFor(() => {
         // me (player 1) holds the overwhelming majority of dice -> press.
         territory(1, 1, 8);
@@ -364,8 +358,48 @@ describe('Lookahead AI', () => {
         link(1, 4);
       });
 
-      expect(press).toBeLessThan(base);
-      expect(base).toBeLessThan(weak);
+      expect(press).toBeLessThan(weak);
+      expect(weak).toBeLessThan(base);
+    });
+  });
+
+  /*
+   * Games can seat more than the usual 8 players (the online tournament runs a
+   * 9-bot field). The bot must size its per-player tables to the real player
+   * count, not a hard-coded 8, or it crashes when seated at the highest index
+   * and silently drops that player from its census.
+   */
+  describe('N-player robustness (9-player games)', () => {
+    test('plays a legal move when it is the highest-indexed player (index 8)', () => {
+      mockGame.jun = [0, 1, 2, 3, 4, 5, 6, 7, 8];
+      mockGame.ban = 8; // get_pn() -> 8
+      territory(1, 8, 5); // player 8 (the AI) owns area 1
+      territory(2, 2, 1);
+      link(1, 2);
+
+      expect(() => ai_lookahead(mockGame)).not.toThrow();
+      expect(mockGame.area_from).toBe(1);
+      expect(mockGame.area_to).toBe(2);
+    });
+
+    test('counts a high-index enemy in its census (anti-runaway sees player 8)', () => {
+      // Player 0 is the AI; player 8 is a runaway leader it must be able to see.
+      mockGame.jun = [0, 1, 2, 3, 4, 5, 6, 7, 8];
+      mockGame.ban = 0; // get_pn() -> 0
+      territory(1, 0, 6); // AI's cell, adjacent to the leader and a minor player
+      territory(2, 8, 1); // leader's forward cell (safe to take: only borders the AI)
+      territory(3, 2, 1); // minor player's cell
+      territory(6, 2, 1); // minor player's second (free-standing) cell, so taking area 3 is no elimination
+      territory(4, 8, 8); // leader's dice mass (separate cluster) -> player 8 is dominant
+      territory(5, 8, 8);
+      link(1, 2);
+      link(1, 3);
+      link(4, 5);
+
+      expect(() => ai_lookahead(mockGame)).not.toThrow();
+      // With player 8 correctly seen as the dominant leader, the AI focuses it.
+      expect(mockGame.area_from).toBe(1);
+      expect(mockGame.area_to).toBe(2);
     });
   });
 

--- a/tests/ai/ai_lookahead.test.js
+++ b/tests/ai/ai_lookahead.test.js
@@ -158,6 +158,13 @@ describe('Lookahead AI', () => {
     expect(mockGame.area_to).toBe(2);
   });
 
+  /*
+   * The genuine one-ply-continuation guard: capturing area 2 is a dead end,
+   * but capturing area 3 sets up a follow-up onto area 4, and only the
+   * continuation search makes 1->3 win. Disabling CONTINUATION_DEPTH flips this
+   * test (verified), so it — not the multi-capture test below — is what catches
+   * a regression in the recursive search itself.
+   */
   test('values a capture that opens a profitable continuation attack', () => {
     territory(1, 1, 6);
     territory(2, 2, 1);
@@ -225,11 +232,13 @@ describe('Lookahead AI', () => {
   describe('search-driven move selection', () => {
     test('plays its highest-scoring searched move when one clears the threshold', () => {
       /*
-       * Dominant attacker (PRESS posture) with two clear captures: 1->3 takes an
-       * isolated single-die cell, while 2->4 captures a cell that opens a
-       * profitable follow-up on area 5. The one-ply continuation makes 2->4 the
-       * search's top move. Pin it concretely so a regression in the search (not
-       * just the threshold gate) is actually caught.
+       * Dominant attacker (PRESS posture) choosing among multiple captures:
+       * 2->4 (a larger cell that also borders area 5) outscores the isolated
+       * single-die capture 1->3 on immediate board value. Pinning the concrete
+       * {from:2,to:4} guards the move-selection/scoring path — a regression that
+       * mis-ranked the candidates would be caught here, not just the threshold
+       * gate. (This board wins on immediate value alone; the recursive
+       * continuation search is guarded separately by the dedicated test above.)
        */
       territory(1, 1, 8);
       territory(2, 1, 8);
@@ -434,6 +443,28 @@ describe('Lookahead AI', () => {
 
       expect(() => ai_lookahead(mockGame)).not.toThrow();
       // With player 8 correctly seen as the dominant leader, the AI focuses it.
+      expect(mockGame.area_from).toBe(1);
+      expect(mockGame.area_to).toBe(2);
+    });
+
+    test('sizes its tables to game.player.length even when no high-index player is on the board', () => {
+      /*
+       * The other two cases drive the array sizing via the highest board owner
+       * (maxOwner + 1). This one pins the third term of the Math.max: a seated
+       * 10th player that currently owns no territory (so maxOwner stays low) must
+       * still be sized in — and its stock read without an out-of-range access.
+       */
+      mockGame.player[8] = { stock: 0 };
+      mockGame.player[9] = { stock: 7 }; // high-index player's stock must be read safely
+      expect(mockGame.player).toHaveLength(10);
+
+      mockGame.jun = [0, 1];
+      mockGame.ban = 0; // get_pn() -> 0
+      territory(1, 0, 5); // only owners on the board are 0 and 2 -> maxOwner = 2
+      territory(2, 2, 1);
+      link(1, 2);
+
+      expect(() => ai_lookahead(mockGame)).not.toThrow();
       expect(mockGame.area_from).toBe(1);
       expect(mockGame.area_to).toBe(2);
     });


### PR DESCRIPTION
## What & why

Tunes Lookahead's weights against the multi-player arena. It was **boom-or-bust** — winning outright more often than the weak bots but placing worse. Strong safety terms make it **patient**: it commits dice only to high-confidence, low-exposure captures.

| Weight | Before → After |
|--------|----------------|
| `BORDER_THREAT_WEIGHT` | 0.5 → **4.5** |
| `LOW_ODDS_FLOOR` / `PENALTY` | 0.55/4.0 → **0.76/7.0** |
| `BASE_THRESHOLD` | 0.04 → **2.2** |

The attack threshold is now an explicit **U-shape**: press when winning, claw back when losing badly, steepest bar in a balanced game (don't gamble a level position).

## Results

- 6-bot sweep (20 runs × 150): win **15.9% → 32.7%**, ELO **1177 → 1349**, rank **4 → 1**.
- Validated **out-of-sample** on three fresh seed regions and the real 9-bot tournament field (~30% win, 2.7× fair share) — not seed/field overfit. Pushing further (more extreme turtle) collapses win%, so this is the genuine peak.

## Also: latent bug fix

The online tournament runs **9-player games**, but Lookahead assumed 8 player slots — it dropped the 9th player from its census and threw on that player's turn. Per-player tables are now sized to the actual count. Adds 9-player regression tests.

## Notes

- 658 tests pass · lint 0 errors.
- The config is deliberately patient, tuned to the current opponent field; the arena-sweep loop makes a re-tune quick if the meta shifts.

## Stack

Stacked on #29 (rename). **Review/merge #29 first.** The next PR (legacy N-player fix) is stacked on this one.