### PR TITLE
feat(ui): play curated community bots in-game

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Built on the original [Dice Wars](https://www.gamedesign.jp/games/dicewars/) by 
 ## Features
 
 - **Play or spectate** — play against AI opponents or watch bots battle each other
+- **Choose your opponents** — pick a bot per slot before each game (Customize players), including the curated community bots — duplicates allowed
 - **Configurable map size** — pick Small (20×24), Medium (28×32, default) or Large (36×40) before each game
 - **Bot SDK** — write a bot in a single function and compete in the arena
 - **Arena mode** — run tournaments with ELO ratings and match replays

--- a/docs/BOT_GUIDE.md
+++ b/docs/BOT_GUIDE.md
@@ -160,6 +160,11 @@ Submit your bot to the online arena where it competes in daily automated tournam
 
 Your bot will be included in the daily tournament once merged. Check the live leaderboard on the [game site](https://bigintersmind.github.io/dicewarsjs/).
 
+Once merged, your bot is also **playable in-game**: on the title screen, expand
+**Customize players** and pick it from the **Community** group of any opponent
+slot (duplicates allowed). It runs through the exact same `BotState` it sees in
+the arena, so its in-game behavior matches its tournament behavior.
+
 ### Other ways
 
 - **Issue**: Open an issue using the [Bot Submission](https://github.com/bigintersmind/dicewarsjs/issues/new?template=bot_submission.md) template

--- a/src/arena/communityBots.js
+++ b/src/arena/communityBots.js
@@ -1,0 +1,88 @@
+/**
+ * Community Bot Loader (browser)
+ *
+ * Surfaces the curated community bots in `community-bots/registry.json` to the
+ * app. The bot sources are function bodies (not ES modules), so they are bundled
+ * as raw strings via `import.meta.glob(..., { query: '?raw' })` and compiled with
+ * the same `compileCustomBot` the rest of the project uses.
+ *
+ * Two entry points:
+ * - `getCommunityBotList()` — registry metadata only (no compilation), for the
+ *   Title Screen picker.
+ * - `loadCommunityBot(id)` — the compiled modern bot function (memoized), used by
+ *   the controller when a community bot is actually selected.
+ *
+ * @module arena/communityBots
+ */
+
+import registry from '../../community-bots/registry.json';
+import { compileCustomBot } from './customBotCompiler.js';
+
+/**
+ * Raw source of every community bot file, keyed by module path
+ * (e.g. '../../community-bots/bigintersmind/connector.js'). `.meta.json` and
+ * docs are excluded by the `*.js` glob; `?raw` keeps each as a string.
+ */
+const sources = import.meta.glob('../../community-bots/**/*.js', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+});
+
+/** Active registry entries (a bot is active unless explicitly `active: false`). */
+const ACTIVE = registry.filter(entry => entry.active !== false);
+
+/** Compiled bot functions, memoized by registry id. */
+const compiledCache = new Map();
+
+/**
+ * Find the raw source string for a registry `file` (e.g. 'bigintersmind/connector.js').
+ * @param {string} file
+ * @returns {string | null}
+ */
+function sourceForFile(file) {
+  const suffix = `/community-bots/${file}`;
+  for (const [key, src] of Object.entries(sources)) {
+    if (key.endsWith(suffix)) return src;
+  }
+  return null;
+}
+
+/**
+ * List active community bots as picker metadata (no compilation).
+ * @returns {{ id: string, name: string, author: string, description: string }[]}
+ */
+export function getCommunityBotList() {
+  return ACTIVE.map(({ id, name, author, description }) => ({
+    id,
+    name,
+    author,
+    description,
+  }));
+}
+
+/**
+ * Compile and return a community bot's modern function by registry id.
+ * Result is memoized so repeated selections reuse the same function.
+ *
+ * @param {string} id - Registry id (e.g. 'bigintersmind/connector')
+ * @returns {Function} Modern bot: (BotState) → { from, to } | null
+ * @throws {Error} If the id is unknown, the source is missing, or it fails to compile
+ */
+export function loadCommunityBot(id) {
+  if (compiledCache.has(id)) return compiledCache.get(id);
+
+  const entry = ACTIVE.find(e => e.id === id);
+  if (!entry) {
+    throw new Error(`Unknown community bot: ${id}`);
+  }
+
+  const src = sourceForFile(entry.file);
+  if (src == null) {
+    throw new Error(`Source not found for community bot ${id} (${entry.file})`);
+  }
+
+  const { fn } = compileCustomBot(src, entry.name);
+  compiledCache.set(id, fn);
+  return fn;
+}

--- a/src/arena/modernBotAdapter.js
+++ b/src/arena/modernBotAdapter.js
@@ -1,0 +1,56 @@
+/**
+ * Modern Bot Adapter (reverse of legacyBotAdapter)
+ *
+ * Wraps a modern-style bot — `(BotState) => { from, to } | null`, the signature
+ * used by arena and community bots — so it can run inside the in-game AI loop,
+ * which drives functions through `runAI(state, fn)` in engine/AIAdapter.
+ *
+ * The wrapped function takes the engine GameState directly and builds a
+ * BotState with the SAME `createBotState` the arena uses, so a community bot
+ * behaves identically in-game and in the arena. It is tagged `__modernBot` so
+ * `runAI` calls it with state (instead of building a legacy mutable game view).
+ *
+ * @module arena/modernBotAdapter
+ */
+
+import { createBotState } from './botState.js';
+
+/**
+ * Wrap a modern bot function for the in-game AI loop.
+ *
+ * @param {Function} modernFn - Modern bot: (BotState) → { from, to } | null
+ * @param {string}   [name]   - Optional name for debugging
+ * @returns {Function} Engine-callable bot: (GameState) → { from, to } | null,
+ *   tagged with `__modernBot = true`.
+ */
+export function adaptModernBot(modernFn, name) {
+  const botName = name || modernFn.botName || modernFn.name || 'modern_bot';
+
+  function wrapped(state) {
+    const playerId = state.turnOrder[state.currentPlayerIndex];
+    const botState = createBotState(state, playerId);
+
+    let move;
+    try {
+      move = modernFn(botState);
+    } catch (err) {
+      /*
+       * A community/arena bot throwing is a bot error, not an adapter bug —
+       * log it and end the turn rather than crashing the game loop.
+       */
+      console.warn(`Modern bot "${botName}" threw: ${err.message}`);
+      return null;
+    }
+
+    if (move && typeof move.from === 'number' && typeof move.to === 'number') {
+      return { from: move.from, to: move.to };
+    }
+
+    // null / undefined / malformed → end turn
+    return null;
+  }
+
+  wrapped.__modernBot = true;
+  Object.defineProperty(wrapped, 'name', { value: botName });
+  return wrapped;
+}

--- a/src/arena/modernBotAdapter.js
+++ b/src/arena/modernBotAdapter.js
@@ -18,6 +18,12 @@ import { createBotState } from './botState.js';
 /**
  * Wrap a modern bot function for the in-game AI loop.
  *
+ * `adaptModernBot` is the ONLY supported producer of `__modernBot`-tagged
+ * functions: its try/catch converts a bot's own throw into end-turn, which is
+ * what lets `runAI` treat any throw it sees from a tagged function as an
+ * adapter/sanitization bug (see engine/AIAdapter.js). Tag a raw bot `__modernBot`
+ * without this wrapper and that invariant breaks.
+ *
  * @param {Function} modernFn - Modern bot: (BotState) → { from, to } | null
  * @param {string}   [name]   - Optional name for debugging
  * @returns {Function} Engine-callable bot: (GameState) → { from, to } | null,
@@ -36,9 +42,10 @@ export function adaptModernBot(modernFn, name) {
     } catch (err) {
       /*
        * A community/arena bot throwing is a bot error, not an adapter bug —
-       * log it and end the turn rather than crashing the game loop.
+       * log it (with stack, to match the legacy path) and end the turn rather
+       * than crashing the game loop.
        */
-      console.warn(`Modern bot "${botName}" threw: ${err.message}`);
+      console.warn(`Modern bot "${botName}" threw: ${err.message}\n${err.stack}`);
       return null;
     }
 
@@ -46,7 +53,17 @@ export function adaptModernBot(modernFn, name) {
       return { from: move.from, to: move.to };
     }
 
-    // null / undefined / malformed → end turn
+    /*
+     * null / undefined is the legitimate "I'm done" signal. A truthy-but-wrong
+     * shape is almost always a bot bug (e.g. a typo'd move), so warn rather than
+     * silently passing — mirroring the legacy path's "unexpected value" warning.
+     */
+    if (move != null) {
+      console.warn(
+        `Modern bot "${botName}" returned a malformed move ${JSON.stringify(move)}; ` +
+          `expected { from: number, to: number } or null. Ending turn.`
+      );
+    }
     return null;
   }
 

