### PR TITLE
feat(ui): choose bots per slot at game start

### DIFF
--- a/src/controller/GameController.js
+++ b/src/controller/GameController.js
@@ -108,7 +108,13 @@ export function createGameController(store, renderer, soundManager, preferencesM
   /**
    * Start a new game from the title screen.
    *
-   * @param {{ playerCount: number, spectator: boolean, mapSize?: string }} config
+   * @param {Object} config
+   * @param {number} config.playerCount
+   * @param {boolean} config.spectator
+   * @param {string} [config.mapSize]
+   * @param {(string | null)[]} [config.aiAssignments] - Per-slot AI strategy IDs
+   *   (index = player slot, null = human). Falls back to the store's current
+   *   assignments when omitted.
    */
   async function startNewGame(config) {
     aiAborted = true; // abort any running AI turn
@@ -133,13 +139,19 @@ export function createGameController(store, renderer, soundManager, preferencesM
      * store's current value if the caller omits it.
      */
     const mapSize = config.mapSize ?? store.getState().config.mapSize;
+    /*
+     * Per-slot bot lineup chosen on the title screen. Fall back to the store's
+     * current assignments when the caller omits it. loadAIFunctions reads this
+     * from the store below, so it must be written before that call.
+     */
+    const aiAssignments = config.aiAssignments ?? store.getState().config.aiAssignments;
 
     /*
      * Update store config. Persist mapSize so a later rejectMap() regenerates
      * at the same size the player chose.
      */
     store.setState({
-      config: { ...store.getState().config, playerCount, mapSize },
+      config: { ...store.getState().config, playerCount, mapSize, aiAssignments },
       humanPlayerIndex: spectator ? null : 0,
     });
 

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -41,6 +41,7 @@ export function App({ store, controller, preferencesManager }) {
       <ErrorBoundary>
         {settings}
         <TitleScreen
+          store={store}
           error={error}
           onStart={config => controller.startNewGame(config)}
           onArena={() => controller.goToArena()}

--- a/src/ui/TitleScreen.jsx
+++ b/src/ui/TitleScreen.jsx
@@ -1,13 +1,15 @@
 /**
  * Title Screen
  *
- * Player count selection, START and AI vs AI buttons.
+ * Player count selection, an optional per-slot bot picker, START and AI vs AI
+ * buttons.
  *
  * @module ui/TitleScreen
  */
 
 import { useState } from 'preact/hooks';
 import { DEFAULT_MAP_SIZE } from '../utils/config.js';
+import { getAllAIStrategies } from '../ai/aiConfig.js';
 
 /**
  * Map-size options shown on the title screen. `value` keys must match
@@ -19,6 +21,9 @@ const MAP_SIZE_OPTIONS = [
   { value: 'medium', label: 'Medium' },
   { value: 'large', label: 'Large' },
 ];
+
+/** Built-in AI strategies offered in the per-slot bot picker. */
+const AI_OPTIONS = getAllAIStrategies();
 
 const STYLE = {
   container: {
@@ -125,26 +130,98 @@ const STYLE = {
     maxWidth: '400px',
     textAlign: 'center',
   },
+  disclosureBtn: {
+    fontFamily: 'Roboto, sans-serif',
+    fontSize: '0.8rem',
+    letterSpacing: '0.08em',
+    textTransform: 'uppercase',
+    background: 'transparent',
+    border: 'none',
+    color: 'var(--ui-text-muted)',
+    cursor: 'pointer',
+    marginBottom: '0.8rem',
+    padding: '0.2rem 0.4rem',
+  },
+  customizePanel: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.5rem',
+    width: '100%',
+    maxWidth: '320px',
+    marginBottom: '1.5rem',
+  },
+  slotRow: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: '0.8rem',
+  },
+  slotLabel: {
+    fontFamily: 'Roboto, sans-serif',
+    fontSize: '0.9rem',
+    color: 'var(--ui-text-muted)',
+  },
+  humanTag: {
+    fontFamily: 'Roboto, sans-serif',
+    fontSize: '0.9rem',
+    color: 'var(--ui-accent)',
+  },
+  select: {
+    fontFamily: 'Roboto, sans-serif',
+    fontSize: '0.9rem',
+    padding: '0.3rem 0.5rem',
+    background: 'var(--ui-overlay-bg)',
+    color: 'var(--ui-text)',
+    border: '2px solid var(--ui-border)',
+    borderRadius: '4px',
+    cursor: 'pointer',
+    minWidth: '160px',
+  },
 };
 
 /**
  * @param {Object} props
+ * @param {Object} props.store - GameStore, used to seed the default bot lineup
  * @param {string | null} [props.error] - Error message to display
- * @param {(config: { playerCount: number, spectator: boolean, mapSize: string }) => void} props.onStart
+ * @param {(config: { playerCount: number, spectator: boolean, mapSize: string, aiAssignments: (string | null)[] }) => void} props.onStart
  * @param {() => void} [props.onArena] - Navigate to arena screen
  * @param {() => void} [props.onTournament] - Navigate to tournament screen
  * @param {() => void} [props.onLeaderboard] - Navigate to online leaderboard screen
  */
-export function TitleScreen({ error, onStart, onArena, onTournament, onLeaderboard }) {
+export function TitleScreen({ store, error, onStart, onArena, onTournament, onLeaderboard }) {
   const [playerCount, setPlayerCount] = useState(7);
   const [mapSize, setMapSize] = useState(DEFAULT_MAP_SIZE);
+  const [showCustomize, setShowCustomize] = useState(false);
+  // Per-slot AI strategy IDs (index = player slot). Seeded from store defaults.
+  const [assignments, setAssignments] = useState(() =>
+    (store?.getState().config.aiAssignments ?? []).slice()
+  );
+
+  const handleAssign = (slot, aiId) => {
+    setAssignments(prev => {
+      const next = prev.slice();
+      next[slot] = aiId;
+      return next;
+    });
+  };
+
+  /*
+   * Build the lineup passed to the controller: slot 0 is always the human seat
+   * (null — the controller fills it with a default bot in spectator mode), and
+   * every AI slot resolves to a concrete strategy id so a null never gets
+   * mistaken for a human.
+   */
+  const buildAssignments = () =>
+    Array.from({ length: playerCount }, (_, i) =>
+      i === 0 ? null : assignments[i] || 'ai_default'
+    );
 
   const handleStart = () => {
-    onStart({ playerCount, spectator: false, mapSize });
+    onStart({ playerCount, spectator: false, mapSize, aiAssignments: buildAssignments() });
   };
 
   const handleAIvsAI = () => {
-    onStart({ playerCount, spectator: true, mapSize });
+    onStart({ playerCount, spectator: true, mapSize, aiAssignments: buildAssignments() });
   };
 
   return (
@@ -190,6 +267,41 @@ export function TitleScreen({ error, onStart, onArena, onTournament, onLeaderboa
           </button>
         ))}
       </div>
+
+      <button
+        type="button"
+        style={STYLE.disclosureBtn}
+        aria-expanded={showCustomize}
+        onClick={() => setShowCustomize(v => !v)}
+      >
+        {showCustomize ? '▾' : '▸'} Customize players
+      </button>
+
+      {showCustomize && (
+        <div style={STYLE.customizePanel}>
+          {Array.from({ length: playerCount }, (_, i) => (
+            <div key={i} style={STYLE.slotRow}>
+              <span style={STYLE.slotLabel}>Player {i + 1}</span>
+              {i === 0 ? (
+                <span style={STYLE.humanTag}>You (human)</span>
+              ) : (
+                <select
+                  aria-label={`Bot for player ${i + 1}`}
+                  style={STYLE.select}
+                  value={assignments[i] || 'ai_default'}
+                  onChange={e => handleAssign(i, e.target.value)}
+                >
+                  {AI_OPTIONS.map(ai => (
+                    <option key={ai.id} value={ai.id}>
+                      {ai.name}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
 
       <div style={STYLE.buttonRow}>
         <button style={STYLE.startBtn} onClick={handleStart}>

--- a/tests/controller/GameController.test.js
+++ b/tests/controller/GameController.test.js
@@ -192,6 +192,34 @@ describe('GameController', () => {
       expect(soundManager.loadAll).toHaveBeenCalledTimes(1);
     });
 
+    it('threads custom aiAssignments into store config, keeping slot 0 human', async () => {
+      const custom = [null, 'ai_strategist', 'ai_lookahead'];
+      await controller.startNewGame({ playerCount: 3, spectator: false, aiAssignments: custom });
+
+      expect(store.getState().config.aiAssignments).toEqual(custom);
+      expect(store.getState().config.aiAssignments[0]).toBeNull();
+    });
+
+    it('loads the AI implementations named in aiAssignments', async () => {
+      const { getAIImplementation } = await import('../../src/ai/aiConfig.js');
+
+      await controller.startNewGame({
+        playerCount: 3,
+        spectator: false,
+        aiAssignments: [null, 'ai_strategist', 'ai_lookahead'],
+      });
+
+      expect(getAIImplementation).toHaveBeenCalledWith('ai_strategist');
+      expect(getAIImplementation).toHaveBeenCalledWith('ai_lookahead');
+    });
+
+    it('falls back to the store lineup when aiAssignments is omitted', async () => {
+      const before = store.getState().config.aiAssignments;
+      await controller.startNewGame({ playerCount: 2, spectator: false });
+
+      expect(store.getState().config.aiAssignments).toEqual(before);
+    });
+
     it('resets to title screen on createGame failure', async () => {
       const { createGame } = await import('../../src/engine/index.js');
       createGame.mockImplementationOnce(() => {

--- a/tests/ui/TitleScreen.test.js
+++ b/tests/ui/TitleScreen.test.js
@@ -28,10 +28,23 @@ function renderTitle(props = {}) {
 }
 
 const sizeBtn = label => container.querySelector(`button[aria-label="${label} map"]`);
+const playerBtn = n => container.querySelector(`button[aria-label="Play with ${n} players"]`);
 const startBtn = () =>
   [...container.querySelectorAll('button')].find(b => b.textContent === 'START');
 const aiBtn = () =>
   [...container.querySelectorAll('button')].find(b => b.textContent === 'AI vs AI');
+const customizeBtn = () =>
+  [...container.querySelectorAll('button')].find(b => b.textContent.includes('Customize players'));
+const slotSelect = n => container.querySelector(`select[aria-label="Bot for player ${n}"]`);
+
+/** Set a native <select> value and fire the change event Preact listens for. */
+function chooseBot(playerNumber, aiId) {
+  const sel = slotSelect(playerNumber);
+  act(() => {
+    sel.value = aiId;
+    sel.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+}
 
 afterEach(() => {
   if (container) {
@@ -66,25 +79,88 @@ describe('TitleScreen', () => {
   it('passes the default map size to onStart via START', () => {
     const { onStart } = renderTitle();
     act(() => startBtn().click());
-    expect(onStart).toHaveBeenCalledWith({ playerCount: 7, spectator: false, mapSize: 'medium' });
+    expect(onStart).toHaveBeenCalledWith(
+      expect.objectContaining({ playerCount: 7, spectator: false, mapSize: 'medium' })
+    );
   });
 
   it('passes the chosen map size to onStart via START', () => {
     const { onStart } = renderTitle();
     act(() => sizeBtn('Small').click());
     act(() => startBtn().click());
-    expect(onStart).toHaveBeenCalledWith({ playerCount: 7, spectator: false, mapSize: 'small' });
+    expect(onStart).toHaveBeenCalledWith(
+      expect.objectContaining({ playerCount: 7, spectator: false, mapSize: 'small' })
+    );
   });
 
   it('threads the chosen map size through the AI-vs-AI (spectator) path', () => {
     const { onStart } = renderTitle();
     act(() => sizeBtn('Large').click());
     act(() => aiBtn().click());
-    expect(onStart).toHaveBeenCalledWith({ playerCount: 7, spectator: true, mapSize: 'large' });
+    expect(onStart).toHaveBeenCalledWith(
+      expect.objectContaining({ playerCount: 7, spectator: true, mapSize: 'large' })
+    );
   });
 
   it('renders an error banner when error prop is set', () => {
     renderTitle({ error: 'Map generation failed' });
     expect(container.textContent).toContain('Map generation failed');
+  });
+
+  describe('per-slot bot picker', () => {
+    it('hides the slot controls until "Customize players" is expanded', () => {
+      renderTitle();
+      expect(slotSelect(2)).toBeNull();
+      act(() => customizeBtn().click());
+      expect(slotSelect(2)).toBeTruthy();
+    });
+
+    it('shows one bot dropdown per AI slot, with slot 0 marked as the human', () => {
+      renderTitle();
+      act(() => customizeBtn().click());
+      // 7 players → slot 0 is "You", slots 1..6 are dropdowns.
+      expect(container.querySelectorAll('select')).toHaveLength(6);
+      expect(container.textContent).toContain('You (human)');
+    });
+
+    it('resizes the slot list when the player count changes', () => {
+      renderTitle();
+      act(() => customizeBtn().click());
+      expect(container.querySelectorAll('select')).toHaveLength(6);
+      act(() => playerBtn(3).click());
+      // 3 players → slot 0 human + 2 dropdowns.
+      expect(container.querySelectorAll('select')).toHaveLength(2);
+    });
+
+    it('always sends a human (null) slot 0 and a concrete bot for every AI slot', () => {
+      const { onStart } = renderTitle();
+      act(() => startBtn().click());
+      const { aiAssignments } = onStart.mock.calls[0][0];
+      expect(aiAssignments).toHaveLength(7);
+      expect(aiAssignments[0]).toBeNull();
+      expect(aiAssignments.slice(1).every(id => typeof id === 'string')).toBe(true);
+    });
+
+    it('threads chosen bots — including duplicates — into onStart', () => {
+      const { onStart } = renderTitle();
+      act(() => customizeBtn().click());
+      chooseBot(2, 'ai_strategist');
+      chooseBot(3, 'ai_strategist');
+      act(() => startBtn().click());
+      const { aiAssignments } = onStart.mock.calls[0][0];
+      expect(aiAssignments[0]).toBeNull();
+      expect(aiAssignments[1]).toBe('ai_strategist');
+      expect(aiAssignments[2]).toBe('ai_strategist');
+    });
+
+    it('carries the chosen lineup through the AI-vs-AI path too', () => {
+      const { onStart } = renderTitle();
+      act(() => customizeBtn().click());
+      chooseBot(2, 'ai_lookahead');
+      act(() => aiBtn().click());
+      const { spectator, aiAssignments } = onStart.mock.calls[0][0];
+      expect(spectator).toBe(true);
+      expect(aiAssignments[1]).toBe('ai_lookahead');
+    });
   });
 });


### PR DESCRIPTION
## Summary

Adds a **per-slot bot picker** to the Title Screen. Clicking "▸ Customize players" reveals one dropdown per AI slot, letting the player assign any of the 6 built-in AIs to any opponent seat — **duplicates allowed**. Player 1 stays the human ("You"). The quick-start path is untouched: collapsed, the screen behaves exactly as before with sensible defaults.

Most of the plumbing already existed (`config.aiAssignments` in the store + `GameController.loadAIFunctions()`), so this is mostly UI plus one line to thread the chosen lineup through `startNewGame`.

## Changes

- **`src/ui/TitleScreen.jsx`** — expandable disclosure + per-slot `<select>` (options from `getAllAIStrategies()`), seeded from store defaults. `buildAssignments()` keeps slot 0 the human and guarantees every AI slot resolves to a concrete strategy id (a null is never mistaken for a human).
- **`src/ui/App.jsx`** — forwards `store` to `TitleScreen`.
- **`src/controller/GameController.js`** — `startNewGame` merges incoming `aiAssignments` into store config *before* `loadAIFunctions` runs; falls back to the existing lineup when omitted. `loadAIFunctions` unchanged.
- **Tests** — 6 new TitleScreen picker tests (visibility, slot count, resize, human-slot invariant, duplicate threading, AI-vs-AI path) and 3 new GameController tests (lineup threading, implementation loading, omitted-fallback). Relaxed 3 existing map-size assertions to `objectContaining` for the new `onStart` field.

## Scope / decisions

- Human is fixed at slot 0 (matches current `humanPlayerIndex` model).
- Built-in AIs only — community bots use a different function signature with no in-game adapter (deferred).
- No persistence — selections live in the store for the session, like player count and map size today.

### Known limitation (matches today's behavior)
In AI-vs-AI mode, slot 0's bot isn't user-selectable — it falls back to `ai_default`, exactly as it does now.

## Verification

- **Tests:** 686 passed across 49 files.
- **Lint:** 0 errors; warning count identical to clean-`master` baseline (no new issues).
- **Build:** succeeds.
- **Browser smoke test:** expanded the picker, set a duplicate (Strategist on players 2 & 3), started a 7-player game → map preview → board rendered with all 7 players, **zero console errors**.

## Follow-ups (out of scope)
- Community bots in-game (needs a new-style→in-game adapter + browser compile)
- Persisting the last lineup across reloads
- Letting the human take a non-zero slot / picking slot 0's bot in AI-vs-AI