### PR TITLE
fix(ai): make legacy built-in bots correct in >8-player games

### DIFF
--- a/src/ai/ai_adaptive.js
+++ b/src/ai/ai_adaptive.js
@@ -10,6 +10,8 @@
  * - Choke points and strategic territory value
  * - Attack risk and potential rewards
  */
+import { getPlayerCount } from './playerCount.js';
+
 export const ai_adaptive = game => {
   // Get current player number
   const pn = game.get_pn();
@@ -42,24 +44,25 @@ export const ai_adaptive = game => {
  * @returns {Object} Analysis of the current game state
  */
 const analyzeGameState = game => {
+  const pmax = getPlayerCount(game);
   const state = {
     playerStats: [],
     territories: {
       total: 0,
-      byPlayer: new Array(8).fill(0),
+      byPlayer: new Array(pmax).fill(0),
     },
     dice: {
       total: 0,
-      byPlayer: new Array(8).fill(0),
+      byPlayer: new Array(pmax).fill(0),
     },
-    borderTerritories: new Array(8).fill(0),
+    borderTerritories: new Array(pmax).fill(0),
     playerRankings: [],
     dominantPlayer: -1,
-    averageDicePerTerritory: new Array(8).fill(0),
+    averageDicePerTerritory: new Array(pmax).fill(0),
     gamePhase: 'early',
     remainingPlayers: 0,
     chokePoints: [],
-    playerThreatLevel: new Array(8).fill(0),
+    playerThreatLevel: new Array(pmax).fill(0),
   };
 
   // Get territories data
@@ -92,7 +95,7 @@ const analyzeGameState = game => {
   });
 
   // Calculate average dice per territory and count active players
-  for (let i = 0; i < 8; i++) {
+  for (let i = 0; i < pmax; i++) {
     if (state.territories.byPlayer[i] > 0) {
       state.averageDicePerTerritory[i] = state.dice.byPlayer[i] / state.territories.byPlayer[i];
       state.remainingPlayers++;
@@ -109,7 +112,7 @@ const analyzeGameState = game => {
   }
 
   // Rank players by dice count (index 0 = highest ranking player)
-  state.playerRankings = Array(8)
+  state.playerRankings = Array(pmax)
     .fill()
     .map((_, i) => i)
     .filter(i => state.territories.byPlayer[i] > 0) // Only include active players
@@ -644,7 +647,7 @@ const findWeakestPlayer = game => {
   const { player } = game;
 
   // Filter active players and find the one with minimum dice
-  return [...Array(8).keys()]
+  return [...Array(getPlayerCount(game)).keys()]
     .filter(i => player[i].area_c > 0)
     .reduce((weakest, i) => (player[i].dice_c < player[weakest]?.dice_c ? i : weakest), -1);
 };

--- a/src/ai/ai_default.js
+++ b/src/ai/ai_default.js
@@ -6,9 +6,13 @@
  * 3. Identifies dominant players
  * 4. Makes random attacks from valid options
  */
+import { getPlayerCount } from './playerCount.js';
+
 export const ai_default = game => {
+  const pmax = getPlayerCount(game);
+
   // Initialize area and dice counts for all players
-  for (let i = 0; i < 8; i++) {
+  for (let i = 0; i < pmax; i++) {
     game.player[i].area_c = 0;
     game.player[i].dice_c = 0;
   }
@@ -43,7 +47,7 @@ export const ai_default = game => {
    */
   const rankPlayersByDiceCount = () => {
     // Create array of player indices with their dice counts
-    const playerRankings = Array.from({ length: 8 }, (_, i) => ({
+    const playerRankings = Array.from({ length: pmax }, (_, i) => ({
       playerIndex: i,
       diceCount: game.player[i].dice_c,
     }));

--- a/src/ai/ai_strategist.js
+++ b/src/ai/ai_strategist.js
@@ -33,6 +33,7 @@
  * and tooling import winProbability from this strategy.
  */
 import { MAX_DICE, WIN_TABLE, winProbability } from './diceOdds.js';
+import { getPlayerCount } from './playerCount.js';
 
 export { winProbability };
 
@@ -60,8 +61,9 @@ export const ai_strategist = game => {
   };
 
   // --- Board census ---
-  const diceByPlayer = new Array(8).fill(0);
-  const areasByPlayer = new Array(8).fill(0);
+  const pmax = getPlayerCount(game);
+  const diceByPlayer = new Array(pmax).fill(0);
+  const areasByPlayer = new Array(pmax).fill(0);
   let totalDice = 0;
   for (let i = 1; i < AREA_MAX; i++) {
     if (!exists(i)) continue;
@@ -188,7 +190,7 @@ export const ai_strategist = game => {
 
   // --- Strategic posture ---
   let dominantPlayer = -1;
-  for (let i = 0; i < 8; i++) {
+  for (let i = 0; i < pmax; i++) {
     if (diceByPlayer[i] > totalDice * DOMINANCE_SHARE) {
       dominantPlayer = i;
       break;

--- a/src/ai/playerCount.js
+++ b/src/ai/playerCount.js
@@ -16,7 +16,11 @@
 export function getPlayerCount(game) {
   let max = game.player?.length || 0;
   const { adat, AREA_MAX } = game;
-  for (let i = 1; i < AREA_MAX; i++) {
+  /*
+   * Guard `adat`: a partial view (or test mock) may omit the board entirely,
+   * in which case the player[] length and the floor of 8 are all we have.
+   */
+  for (let i = 1; adat && i < AREA_MAX; i++) {
     const area = adat[i];
     if (area && area.size !== 0 && area.arm + 1 > max) {
       max = area.arm + 1;

--- a/src/ai/playerCount.js
+++ b/src/ai/playerCount.js
@@ -1,30 +1,70 @@
 /**
- * Number of player slots an AI must account for in a legacy game view.
+ * Player-slot sizing for legacy game views — the single source of truth.
  *
- * Games can seat more than the usual 8 players — the online tournament runs a
- * 9-bot field — so AIs must size their per-player tables to the real count
- * rather than a hard-coded 8, or they drop the extra player(s) from their
- * census and crash when one of them takes a turn.
+ * Games can seat more than the usual 8 players (the online tournament runs a
+ * larger field), so a legacy view's per-player tables — `player[]`, plus the
+ * census arrays AIs build — must be sized to the real player count rather than
+ * a hard-coded 8. Get it wrong and an AI drops the extra player(s) from its
+ * census and crashes when one of them takes a turn.
  *
- * Returns the largest of: the provided `player[]` length, one past the highest
- * owner index on the board, and 8 (a floor for the common case and for views
- * that under-provision `player[]`).
+ * Both the view builders (engine/AIAdapter, arena/legacyBotAdapter) and the AIs
+ * that read those views derive their size from this one module. The builders
+ * call playerSlotCount to size `player[]`; the AIs call getPlayerCount on the
+ * finished view. Because both fold in the same board scan, a built `player[]`
+ * and a later getPlayerCount(view) can never disagree.
  *
- * @param {Object} game - Legacy mutable game view (adat[], player[], AREA_MAX).
+ * @module ai/playerCount
+ */
+
+/** Floor on player slots: the common case, and a net for views that under-provision `player[]`. */
+const PLAYER_FLOOR = 8;
+
+/**
+ * One past the highest owner index among occupied legacy `adat` areas (0 if the
+ * board is empty or absent). Empty/sentinel areas (size 0, arm -1) are skipped,
+ * and a missing `adat` is tolerated so partial views don't throw.
+ *
+ * @param {Array|undefined} adat - Legacy area table, 1-indexed; each `{ size, arm }`.
+ * @param {number} areaMax - One past the highest area id (adat length).
+ * @returns {number}
+ */
+function highestOwnerSlot(adat, areaMax) {
+  let slot = 0;
+  for (let i = 1; adat && i < areaMax; i++) {
+    const area = adat[i];
+    if (area && area.size !== 0 && area.arm + 1 > slot) {
+      slot = area.arm + 1;
+    }
+  }
+  return slot;
+}
+
+/**
+ * Number of player slots a legacy view must allocate: the largest of the seated
+ * player count, one past the highest board owner index, and a floor of 8.
+ *
+ * View builders call this to size `player[]` up front. Sizing from the same
+ * board scan the AIs use guarantees `player.length` covers every owner index,
+ * so the per-player loops in the AIs can index `player[]` without going out of
+ * bounds.
+ *
+ * @param {number} playerLength - Number of seated players (0 if unknown).
+ * @param {Array|undefined} adat - Legacy area table (see highestOwnerSlot).
+ * @param {number} areaMax - One past the highest area id.
+ * @returns {number}
+ */
+export function playerSlotCount(playerLength, adat, areaMax) {
+  return Math.max(playerLength || 0, highestOwnerSlot(adat, areaMax), PLAYER_FLOOR);
+}
+
+/**
+ * Number of player slots an AI must account for in a legacy game view. Sized
+ * from the view's own `player[]` length and board, so it matches the count the
+ * view was built with (see playerSlotCount).
+ *
+ * @param {Object} game - Legacy mutable game view (player[], adat[], AREA_MAX).
  * @returns {number} Player count to iterate / size tables to.
  */
 export function getPlayerCount(game) {
-  let max = game.player?.length || 0;
-  const { adat, AREA_MAX } = game;
-  /*
-   * Guard `adat`: a partial view (or test mock) may omit the board entirely,
-   * in which case the player[] length and the floor of 8 are all we have.
-   */
-  for (let i = 1; adat && i < AREA_MAX; i++) {
-    const area = adat[i];
-    if (area && area.size !== 0 && area.arm + 1 > max) {
-      max = area.arm + 1;
-    }
-  }
-  return Math.max(max, 8);
+  return playerSlotCount(game.player?.length || 0, game.adat, game.AREA_MAX);
 }

--- a/src/ai/playerCount.js
+++ b/src/ai/playerCount.js
@@ -1,0 +1,26 @@
+/**
+ * Number of player slots an AI must account for in a legacy game view.
+ *
+ * Games can seat more than the usual 8 players — the online tournament runs a
+ * 9-bot field — so AIs must size their per-player tables to the real count
+ * rather than a hard-coded 8, or they drop the extra player(s) from their
+ * census and crash when one of them takes a turn.
+ *
+ * Returns the largest of: the provided `player[]` length, one past the highest
+ * owner index on the board, and 8 (a floor for the common case and for views
+ * that under-provision `player[]`).
+ *
+ * @param {Object} game - Legacy mutable game view (adat[], player[], AREA_MAX).
+ * @returns {number} Player count to iterate / size tables to.
+ */
+export function getPlayerCount(game) {
+  let max = game.player?.length || 0;
+  const { adat, AREA_MAX } = game;
+  for (let i = 1; i < AREA_MAX; i++) {
+    const area = adat[i];
+    if (area && area.size !== 0 && area.arm + 1 > max) {
+      max = area.arm + 1;
+    }
+  }
+  return Math.max(max, 8);
+}

--- a/src/arena/legacyBotAdapter.js
+++ b/src/arena/legacyBotAdapter.js
@@ -50,9 +50,14 @@ function createLegacyViewFromBotState(botState) {
     };
   }
 
-  // Build player[] in legacy shape (padded to 8)
-  const player = new Array(8);
-  for (let i = 0; i < 8; i++) {
+  /*
+   * Build player[] in legacy shape, one entry per real player. Games can seat
+   * more than 8 players (the online tournament runs a 9-bot field), so size to
+   * the actual count; keep a floor of 8 for legacy AIs that still index up to 8.
+   */
+  const playerSlots = Math.max(8, players.length, totalPlayers);
+  const player = new Array(playerSlots);
+  for (let i = 0; i < playerSlots; i++) {
     if (i < players.length) {
       const p = players[i];
       player[i] = {

--- a/src/arena/legacyBotAdapter.js
+++ b/src/arena/legacyBotAdapter.js
@@ -7,6 +7,8 @@
  * @module arena/legacyBotAdapter
  */
 
+import { playerSlotCount } from '../ai/playerCount.js';
+
 /**
  * Build a legacy mutable game view from a BotState.
  *
@@ -52,10 +54,11 @@ function createLegacyViewFromBotState(botState) {
 
   /*
    * Build player[] in legacy shape, one entry per real player. Games can seat
-   * more than 8 players (the online tournament runs a 9-bot field), so size to
-   * the actual count; keep a floor of 8 for legacy AIs that still index up to 8.
+   * more than 8 players, so size via playerSlotCount — the same board-aware
+   * sizing the AIs use through getPlayerCount — so player.length always covers
+   * every owner index. Floors at 8 for legacy AIs that still index up to 8.
    */
-  const playerSlots = Math.max(8, players.length, totalPlayers);
+  const playerSlots = playerSlotCount(players.length, adat, AREA_MAX);
   const player = new Array(playerSlots);
   for (let i = 0; i < playerSlots; i++) {
     if (i < players.length) {

--- a/src/engine/AIAdapter.js
+++ b/src/engine/AIAdapter.js
@@ -42,9 +42,15 @@ export function createLegacyGameView(state) {
     };
   }
 
-  // Build player[] in legacy shape
-  const player = new Array(8);
-  for (let i = 0; i < 8; i++) {
+  /*
+   * Build player[] in legacy shape, one entry per real player. Games can have
+   * more than 8 players (the online tournament runs a 9-bot field), so size to
+   * the actual count; keep a floor of 8 because some legacy AIs still index up
+   * to 8 unconditionally. The extra slots above players.length are empty pads.
+   */
+  const playerSlots = Math.max(8, players.length);
+  const player = new Array(playerSlots);
+  for (let i = 0; i < playerSlots; i++) {
     if (i < players.length) {
       player[i] = {
         area_c: players[i].territoryCount,
@@ -54,7 +60,6 @@ export function createLegacyGameView(state) {
         stock: players[i].stock,
       };
     } else {
-      // Pad to 8 players (AIs hardcode loops to 8)
       player[i] = { area_c: 0, dice_c: 0, area_tc: 0, dice_jun: 0, stock: 0 };
     }
   }
@@ -78,8 +83,8 @@ export function createLegacyGameView(state) {
     },
   };
 
-  // Pad jun to 8 if needed
-  while (view.jun.length < 8) {
+  // Pad jun up to the player-slot count if the turn order is shorter.
+  while (view.jun.length < playerSlots) {
     view.jun.push(view.jun.length);
   }
 

--- a/src/engine/AIAdapter.js
+++ b/src/engine/AIAdapter.js
@@ -10,6 +10,7 @@
 
 import { applyAction, getValidMoves } from './StateManager.js';
 import { ACTION_TYPES, GAME_PHASES } from './constants.js';
+import { playerSlotCount } from '../ai/playerCount.js';
 
 /**
  * Transform engine GameState into the mutable shape legacy AIs expect.
@@ -44,11 +45,12 @@ export function createLegacyGameView(state) {
 
   /*
    * Build player[] in legacy shape, one entry per real player. Games can have
-   * more than 8 players (the online tournament runs a 9-bot field), so size to
-   * the actual count; keep a floor of 8 because some legacy AIs still index up
-   * to 8 unconditionally. The extra slots above players.length are empty pads.
+   * more than 8 players, so size via playerSlotCount — the same board-aware
+   * sizing the AIs use through getPlayerCount — so player.length always covers
+   * every owner index. Floors at 8 because some legacy AIs still index up to 8
+   * unconditionally; extra slots above players.length are empty pads.
    */
-  const playerSlots = Math.max(8, players.length);
+  const playerSlots = playerSlotCount(players.length, adat, AREA_MAX);
   const player = new Array(playerSlots);
   for (let i = 0; i < playerSlots; i++) {
     if (i < players.length) {

--- a/tests/ai/playerCount.test.js
+++ b/tests/ai/playerCount.test.js
@@ -1,0 +1,72 @@
+import { getPlayerCount } from '../../src/ai/playerCount.js';
+
+/*
+ * getPlayerCount reads only three fields of a legacy game view: player[] (for
+ * its length), adat[] (1-indexed board areas, each { size, arm }), and
+ * AREA_MAX. It returns the largest of player.length, one-past-the-highest board
+ * owner index, and a floor of 8. These cases pin each branch directly — the
+ * 9-player integration test in tests/arena/legacyBotAdapter.test.js exercises
+ * the fix end-to-end but cannot reach the board-scan branch (there player.length
+ * already equals the owner count), so this is where that logic is guarded.
+ */
+
+// area { size, arm }: size !== 0 means occupied; arm is the owner's player index.
+const occupied = arm => ({ size: 1, arm });
+const empty = arm => ({ size: 0, arm }); // a vacated/sentinel area (arm ignored)
+
+describe('getPlayerCount', () => {
+  it('returns player.length when it dominates the board owner count', () => {
+    const game = {
+      player: Array(9).fill(null),
+      AREA_MAX: 4,
+      adat: [null, occupied(0), occupied(1), occupied(2)],
+    };
+    expect(getPlayerCount(game)).toBe(9);
+  });
+
+  it('returns one past the highest board owner index when it exceeds player.length', () => {
+    // The regression-critical branch: player[] is shorter than the board needs.
+    const game = {
+      player: Array(8).fill(null),
+      AREA_MAX: 3,
+      adat: [null, occupied(9), occupied(2)],
+    };
+    expect(getPlayerCount(game)).toBe(10);
+  });
+
+  it('falls back to the floor of 8 when both inputs are smaller', () => {
+    const game = {
+      player: Array(4).fill(null),
+      AREA_MAX: 3,
+      adat: [null, occupied(0), occupied(1)],
+    };
+    expect(getPlayerCount(game)).toBe(8);
+  });
+
+  it('treats a missing player[] as length 0 (still floored to 8)', () => {
+    const game = {
+      AREA_MAX: 3,
+      adat: [null, occupied(0), occupied(1)],
+    };
+    expect(getPlayerCount(game)).toBe(8);
+  });
+
+  it('ignores empty/sentinel areas and tolerates holes in adat', () => {
+    /*
+     * adat[1] is vacated (size 0) with a high arm that must NOT count; index 2
+     * is a hole (undefined); the real owners are at indices 10 and 3.
+     */
+    const game = {
+      player: Array(8).fill(null),
+      AREA_MAX: 6,
+      adat: [null, empty(99), undefined, occupied(10), null, occupied(3)],
+    };
+    expect(getPlayerCount(game)).toBe(11);
+  });
+
+  it('does not throw when the board (adat) is absent from a partial view', () => {
+    const game = { player: Array(9).fill(null), AREA_MAX: 5 };
+    expect(() => getPlayerCount(game)).not.toThrow();
+    expect(getPlayerCount(game)).toBe(9);
+  });
+});

--- a/tests/ai/playerCount.test.js
+++ b/tests/ai/playerCount.test.js
@@ -1,4 +1,4 @@
-import { getPlayerCount } from '../../src/ai/playerCount.js';
+import { getPlayerCount, playerSlotCount } from '../../src/ai/playerCount.js';
 
 /*
  * getPlayerCount reads only three fields of a legacy game view: player[] (for
@@ -68,5 +68,45 @@ describe('getPlayerCount', () => {
     const game = { player: Array(9).fill(null), AREA_MAX: 5 };
     expect(() => getPlayerCount(game)).not.toThrow();
     expect(getPlayerCount(game)).toBe(9);
+  });
+});
+
+/*
+ * playerSlotCount is the shared core the view builders (AIAdapter,
+ * legacyBotAdapter) call to size player[] up front, from the same board scan
+ * getPlayerCount runs afterward. These cases pin that contract and the
+ * invariant that ties the two together: a view sized by playerSlotCount always
+ * reports the same count from getPlayerCount, so AIs never index past player[].
+ */
+describe('playerSlotCount', () => {
+  const adat = [null, occupied(0), occupied(1), occupied(2)];
+  const AREA_MAX = 4;
+
+  it('takes the seated player count when it dominates', () => {
+    expect(playerSlotCount(9, adat, AREA_MAX)).toBe(9);
+  });
+
+  it('takes one past the highest owner index when the board has more owners than seats', () => {
+    expect(playerSlotCount(8, [null, occupied(9), occupied(2)], 3)).toBe(10);
+  });
+
+  it('floors at 8 and tolerates an absent board', () => {
+    expect(playerSlotCount(4, adat, AREA_MAX)).toBe(8);
+    expect(playerSlotCount(3, undefined, 5)).toBe(8);
+  });
+
+  it('agrees with getPlayerCount on a view it was used to size', () => {
+    /*
+     * Mirror how a builder works: size player[] via playerSlotCount, then let
+     * an AI re-derive the count from the finished view — they must match, and
+     * every owner index must be a valid player[] slot.
+     */
+    const board = [null, occupied(9), occupied(2), occupied(0)];
+    const slots = playerSlotCount(5, board, 4);
+    const view = { player: Array(slots).fill(null), adat: board, AREA_MAX: 4 };
+
+    expect(getPlayerCount(view)).toBe(slots);
+    expect(slots).toBe(10); // owner index 9 forces 10 slots even with 5 seated
+    expect(view.player.length).toBeGreaterThan(9); // index 9 deref is in-bounds
   });
 });

--- a/tests/arena/legacyBotAdapter.test.js
+++ b/tests/arena/legacyBotAdapter.test.js
@@ -18,10 +18,13 @@ function createTestBotState(seed = 42, playerCount = 4) {
 /*
  * The online tournament runs a 9-bot field, so games can seat more than 8
  * players. Legacy bots that assumed 8 player slots dropped the 9th player from
- * their census and threw on its turn; adaptLegacyBot swallows the throw (logs
- * "threw" and forfeits), so a crash shows up as a silent forfeit, not a test
- * failure. These tests pin that every built-in bot runs cleanly as the
- * highest-indexed player (index 8) in a 9-player game.
+ * their census and threw on its turn; adaptLegacyBot swallows the throw (it
+ * logs a warning and forfeits), so a crash shows up as a silent forfeit, not a
+ * test failure. adaptLegacyBot only warns on that swallowed throw, so we assert
+ * that no warning fired at all — keying on the call, not its wording, so the
+ * guard survives a reword of the log message. These tests pin that every
+ * built-in bot runs cleanly as the highest-indexed player (index 8) in a
+ * 9-player game.
  */
 describe('built-in bots in 9-player games (N-player robustness)', () => {
   const BOTS = [
@@ -41,10 +44,10 @@ describe('built-in bots in 9-player games (N-player robustness)', () => {
 
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const move = bot(botState);
-      const threw = warnSpy.mock.calls.some(args => String(args[0]).includes('threw'));
+      const warned = warnSpy.mock.calls.length > 0;
       warnSpy.mockRestore();
 
-      expect(threw).toBe(false);
+      expect(warned).toBe(false);
       if (move !== null) {
         expect(validateMove(move, botState).valid).toBe(true);
       }

--- a/tests/arena/legacyBotAdapter.test.js
+++ b/tests/arena/legacyBotAdapter.test.js
@@ -6,12 +6,51 @@ import { ai_example } from '../../src/ai/ai_example.js';
 import { ai_default } from '../../src/ai/ai_default.js';
 import { ai_defensive } from '../../src/ai/ai_defensive.js';
 import { ai_adaptive } from '../../src/ai/ai_adaptive.js';
+import { ai_strategist } from '../../src/ai/ai_strategist.js';
+import { ai_lookahead } from '../../src/ai/ai_lookahead.js';
 
 function createTestBotState(seed = 42, playerCount = 4) {
   const state = createGame({ seed, playerCount });
   const playerId = state.turnOrder[state.currentPlayerIndex];
   return createBotState(state, playerId);
 }
+
+/*
+ * The online tournament runs a 9-bot field, so games can seat more than 8
+ * players. Legacy bots that assumed 8 player slots dropped the 9th player from
+ * their census and threw on its turn; adaptLegacyBot swallows the throw (logs
+ * "threw" and forfeits), so a crash shows up as a silent forfeit, not a test
+ * failure. These tests pin that every built-in bot runs cleanly as the
+ * highest-indexed player (index 8) in a 9-player game.
+ */
+describe('built-in bots in 9-player games (N-player robustness)', () => {
+  const BOTS = [
+    ['ai_example', ai_example],
+    ['ai_default', ai_default],
+    ['ai_defensive', ai_defensive],
+    ['ai_adaptive', ai_adaptive],
+    ['ai_strategist', ai_strategist],
+    ['ai_lookahead', ai_lookahead],
+  ];
+
+  for (const [name, fn] of BOTS) {
+    it(`${name} runs without throwing when seated at player index 8`, () => {
+      const state = createGame({ seed: 7, playerCount: 9 });
+      const botState = createBotState(state, 8); // the 9th player
+      const bot = adaptLegacyBot(fn, name);
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const move = bot(botState);
+      const threw = warnSpy.mock.calls.some(args => String(args[0]).includes('threw'));
+      warnSpy.mockRestore();
+
+      expect(threw).toBe(false);
+      if (move !== null) {
+        expect(validateMove(move, botState).valid).toBe(true);
+      }
+    });
+  }
+});
 
 describe('adaptLegacyBot', () => {
   it('returns a function', () => {


### PR DESCRIPTION
## What & why

The online tournament runs a **9-bot field**, but the legacy game-view builders and several bots assumed **8 player slots**. In a 9-player game the 9th player was dropped from each bot's census, and bots threw when reading that player's data or taking its turn. `adaptLegacyBot` swallows the throw (logs `"threw"`, forfeits the turn), so the bug surfaced as **silent forfeits, not crashes** — `ai_default` alone threw ~86k times over a 200-game 9-bot arena.

## Fixes

- **Both view builders** now size `player[]` (and `jun` padding) to the real player count, floored at 8:
  - `AIAdapter.createLegacyGameView` (engine path)
  - `legacyBotAdapter.createLegacyViewFromBotState` (**arena / tournament path** — the one that actually bit)
- New shared helper **`getPlayerCount(game)`** derives the count from `player[]` length and the highest owner index on the board.
- `ai_strategist`, `ai_default`, `ai_adaptive` size their per-player tables/loops to `getPlayerCount(game)` instead of a hard-coded 8.
- `ai_defensive`/`ai_example` need no bot-level change (area-only / guarded by the adapter fix); `ai_lookahead` was already N-player-safe (PR #30).

## Verification

- A 9-bot, 200-game arena now logs **0 `"threw"` warnings** (was ~86k).
- Behavior in ≤8-player games is unchanged (`getPlayerCount` returns 8).
- Re-measured the now-fixed 9-bot field (1500 games): **Lookahead still #1** (28.9% win / 1360 ELO), Strategist #2 (17.7% / 1295) — so the tuning in #30 holds up against properly-playing opponents; no re-tune needed.
- 664 tests pass · lint 0 errors. Adds 9-player regression tests for every built-in bot through the real arena path.

## Heads-up

The **next tournament's leaderboard will shift** — bots that were silently forfeiting as the 9th player will now compete properly (Defensive, Adaptive should climb). The name-based ELO continuity from #29 still applies; standings just re-sort.

## Stack

Stacked on #30 (tuning), which is stacked on #29 (rename). **Merge order: #29 → #30 → this.**