--- a/src/controller/GameController.js
+++ b/src/controller/GameController.js
@@ -60,8 +60,15 @@ export function createGameController(store, renderer, soundManager, preferencesM
 
   /**
    * Build AI assignment array from config.
+   *
+   * Returns the per-slot functions plus any player-facing notices: when a
+   * community bot (the player's explicit per-slot choice) fails to load we fall
+   * back to ai_default, but silently swapping it in would misrepresent who the
+   * player is up against — so those failures are surfaced (see startNewGame).
+   *
    * @param {number} playerCount
    * @param {boolean} spectator
+   * @returns {Promise<{ fns: (Function | null)[], warnings: string[] }>}
    */
   async function loadAIFunctions(playerCount, spectator) {
     const storeState = store.getState();
@@ -75,6 +82,7 @@ export function createGameController(store, renderer, soundManager, preferencesM
     }
 
     const fns = [];
+    const warnings = [];
     for (let i = 0; i < playerCount; i++) {
       const aiId = assignments[i];
       if (!aiId) {
@@ -87,17 +95,29 @@ export function createGameController(store, renderer, soundManager, preferencesM
             `Failed to load AI "${aiId}" for player ${i}, falling back to ai_default:`,
             err
           );
+          /*
+           * Built-in id failures are internal bugs that shouldn't happen in
+           * normal use; community-bot failures are expected (a curated bot can
+           * have a bug) and are the player's explicit choice, so surface those.
+           */
+          if (aiId.startsWith(COMMUNITY_PREFIX)) {
+            warnings.push(
+              `Player ${i + 1}: community bot "${aiId.slice(COMMUNITY_PREFIX.length)}" ` +
+                `could not load — using Default AI instead.`
+            );
+          }
           try {
             fns.push(await getAIImplementation('ai_default'));
           } catch (fallbackErr) {
             throw new Error(
-              `Cannot load any AI for player ${i}: both "${aiId}" and "ai_default" failed`
+              `Cannot load any AI for player ${i}: both "${aiId}" and "ai_default" failed`,
+              { cause: fallbackErr }
             );
           }
         }
       }
     }
-    return fns;
+    return { fns, warnings };
   }
 
   /**
@@ -139,7 +159,7 @@ export function createGameController(store, renderer, soundManager, preferencesM
    */
   async function startNewGame(config) {
     aiAborted = true; // abort any running AI turn
-    store.setState({ error: null });
+    store.setState({ error: null, aiLoadWarnings: [] });
 
     if (!renderer) {
       store.setState({ error: 'Cannot start game: graphics engine not available.' });
@@ -178,7 +198,8 @@ export function createGameController(store, renderer, soundManager, preferencesM
 
     try {
       // Load AI functions
-      aiFunctions = await loadAIFunctions(playerCount, spectator);
+      const { fns, warnings } = await loadAIFunctions(playerCount, spectator);
+      aiFunctions = fns;
 
       // Create game via engine
       const gameState = createGame({
@@ -195,6 +216,7 @@ export function createGameController(store, renderer, soundManager, preferencesM
         animationPhase: 'idle',
         awaitingInput: null,
         humanEliminated: false,
+        aiLoadWarnings: warnings,
       });
 
       // Draw the map in the renderer

--- a/src/controller/GameController.js
+++ b/src/controller/GameController.js
@@ -18,7 +18,28 @@ import {
 import { runAI } from '../engine/AIAdapter.js';
 import { getAIImplementation } from '../ai/aiConfig.js';
 import { createReplayFromState } from '../arena/replayFormat.js';
+import { loadCommunityBot } from '../arena/communityBots.js';
+import { adaptModernBot } from '../arena/modernBotAdapter.js';
 import { resolveMapSize } from '../utils/config.js';
+
+/** Prefix marking a per-slot assignment id as a curated community bot. */
+const COMMUNITY_PREFIX = 'community:';
+
+/**
+ * Resolve a single per-slot assignment id to an engine-callable AI function.
+ * Community ids (prefixed `community:`) are compiled and reverse-adapted so the
+ * in-game loop can drive them; everything else is a built-in strategy id.
+ *
+ * @param {string} aiId
+ * @returns {Promise<Function>}
+ */
+async function resolveAIFunction(aiId) {
+  if (aiId.startsWith(COMMUNITY_PREFIX)) {
+    const communityId = aiId.slice(COMMUNITY_PREFIX.length);
+    return adaptModernBot(loadCommunityBot(communityId), aiId);
+  }
+  return getAIImplementation(aiId);
+}
 
 /**
  * Create a game controller.
@@ -60,7 +81,7 @@ export function createGameController(store, renderer, soundManager, preferencesM
         fns.push(null); // human
       } else {
         try {
-          fns.push(await getAIImplementation(aiId));
+          fns.push(await resolveAIFunction(aiId));
         } catch (err) {
           console.error(
             `Failed to load AI "${aiId}" for player ${i}, falling back to ai_default:`,

--- a/src/engine/AIAdapter.js
+++ b/src/engine/AIAdapter.js
@@ -95,13 +95,42 @@ export function createLegacyGameView(state) {
 
 /**
  * Run a single AI decision step.
- * Creates a legacy view, calls the AI, extracts the chosen move.
+ *
+ * Two calling conventions are supported:
+ * - Legacy AIs (the built-in strategies): called with a mutable legacy game
+ *   view; they set `area_from`/`area_to` and return 0 to end their turn.
+ * - Modern bots (arena/community bots wrapped by `adaptModernBot`, marked with
+ *   `__modernBot`): called with the engine state directly and return
+ *   `{ from, to } | null`. The wrapper sanitizes state into a BotState, so the
+ *   engine never hands raw state to untrusted bot code.
  *
  * @param {import('./types.js').GameState} state
- * @param {Function} aiFunction - Legacy AI function (game → void|0)
+ * @param {Function} aiFunction - Legacy AI function (game → void|0) or a modern
+ *   bot tagged `__modernBot` (state → { from, to } | null)
  * @returns {{ from: number, to: number } | null} Move or null to end turn
  */
 export function runAI(state, aiFunction) {
+  // Modern bots take the engine state directly and return a move.
+  if (aiFunction && aiFunction.__modernBot) {
+    let move;
+    try {
+      move = aiFunction(state);
+    } catch (err) {
+      const playerId = state.turnOrder[state.currentPlayerIndex];
+      /*
+       * The adapter already catches the bot's own throws; reaching here means
+       * the adapter/sanitization layer failed — surface it as an adapter bug.
+       */
+      throw new Error(`Modern bot adapter error for player ${playerId}: ${err.message}`, {
+        cause: err,
+      });
+    }
+    if (move && typeof move.from === 'number' && typeof move.to === 'number') {
+      if (move.from > 0 && move.to > 0) return { from: move.from, to: move.to };
+    }
+    return null;
+  }
+
   const view = createLegacyGameView(state);
   let result;
   try {

--- a/src/engine/AIAdapter.js
+++ b/src/engine/AIAdapter.js
@@ -101,8 +101,12 @@ export function createLegacyGameView(state) {
  *   view; they set `area_from`/`area_to` and return 0 to end their turn.
  * - Modern bots (arena/community bots wrapped by `adaptModernBot`, marked with
  *   `__modernBot`): called with the engine state directly and return
- *   `{ from, to } | null`. The wrapper sanitizes state into a BotState, so the
- *   engine never hands raw state to untrusted bot code.
+ *   `{ from, to } | null`. `runAI` passes the raw state to the wrapper, and the
+ *   wrapper (from `adaptModernBot`) sanitizes it into a BotState before invoking
+ *   the real bot — so the untrusted bot code only ever sees the sanitized
+ *   BotState, never raw engine state. A `__modernBot` function MUST come from
+ *   `adaptModernBot`; that is what makes a throw here an adapter bug, not a
+ *   bot bug (the wrapper already swallows the bot's own throws).
  *
  * @param {import('./types.js').GameState} state
  * @param {Function} aiFunction - Legacy AI function (game → void|0) or a modern
@@ -127,6 +131,18 @@ export function runAI(state, aiFunction) {
     }
     if (move && typeof move.from === 'number' && typeof move.to === 'number') {
       if (move.from > 0 && move.to > 0) return { from: move.from, to: move.to };
+      /*
+       * { from: 0, to: 0 } is a conventional "no move" sentinel (area 0 is
+       * unused). Any other non-positive/NaN pair is a bot bug, so warn rather
+       * than silently ending the turn — consistent with the legacy path below.
+       */
+      if (!(move.from === 0 && move.to === 0)) {
+        const playerId = state.turnOrder[state.currentPlayerIndex];
+        console.warn(
+          `Modern bot for player ${playerId} returned an out-of-range move ` +
+            `(from=${move.from}, to=${move.to}). Treating as end turn.`
+        );
+      }
     }
     return null;
   }

--- a/src/store/GameStore.js
+++ b/src/store/GameStore.js
@@ -26,6 +26,8 @@
  * @property {number} aiSpeed
  * @property {boolean} soundEnabled
  * @property {string | null} error
+ * @property {string[]} aiLoadWarnings - Per-slot notices when a chosen bot
+ *   failed to load and was replaced by the default AI (shown on map preview).
  * @property {Object} config
  * @property {Object | null} currentReplay
  */
@@ -43,6 +45,7 @@ const DEFAULT_STATE = {
   aiSpeed: 1,
   soundEnabled: true,
   error: null,
+  aiLoadWarnings: [],
   currentReplay: null,
   replayOrigin: null,
   focusedAreaId: null,

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -111,6 +111,7 @@ export function App({ store, controller, preferencesManager }) {
       <ErrorBoundary>
         {settings}
         <MapPreview
+          store={store}
           onAccept={() => controller.acceptMap()}
           onReject={() => controller.rejectMap()}
         />

--- a/src/ui/MapPreview.jsx
+++ b/src/ui/MapPreview.jsx
@@ -6,7 +6,30 @@
  * @module ui/MapPreview
  */
 
+import { useGameStore } from './hooks/useGameStore.js';
+
 const STYLE = {
+  warnings: {
+    position: 'absolute',
+    bottom: '140px',
+    left: 0,
+    right: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: '0.25rem',
+    pointerEvents: 'none',
+  },
+  warning: {
+    fontFamily: 'sans-serif',
+    fontSize: '0.95rem',
+    color: 'var(--ui-text)',
+    background: 'rgba(0,0,0,0.6)',
+    padding: '0.35rem 0.75rem',
+    borderRadius: '6px',
+    borderLeft: '3px solid var(--ui-accent)',
+    maxWidth: '90%',
+  },
   overlay: {
     position: 'absolute',
     bottom: '80px',
@@ -46,19 +69,33 @@ const STYLE = {
 
 /**
  * @param {Object} props
+ * @param {Object} props.store - GameStore, used to surface bot-load notices
  * @param {() => void} props.onAccept
  * @param {() => void} props.onReject
  */
-export function MapPreview({ onAccept, onReject }) {
+export function MapPreview({ store, onAccept, onReject }) {
+  const warnings = useGameStore(store, s => s.aiLoadWarnings);
+
   return (
-    <div style={STYLE.overlay}>
-      <span style={STYLE.label}>Play this board?</span>
-      <button style={{ ...STYLE.btn, ...STYLE.yes }} onClick={onAccept}>
-        YES
-      </button>
-      <button style={{ ...STYLE.btn, ...STYLE.no }} onClick={onReject}>
-        NO
-      </button>
-    </div>
+    <>
+      {warnings && warnings.length > 0 && (
+        <div style={STYLE.warnings} role="alert">
+          {warnings.map(message => (
+            <div key={message} style={STYLE.warning}>
+              ⚠ {message}
+            </div>
+          ))}
+        </div>
+      )}
+      <div style={STYLE.overlay}>
+        <span style={STYLE.label}>Play this board?</span>
+        <button style={{ ...STYLE.btn, ...STYLE.yes }} onClick={onAccept}>
+          YES
+        </button>
+        <button style={{ ...STYLE.btn, ...STYLE.no }} onClick={onReject}>
+          NO
+        </button>
+      </div>
+    </>
   );
 }

--- a/src/ui/TitleScreen.jsx
+++ b/src/ui/TitleScreen.jsx
@@ -10,6 +10,7 @@
 import { useState } from 'preact/hooks';
 import { DEFAULT_MAP_SIZE } from '../utils/config.js';
 import { getAllAIStrategies } from '../ai/aiConfig.js';
+import { getCommunityBotList } from '../arena/communityBots.js';
 
 /**
  * Map-size options shown on the title screen. `value` keys must match
@@ -24,6 +25,13 @@ const MAP_SIZE_OPTIONS = [
 
 /** Built-in AI strategies offered in the per-slot bot picker. */
 const AI_OPTIONS = getAllAIStrategies();
+
+/*
+ * Curated community bots offered alongside the built-ins. Their option values
+ * are namespaced with `community:` so the controller can tell them apart from
+ * built-in `ai_*` ids and route them through the modern-bot adapter.
+ */
+const COMMUNITY_OPTIONS = getCommunityBotList();
 
 const STYLE = {
   container: {
@@ -291,11 +299,22 @@ export function TitleScreen({ store, error, onStart, onArena, onTournament, onLe
                   value={assignments[i] || 'ai_default'}
                   onChange={e => handleAssign(i, e.target.value)}
                 >
-                  {AI_OPTIONS.map(ai => (
-                    <option key={ai.id} value={ai.id}>
-                      {ai.name}
-                    </option>
-                  ))}
+                  <optgroup label="Built-in">
+                    {AI_OPTIONS.map(ai => (
+                      <option key={ai.id} value={ai.id}>
+                        {ai.name}
+                      </option>
+                    ))}
+                  </optgroup>
+                  {COMMUNITY_OPTIONS.length > 0 && (
+                    <optgroup label="Community">
+                      {COMMUNITY_OPTIONS.map(bot => (
+                        <option key={bot.id} value={`community:${bot.id}`}>
+                          {bot.name}
+                        </option>
+                      ))}
+                    </optgroup>
+                  )}
                 </select>
               )}
             </div>

--- a/tests/arena/communityBots.test.js
+++ b/tests/arena/communityBots.test.js
@@ -67,7 +67,12 @@ describe('community bot in the in-game loop (end-to-end)', () => {
     const state = createGame({ seed: 9, playerCount: 4 });
     const next = runFullAITurn(state, aiFn);
 
-    // The turn completes and advances the game (END_TURN at minimum).
+    /*
+     * Smoke test only: a real compiled community bot drives a full turn through
+     * the adapter + engine and the turn closes (END_TURN always grows history).
+     * That a modern move actually reaches engine state is proven deterministically
+     * in modernBotAdapter.test.js — a real bot may legitimately pass on this seed.
+     */
     expect(next).toBeDefined();
     expect(next.history.length).toBeGreaterThan(state.history.length);
   });

--- a/tests/arena/communityBots.test.js
+++ b/tests/arena/communityBots.test.js
@@ -1,0 +1,74 @@
+/**
+ * Community bot loader tests
+ *
+ * Verifies the curated registry is bundled and surfaced to the app: metadata
+ * for the picker, and lazily-compiled bot functions for play.
+ */
+
+import { getCommunityBotList, loadCommunityBot } from '../../src/arena/communityBots.js';
+import { adaptModernBot } from '../../src/arena/modernBotAdapter.js';
+import { runFullAITurn } from '../../src/engine/AIAdapter.js';
+import { createGame } from '../../src/engine/GameRunner.js';
+import { createBotState } from '../../src/arena/botState.js';
+
+describe('getCommunityBotList', () => {
+  it('returns metadata for the active registry bots', () => {
+    const list = getCommunityBotList();
+    expect(Array.isArray(list)).toBe(true);
+    expect(list.length).toBeGreaterThanOrEqual(3);
+
+    for (const bot of list) {
+      expect(typeof bot.id).toBe('string');
+      expect(typeof bot.name).toBe('string');
+      expect(bot.id.length).toBeGreaterThan(0);
+      expect(bot.name.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('includes the known curated bots', () => {
+    const ids = getCommunityBotList().map(b => b.id);
+    expect(ids).toContain('bigintersmind/connector');
+    expect(ids).toContain('bigintersmind/blitz');
+    expect(ids).toContain('bigintersmind/giant-slayer');
+  });
+});
+
+describe('loadCommunityBot', () => {
+  it('compiles a bot into a callable modern function that returns a move or null', () => {
+    const fn = loadCommunityBot('bigintersmind/connector');
+    expect(typeof fn).toBe('function');
+
+    const state = createGame({ seed: 7, playerCount: 4 });
+    const playerId = state.turnOrder[state.currentPlayerIndex];
+    const move = fn(createBotState(state, playerId));
+
+    if (move !== null) {
+      expect(typeof move.from).toBe('number');
+      expect(typeof move.to).toBe('number');
+    }
+  });
+
+  it('memoizes the compiled function (same reference on repeat)', () => {
+    const a = loadCommunityBot('bigintersmind/blitz');
+    const b = loadCommunityBot('bigintersmind/blitz');
+    expect(a).toBe(b);
+  });
+
+  it('throws on an unknown id', () => {
+    expect(() => loadCommunityBot('nobody/does-not-exist')).toThrow(/Unknown community bot/);
+  });
+});
+
+describe('community bot in the in-game loop (end-to-end)', () => {
+  it('plays a full turn through the modern adapter + engine without throwing', () => {
+    const aiFn = adaptModernBot(loadCommunityBot('bigintersmind/connector'), 'Connector');
+    expect(aiFn.__modernBot).toBe(true);
+
+    const state = createGame({ seed: 9, playerCount: 4 });
+    const next = runFullAITurn(state, aiFn);
+
+    // The turn completes and advances the game (END_TURN at minimum).
+    expect(next).toBeDefined();
+    expect(next.history.length).toBeGreaterThan(state.history.length);
+  });
+});

--- a/tests/arena/modernBotAdapter.test.js
+++ b/tests/arena/modernBotAdapter.test.js
@@ -6,7 +6,9 @@
  */
 
 import { adaptModernBot } from '../../src/arena/modernBotAdapter.js';
-import { runAI } from '../../src/engine/AIAdapter.js';
+import { runAI, runFullAITurn } from '../../src/engine/AIAdapter.js';
+import { getValidMoves } from '../../src/engine/StateManager.js';
+import { ACTION_TYPES } from '../../src/engine/constants.js';
 import { createGame } from '../../src/engine/GameRunner.js';
 
 describe('adaptModernBot', () => {
@@ -79,5 +81,36 @@ describe('runAI routing for modern bots', () => {
     const state = createGame({ seed: 3, playerCount: 2 });
     const wrapped = adaptModernBot(() => ({ from: 0, to: 0 }));
     expect(runAI(state, wrapped)).toBeNull();
+  });
+
+  it('warns but ends the turn on an out-of-range move (not the {0,0} sentinel)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const state = createGame({ seed: 3, playerCount: 2 });
+    const wrapped = adaptModernBot(() => ({ from: 5, to: 0 }));
+    expect(runAI(state, wrapped)).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('out-of-range'));
+    warnSpy.mockRestore();
+  });
+});
+
+describe('modern bot move application (end-to-end through the engine)', () => {
+  it("applies the wrapped bot's chosen move to engine state, not just END_TURN", () => {
+    const state = createGame({ seed: 9, playerCount: 4 });
+    const validMoves = getValidMoves(state);
+    expect(validMoves.length).toBeGreaterThan(0); // sanity: the board has moves
+
+    /*
+     * A deterministic bot that plays a known-legal attack — proves the move
+     * survives the full adapter → runAI → applyAction chain (Connector may
+     * legitimately pass on a given seed, which is why we don't rely on it here).
+     */
+    const chosen = validMoves[0];
+    const wrapped = adaptModernBot(() => ({ from: chosen.from, to: chosen.to }), 'stub');
+
+    const next = runFullAITurn(state, wrapped);
+
+    const attacks = next.history.filter(h => h.type === ACTION_TYPES.ATTACK);
+    expect(attacks.length).toBeGreaterThan(0); // a real move landed, not only END_TURN
+    expect(attacks[0]).toMatchObject({ from: chosen.from, to: chosen.to });
   });
 });

--- a/tests/arena/modernBotAdapter.test.js
+++ b/tests/arena/modernBotAdapter.test.js
@@ -1,0 +1,83 @@
+/**
+ * Modern bot adapter tests
+ *
+ * The reverse of legacyBotAdapter: wraps a modern `(BotState) => {from,to}|null`
+ * bot so the in-game `runAI(state, fn)` loop can drive it.
+ */
+
+import { adaptModernBot } from '../../src/arena/modernBotAdapter.js';
+import { runAI } from '../../src/engine/AIAdapter.js';
+import { createGame } from '../../src/engine/GameRunner.js';
+
+describe('adaptModernBot', () => {
+  it('tags the wrapped function as a modern bot and preserves the name', () => {
+    const wrapped = adaptModernBot(() => null, 'my_bot');
+    expect(wrapped.__modernBot).toBe(true);
+    expect(wrapped.name).toBe('my_bot');
+  });
+
+  it('builds a BotState for the current player and returns its move', () => {
+    const state = createGame({ seed: 11, playerCount: 4 });
+    const expectedPlayer = state.turnOrder[state.currentPlayerIndex];
+
+    let seenPlayer = null;
+    const wrapped = adaptModernBot(botState => {
+      seenPlayer = botState.myPlayer;
+      // BotState must be the sanitized arena projection, not a legacy view.
+      expect(Array.isArray(botState.allAreas)).toBe(true);
+      expect(typeof botState.turnNumber).toBe('number');
+      return { from: 5, to: 6 };
+    }, 'probe');
+
+    const move = wrapped(state);
+    expect(seenPlayer).toBe(expectedPlayer);
+    expect(move).toEqual({ from: 5, to: 6 });
+  });
+
+  it('returns null when the bot returns null (ends turn)', () => {
+    const state = createGame({ seed: 11, playerCount: 2 });
+    const wrapped = adaptModernBot(() => null);
+    expect(wrapped(state)).toBeNull();
+  });
+
+  it('returns null and does not throw when the bot throws', () => {
+    const state = createGame({ seed: 11, playerCount: 2 });
+    const wrapped = adaptModernBot(() => {
+      throw new Error('boom');
+    }, 'thrower');
+    expect(wrapped(state)).toBeNull();
+  });
+
+  it('returns null for a malformed move', () => {
+    const state = createGame({ seed: 11, playerCount: 2 });
+    const wrapped = adaptModernBot(() => ({ from: 'x' }));
+    expect(wrapped(state)).toBeNull();
+  });
+});
+
+describe('runAI routing for modern bots', () => {
+  it('calls a __modernBot function with engine state (not a legacy view)', () => {
+    const state = createGame({ seed: 3, playerCount: 3 });
+
+    let argued = null;
+    const wrapped = adaptModernBot(botState => {
+      argued = botState;
+      return { from: 2, to: 3 };
+    });
+
+    const move = runAI(state, wrapped);
+    /*
+     * The bot receives a sanitized BotState (has myPlayer/turnNumber), not the
+     * legacy mutable view (which has adat/jun/get_pn).
+     */
+    expect(argued).toHaveProperty('myPlayer');
+    expect(argued.get_pn).toBeUndefined();
+    expect(move).toEqual({ from: 2, to: 3 });
+  });
+
+  it('treats a non-positive move as end-of-turn', () => {
+    const state = createGame({ seed: 3, playerCount: 2 });
+    const wrapped = adaptModernBot(() => ({ from: 0, to: 0 }));
+    expect(runAI(state, wrapped)).toBeNull();
+  });
+});

--- a/tests/controller/GameController.test.js
+++ b/tests/controller/GameController.test.js
@@ -84,6 +84,20 @@ vi.mock('../../src/ai/aiConfig.js', () => ({
   }),
 }));
 
+vi.mock('../../src/arena/communityBots.js', () => ({
+  getCommunityBotList: vi.fn(() => []),
+  loadCommunityBot: vi.fn(() => vi.fn(() => null)), // compiled modern bot stub
+}));
+
+vi.mock('../../src/arena/modernBotAdapter.js', () => ({
+  adaptModernBot: vi.fn((fn, name) => {
+    const wrapped = () => fn();
+    wrapped.__modernBot = true;
+    wrapped.botLabel = name;
+    return wrapped;
+  }),
+}));
+
 vi.mock('../../src/utils/config.js', () => ({
   // Mirror the real preset table so assertions on dimensions are meaningful.
   resolveMapSize: vi.fn(size => {
@@ -218,6 +232,24 @@ describe('GameController', () => {
       await controller.startNewGame({ playerCount: 2, spectator: false });
 
       expect(store.getState().config.aiAssignments).toEqual(before);
+    });
+
+    it('resolves a community: assignment through the loader + modern adapter', async () => {
+      const { loadCommunityBot } = await import('../../src/arena/communityBots.js');
+      const { adaptModernBot } = await import('../../src/arena/modernBotAdapter.js');
+
+      await controller.startNewGame({
+        playerCount: 3,
+        spectator: false,
+        aiAssignments: [null, 'community:bigintersmind/connector', 'ai_default'],
+      });
+
+      // The `community:` prefix is stripped before lookup, then reverse-adapted.
+      expect(loadCommunityBot).toHaveBeenCalledWith('bigintersmind/connector');
+      expect(adaptModernBot).toHaveBeenCalledWith(
+        expect.any(Function),
+        'community:bigintersmind/connector'
+      );
     });
 
     it('resets to title screen on createGame failure', async () => {

--- a/tests/controller/GameController.test.js
+++ b/tests/controller/GameController.test.js
@@ -90,10 +90,11 @@ vi.mock('../../src/arena/communityBots.js', () => ({
 }));
 
 vi.mock('../../src/arena/modernBotAdapter.js', () => ({
+  // Mirror the real adapter's shape: tag __modernBot and set the function name.
   adaptModernBot: vi.fn((fn, name) => {
     const wrapped = () => fn();
     wrapped.__modernBot = true;
-    wrapped.botLabel = name;
+    Object.defineProperty(wrapped, 'name', { value: name });
     return wrapped;
   }),
 }));
@@ -250,6 +251,29 @@ describe('GameController', () => {
         expect.any(Function),
         'community:bigintersmind/connector'
       );
+    });
+
+    it('falls back to ai_default and surfaces a notice when a community bot fails to load', async () => {
+      const { loadCommunityBot } = await import('../../src/arena/communityBots.js');
+      const { getAIImplementation } = await import('../../src/ai/aiConfig.js');
+      loadCommunityBot.mockImplementationOnce(() => {
+        throw new Error('compile failed');
+      });
+
+      await controller.startNewGame({
+        playerCount: 3,
+        spectator: false,
+        aiAssignments: [null, 'community:broken/bot', 'ai_default'],
+      });
+
+      // The game still starts (fallback succeeded), not a crash back to title.
+      expect(store.getState().screen).toBe('mapPreview');
+      expect(getAIImplementation).toHaveBeenCalledWith('ai_default');
+
+      // The player's discarded choice is surfaced, not silently swapped.
+      const warnings = store.getState().aiLoadWarnings;
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('broken/bot');
     });
 
     it('resets to title screen on createGame failure', async () => {

--- a/tests/engine/AIAdapter.test.js
+++ b/tests/engine/AIAdapter.test.js
@@ -150,6 +150,43 @@ describe('runAI', () => {
   });
 });
 
+describe('runAI modern-bot routing', () => {
+  it('calls a __modernBot function with engine state and returns its move', () => {
+    const state = createTestState();
+    let receivedState = null;
+    const modernBot = s => {
+      receivedState = s;
+      return { from: 4, to: 5 };
+    };
+    modernBot.__modernBot = true;
+
+    const move = runAI(state, modernBot);
+    // Modern bots receive the engine state directly (not a legacy view).
+    expect(receivedState).toBe(state);
+    expect(move).toEqual({ from: 4, to: 5 });
+  });
+
+  it('treats a null / non-positive modern move as end-of-turn', () => {
+    const state = createTestState();
+    const endTurn = () => null;
+    endTurn.__modernBot = true;
+    expect(runAI(state, endTurn)).toBeNull();
+
+    const zeroMove = () => ({ from: 0, to: 0 });
+    zeroMove.__modernBot = true;
+    expect(runAI(state, zeroMove)).toBeNull();
+  });
+
+  it('re-throws a modern adapter failure as an adapter error', () => {
+    const state = createTestState();
+    const broken = () => {
+      throw new Error('sanitize failed');
+    };
+    broken.__modernBot = true;
+    expect(() => runAI(state, broken)).toThrow('Modern bot adapter error');
+  });
+});
+
 describe('runFullAITurn', () => {
   it('completes a full turn and advances to next player', () => {
     const state = createTestState();

--- a/tests/ui/MapPreview.test.js
+++ b/tests/ui/MapPreview.test.js
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+/**
+ * MapPreview tests
+ *
+ * Covers the "Play this board?" gate and the bot-load notice banner that warns,
+ * before the player commits to the board, when a chosen community bot failed to
+ * load and was replaced by the default AI.
+ */
+
+import { h, render } from 'preact';
+import { act } from 'preact/test-utils';
+import { MapPreview } from '../../src/ui/MapPreview.jsx';
+import { createGameStore } from '../../src/store/GameStore.js';
+
+let container;
+
+function renderPreview(overrides = {}) {
+  const store = createGameStore(overrides);
+  const onAccept = vi.fn();
+  const onReject = vi.fn();
+
+  container = document.createElement('div');
+  document.body.appendChild(container);
+
+  act(() => {
+    render(h(MapPreview, { store, onAccept, onReject }), container);
+  });
+
+  return { store, onAccept, onReject };
+}
+
+afterEach(() => {
+  if (container) {
+    act(() => render(null, container));
+    if (container.parentNode) document.body.removeChild(container);
+    container = null;
+  }
+});
+
+describe('MapPreview', () => {
+  it('shows the YES/NO gate and no alert banner by default', () => {
+    renderPreview();
+    expect(container.textContent).toContain('Play this board?');
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('surfaces aiLoadWarnings as an alert banner so the fallback is not silent', () => {
+    const message =
+      'Player 2: community bot "broken/bot" could not load — using Default AI instead.';
+    renderPreview({ aiLoadWarnings: [message] });
+
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert).toBeTruthy();
+    expect(alert.textContent).toContain('broken/bot');
+  });
+});

--- a/tests/ui/TitleScreen.test.js
+++ b/tests/ui/TitleScreen.test.js
@@ -162,5 +162,28 @@ describe('TitleScreen', () => {
       expect(spectator).toBe(true);
       expect(aiAssignments[1]).toBe('ai_lookahead');
     });
+
+    it('offers curated community bots in a "Community" optgroup', () => {
+      renderTitle();
+      act(() => customizeBtn().click());
+      const select = slotSelect(2);
+      const builtIn = select.querySelector('optgroup[label="Built-in"]');
+      const community = select.querySelector('optgroup[label="Community"]');
+      expect(builtIn).toBeTruthy();
+      expect(community).toBeTruthy();
+      const values = [...community.querySelectorAll('option')].map(o => o.value);
+      expect(values).toContain('community:bigintersmind/connector');
+      // Community option values are namespaced so the controller can route them.
+      expect(values.every(v => v.startsWith('community:'))).toBe(true);
+    });
+
+    it('threads a chosen community bot (namespaced id) into onStart', () => {
+      const { onStart } = renderTitle();
+      act(() => customizeBtn().click());
+      chooseBot(2, 'community:bigintersmind/connector');
+      act(() => startBtn().click());
+      const { aiAssignments } = onStart.mock.calls[0][0];
+      expect(aiAssignments[1]).toBe('community:bigintersmind/connector');
+    });
   });
 });


### PR DESCRIPTION
## What

Lets players choose the curated **community bots** (`community-bots/registry.json` — Connector, Blitz, Giant Slayer) as opponents in any AI slot via the Title Screen "Customize players" picker, and runs them through the in-game AI loop. Builds on #32 (per-slot bot selection).

Scope (confirmed): **bundled curated registry only** — bots are bundled at build time. No runtime fetch of remote code.

## Why it needed a reverse adapter

Community/arena bots are **modern-style** (`(BotState) => { from, to } | null`); the in-game loop drives **legacy-style** functions (`(view) => mutates area_from/area_to; return 0`) via `runAI`. `adaptLegacyBot` already covered legacy→modern for the arena — this adds the missing **reverse**.

Key correctness point: the adapter builds the `BotState` **straight from engine state using the same `createBotState` the arena uses**, rather than reconstructing it from the lossy in-game legacy view (which lacks `turnNumber`, pads the player array, and can't distinguish an eliminated player from a padding slot). That guarantees a bot behaves **identically in-game and in the arena**.

## Changes

- **`src/arena/modernBotAdapter.js`** (new) — `adaptModernBot(modernFn, name)` wraps a modern bot for the engine loop; builds `BotState` via `createBotState`, catches bot throws, tags itself `__modernBot`.
- **`src/engine/AIAdapter.js`** — `runAI` routes `__modernBot` functions by calling them with engine state (the adapter sanitizes); the legacy path is unchanged, and `runFullAITurn` inherits the support.
- **`src/arena/communityBots.js`** (new) — browser loader: bundles the registry + raw bot sources via `import.meta.glob(..., { query: '?raw' })` and compiles them with the existing `compileCustomBot`. `getCommunityBotList()` (metadata, no compile) + `loadCommunityBot(id)` (compiled, memoized).
- **`src/controller/GameController.js`** — `loadAIFunctions` resolves `community:<id>` slots through the loader + reverse adapter; built-ins and the `ai_default` fallback are unchanged.
- **`src/ui/TitleScreen.jsx`** — each AI-slot `<select>` now has **Built-in** and **Community** `<optgroup>`s; community values are namespaced `community:<id>`.
- **Docs** — `docs/BOT_GUIDE.md` + `README.md` note in-game play of community bots.

## Layering

The reverse adapter lives in `src/arena/` (not `src/ai/`) to avoid an `ai ↔ arena` cycle (`arena → ai` already exists). The engine never imports arena — `runAI` hands modern bots the raw state and the arena-owned adapter sanitizes it.

## Tests
- `tests/arena/modernBotAdapter.test.js` — adapter behavior + `runAI` routing.
- `tests/arena/communityBots.test.js` — loader metadata/compile/memoize + an **end-to-end turn** through the real engine.
- `tests/engine/AIAdapter.test.js` — `runAI` modern-bot routing (state passed, not a legacy view).
- `tests/controller/GameController.test.js` — community wiring in `loadAIFunctions`.
- `tests/ui/TitleScreen.test.js` — Community optgroup + namespaced id threaded into `onStart`.

## Verification
- Full suite **705 tests / 51 files pass**; `npm run lint` 0 errors; `npm run build` succeeds (community sources confirmed bundled into `dist/`).
- **Browser smoke (Playwright):** picked Connector ×2 (duplicate) + Blitz, started a 7-player game, ran a full AI round — board evolved (captures + an elimination) with **zero console errors/warnings**.

## Out of scope (follow-ups)
- Runtime GitHub-fetch / paste-your-own-bot in-app.
- Letting a community bot occupy slot 0 in AI-vs-AI.
- Persisting the chosen lineup; showing ELO/difficulty in the picker.