### PR TITLE
feat(ui): label Customize Players slots by player color

### DIFF
--- a/src/renderer/constants.js
+++ b/src/renderer/constants.js
@@ -30,6 +30,18 @@ export const PLAYER_COLORS_CSS = [
   '#ff5858',
 ];
 
+/** Human-readable names for each player color, indexed like PLAYER_COLORS. */
+export const PLAYER_COLOR_NAMES = [
+  'Purple',
+  'Lime',
+  'Green',
+  'Pink',
+  'Orange',
+  'Cyan',
+  'Yellow',
+  'Red',
+];
+
 /**
  * Color-blind safe player palette (Wong palette).
  * Designed to be distinguishable by users with color vision deficiencies.
@@ -83,6 +95,18 @@ export const COLORBLIND_PLAYER_COLORS_CSS = [
   '#56b4e9',
   '#d55e00',
   '#000000',
+];
+
+/** Human-readable names for the color-blind palette, indexed alike. */
+export const COLORBLIND_PLAYER_COLOR_NAMES = [
+  'Blue',
+  'Orange',
+  'Teal',
+  'Yellow',
+  'Pink',
+  'Sky blue',
+  'Vermillion',
+  'Black',
 ];
 
 /** Territory border color. */

--- a/src/renderer/constants.js
+++ b/src/renderer/constants.js
@@ -8,7 +8,7 @@
 
 /** Player color palette (indexed 0-7), matching the legacy game exactly. */
 export const PLAYER_COLORS = [
-  0xb37ffe, // 0: Purple
+  0xb37ffe, // 0: Lavender (light purple)
   0xb3ff01, // 1: Lime green
   0x009302, // 2: Dark green
   0xff7ffe, // 3: Magenta/pink
@@ -32,10 +32,10 @@ export const PLAYER_COLORS_CSS = [
 
 /** Human-readable names for each player color, indexed like PLAYER_COLORS. */
 export const PLAYER_COLOR_NAMES = [
-  'Purple',
+  'Lavender',
   'Lime',
   'Green',
-  'Pink',
+  'Magenta',
   'Orange',
   'Cyan',
   'Yellow',
@@ -63,7 +63,7 @@ export const COLORBLIND_PLAYER_COLORS = [
  * dark dice.
  */
 export const PLAYER_PIP_COLORS = [
-  0xffffff, // 0: Purple → white
+  0xffffff, // 0: Lavender → white
   0x000000, // 1: Lime green → black
   0xffffff, // 2: Dark green → white
   0xffffff, // 3: Magenta/pink → white

--- a/src/ui/TitleScreen.jsx
+++ b/src/ui/TitleScreen.jsx
@@ -223,9 +223,12 @@ export function TitleScreen({ store, error, onStart, onArena, onTournament, onLe
   const [playerCount, setPlayerCount] = useState(7);
   const [mapSize, setMapSize] = useState(DEFAULT_MAP_SIZE);
   const [showCustomize, setShowCustomize] = useState(false);
-  // Per-slot AI strategy IDs (index = player slot). Seeded from store defaults.
+  /*
+   * Per-slot AI strategy IDs (index = player slot). Seeded from store defaults.
+   * `store` is required (the useGameStore call above already depends on it).
+   */
   const [assignments, setAssignments] = useState(() =>
-    (store?.getState().config.aiAssignments ?? []).slice()
+    (store.getState().config.aiAssignments ?? []).slice()
   );
 
   const handleAssign = (slot, aiId) => {

--- a/src/ui/TitleScreen.jsx
+++ b/src/ui/TitleScreen.jsx
@@ -11,6 +11,13 @@ import { useState } from 'preact/hooks';
 import { DEFAULT_MAP_SIZE } from '../utils/config.js';
 import { getAllAIStrategies } from '../ai/aiConfig.js';
 import { getCommunityBotList } from '../arena/communityBots.js';
+import { useGameStore } from './hooks/useGameStore.js';
+import {
+  PLAYER_COLORS_CSS,
+  COLORBLIND_PLAYER_COLORS_CSS,
+  PLAYER_COLOR_NAMES,
+  COLORBLIND_PLAYER_COLOR_NAMES,
+} from '../renderer/constants.js';
 
 /**
  * Map-size options shown on the title screen. `value` keys must match
@@ -164,10 +171,22 @@ const STYLE = {
     justifyContent: 'space-between',
     gap: '0.8rem',
   },
+  slotIdentity: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0.5rem',
+  },
+  swatch: {
+    width: '14px',
+    height: '14px',
+    borderRadius: '3px',
+    border: '1px solid rgba(255, 255, 255, 0.3)',
+    flexShrink: 0,
+  },
   slotLabel: {
     fontFamily: 'Roboto, sans-serif',
     fontSize: '0.9rem',
-    color: 'var(--ui-text-muted)',
+    color: 'var(--ui-text)',
   },
   humanTag: {
     fontFamily: 'Roboto, sans-serif',
@@ -197,6 +216,10 @@ const STYLE = {
  * @param {() => void} [props.onLeaderboard] - Navigate to online leaderboard screen
  */
 export function TitleScreen({ store, error, onStart, onArena, onTournament, onLeaderboard }) {
+  const prefs = useGameStore(store, s => s.preferences);
+  const colorPalette = prefs?.colorBlindMode ? COLORBLIND_PLAYER_COLORS_CSS : PLAYER_COLORS_CSS;
+  const colorNames = prefs?.colorBlindMode ? COLORBLIND_PLAYER_COLOR_NAMES : PLAYER_COLOR_NAMES;
+
   const [playerCount, setPlayerCount] = useState(7);
   const [mapSize, setMapSize] = useState(DEFAULT_MAP_SIZE);
   const [showCustomize, setShowCustomize] = useState(false);
@@ -287,38 +310,46 @@ export function TitleScreen({ store, error, onStart, onArena, onTournament, onLe
 
       {showCustomize && (
         <div style={STYLE.customizePanel}>
-          {Array.from({ length: playerCount }, (_, i) => (
-            <div key={i} style={STYLE.slotRow}>
-              <span style={STYLE.slotLabel}>Player {i + 1}</span>
-              {i === 0 ? (
-                <span style={STYLE.humanTag}>You (human)</span>
-              ) : (
-                <select
-                  aria-label={`Bot for player ${i + 1}`}
-                  style={STYLE.select}
-                  value={assignments[i] || 'ai_default'}
-                  onChange={e => handleAssign(i, e.target.value)}
-                >
-                  <optgroup label="Built-in">
-                    {AI_OPTIONS.map(ai => (
-                      <option key={ai.id} value={ai.id}>
-                        {ai.name}
-                      </option>
-                    ))}
-                  </optgroup>
-                  {COMMUNITY_OPTIONS.length > 0 && (
-                    <optgroup label="Community">
-                      {COMMUNITY_OPTIONS.map(bot => (
-                        <option key={bot.id} value={`community:${bot.id}`}>
-                          {bot.name}
+          {Array.from({ length: playerCount }, (_, i) => {
+            const colorName = colorNames[i % colorNames.length];
+            return (
+              <div key={i} style={STYLE.slotRow}>
+                <span style={STYLE.slotIdentity}>
+                  <span
+                    style={{ ...STYLE.swatch, background: colorPalette[i % colorPalette.length] }}
+                  />
+                  <span style={STYLE.slotLabel}>{colorName}</span>
+                </span>
+                {i === 0 ? (
+                  <span style={STYLE.humanTag}>You (human)</span>
+                ) : (
+                  <select
+                    aria-label={`Bot for ${colorName} player`}
+                    style={STYLE.select}
+                    value={assignments[i] || 'ai_default'}
+                    onChange={e => handleAssign(i, e.target.value)}
+                  >
+                    <optgroup label="Built-in">
+                      {AI_OPTIONS.map(ai => (
+                        <option key={ai.id} value={ai.id}>
+                          {ai.name}
                         </option>
                       ))}
                     </optgroup>
-                  )}
-                </select>
-              )}
-            </div>
-          ))}
+                    {COMMUNITY_OPTIONS.length > 0 && (
+                      <optgroup label="Community">
+                        {COMMUNITY_OPTIONS.map(bot => (
+                          <option key={bot.id} value={`community:${bot.id}`}>
+                            {bot.name}
+                          </option>
+                        ))}
+                      </optgroup>
+                    )}
+                  </select>
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
 

--- a/tests/ui/TitleScreen.test.js
+++ b/tests/ui/TitleScreen.test.js
@@ -10,19 +10,23 @@ import { h, render } from 'preact';
 import { act } from 'preact/test-utils';
 import { TitleScreen } from '../../src/ui/TitleScreen.jsx';
 import { createGameStore } from '../../src/store/GameStore.js';
-import { PLAYER_COLOR_NAMES } from '../../src/renderer/constants.js';
+import {
+  PLAYER_COLOR_NAMES,
+  PLAYER_COLORS_CSS,
+  COLORBLIND_PLAYER_COLOR_NAMES,
+  COLORBLIND_PLAYER_COLORS_CSS,
+} from '../../src/renderer/constants.js';
 
 let container;
 
 function renderTitle(props = {}) {
-  const store = createGameStore();
-  const onStart = vi.fn();
+  const { store = createGameStore(), onStart = vi.fn(), ...rest } = props;
 
   container = document.createElement('div');
   document.body.appendChild(container);
 
   act(() => {
-    render(h(TitleScreen, { store, onStart, ...props }), container);
+    render(h(TitleScreen, { store, onStart, ...rest }), container);
   });
 
   return { store, onStart };
@@ -36,10 +40,31 @@ const aiBtn = () =>
   [...container.querySelectorAll('button')].find(b => b.textContent === 'AI vs AI');
 const customizeBtn = () =>
   [...container.querySelectorAll('button')].find(b => b.textContent.includes('Customize players'));
-// Slots are labelled by player color now; `n` stays the 1-indexed player number.
+/*
+ * Slots are labelled by player color now; `n` stays the 1-indexed player number.
+ * Assumes the default palette — color-blind-mode tests query by name directly.
+ */
 const slotSelect = n => {
   const colorName = PLAYER_COLOR_NAMES[(n - 1) % PLAYER_COLOR_NAMES.length];
   return container.querySelector(`select[aria-label="Bot for ${colorName} player"]`);
+};
+
+/*
+ * The slot swatch is a bare <span> with no test hook; identify it by its
+ * fixed 14×14 inline dimensions (see STYLE.swatch in TitleScreen.jsx).
+ */
+const slotSwatches = () =>
+  [...container.querySelectorAll('span')].filter(
+    s => s.style.width === '14px' && s.style.height === '14px'
+  );
+
+/*
+ * jsdom's CSSOM normalizes a hex `background` to the `rgb(r, g, b)` form, so
+ * compare swatch fills against the converted palette value.
+ */
+const cssHexToRgb = hex => {
+  const n = parseInt(hex.slice(1), 16);
+  return `rgb(${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255})`;
 };
 
 /** Set a native <select> value and fire the change event Preact listens for. */
@@ -128,6 +153,19 @@ describe('TitleScreen', () => {
       expect(container.textContent).toContain('You (human)');
     });
 
+    it('labels each slot with its in-game color name and a swatch', () => {
+      renderTitle();
+      act(() => customizeBtn().click());
+      // Default palette names for the first slots (human slot 0 + AI slots).
+      expect(container.textContent).toContain('Lavender'); // slot 0
+      expect(container.textContent).toContain('Lime'); // slot 1
+      expect(container.textContent).toContain('Green'); // slot 2
+      // One swatch per visible slot (7 players → 7 swatches).
+      expect(slotSwatches()).toHaveLength(7);
+      // Swatch fill matches the in-game player palette, by slot index.
+      expect(slotSwatches()[0].style.background).toBe(cssHexToRgb(PLAYER_COLORS_CSS[0]));
+    });
+
     it('resizes the slot list when the player count changes', () => {
       renderTitle();
       act(() => customizeBtn().click());
@@ -190,5 +228,51 @@ describe('TitleScreen', () => {
       const { aiAssignments } = onStart.mock.calls[0][0];
       expect(aiAssignments[1]).toBe('community:bigintersmind/connector');
     });
+  });
+
+  describe('color-blind mode', () => {
+    const cbStore = () => createGameStore({ preferences: { colorBlindMode: true } });
+
+    it('labels slots with the Wong palette names when color-blind mode is on', () => {
+      renderTitle({ store: cbStore() });
+      act(() => customizeBtn().click());
+      // index 0 → 'Blue' (Wong) instead of 'Lavender' (default).
+      expect(container.textContent).toContain('Blue');
+      expect(container.textContent).not.toContain('Lavender');
+    });
+
+    it('keys the slot dropdown aria-label off the color-blind color name', () => {
+      renderTitle({ store: cbStore() });
+      act(() => customizeBtn().click());
+      // index 2 → 'Teal' (Wong) instead of 'Green' (default).
+      expect(container.querySelector('select[aria-label="Bot for Teal player"]')).toBeTruthy();
+      expect(container.querySelector('select[aria-label="Bot for Green player"]')).toBeNull();
+    });
+
+    it('paints the swatches from the Wong palette in color-blind mode', () => {
+      renderTitle({ store: cbStore() });
+      act(() => customizeBtn().click());
+      expect(slotSwatches()[0].style.background).toBe(cssHexToRgb(COLORBLIND_PLAYER_COLORS_CSS[0]));
+    });
+
+    it('updates slot labels reactively when color-blind mode is toggled', () => {
+      const { store } = renderTitle();
+      act(() => customizeBtn().click());
+      // Default palette initially: slot 2 is 'Green'.
+      expect(container.querySelector('select[aria-label="Bot for Green player"]')).toBeTruthy();
+      // Flip the preference; the panel re-renders from the store subscription.
+      act(() =>
+        store.setState({ preferences: { ...store.getState().preferences, colorBlindMode: true } })
+      );
+      expect(container.querySelector('select[aria-label="Bot for Teal player"]')).toBeTruthy();
+      expect(container.querySelector('select[aria-label="Bot for Green player"]')).toBeNull();
+    });
+  });
+});
+
+describe('player color palettes', () => {
+  it('keeps the color-name arrays index-aligned with their palettes', () => {
+    expect(PLAYER_COLOR_NAMES).toHaveLength(PLAYER_COLORS_CSS.length);
+    expect(COLORBLIND_PLAYER_COLOR_NAMES).toHaveLength(COLORBLIND_PLAYER_COLORS_CSS.length);
   });
 });

--- a/tests/ui/TitleScreen.test.js
+++ b/tests/ui/TitleScreen.test.js
@@ -10,6 +10,7 @@ import { h, render } from 'preact';
 import { act } from 'preact/test-utils';
 import { TitleScreen } from '../../src/ui/TitleScreen.jsx';
 import { createGameStore } from '../../src/store/GameStore.js';
+import { PLAYER_COLOR_NAMES } from '../../src/renderer/constants.js';
 
 let container;
 
@@ -35,7 +36,11 @@ const aiBtn = () =>
   [...container.querySelectorAll('button')].find(b => b.textContent === 'AI vs AI');
 const customizeBtn = () =>
   [...container.querySelectorAll('button')].find(b => b.textContent.includes('Customize players'));
-const slotSelect = n => container.querySelector(`select[aria-label="Bot for player ${n}"]`);
+// Slots are labelled by player color now; `n` stays the 1-indexed player number.
+const slotSelect = n => {
+  const colorName = PLAYER_COLOR_NAMES[(n - 1) % PLAYER_COLOR_NAMES.length];
+  return container.querySelector(`select[aria-label="Bot for ${colorName} player"]`);
+};
 
 /** Set a native <select> value and fire the change event Preact listens for. */
 function chooseBot(playerNumber, aiId) {


### PR DESCRIPTION
## Summary

The **Customize players** dropdown labelled each slot "Player 1", "Player 2", etc. The player number tells you nothing about which bot ends up controlling which color on the board. This swaps the numeric label for a **color swatch + the color's name** (e.g. Purple, Lime, Red), so the lineup you pick maps directly to what you see in-game.

## Changes

- **`src/renderer/constants.js`** — added `PLAYER_COLOR_NAMES` and `COLORBLIND_PLAYER_COLOR_NAMES` next to the existing palettes so the names stay in sync with the colors.
- **`src/ui/TitleScreen.jsx`** — each slot now renders a color swatch (matching the in-game HUD swatch style) plus the color name. Reads `preferences` via `useGameStore`, so it honors **color-blind mode** (Wong palette + names) and updates reactively when toggled. The `<select>` `aria-label` is now `Bot for <Color> player` for screen readers.
- **`tests/ui/TitleScreen.test.js`** — `slotSelect` helper updated to locate dropdowns by the new color-based `aria-label` (still keyed by 1-indexed player number, so the test bodies are unchanged).

## Notes

- Index 1 (`0xb3ff01`, bright yellow-green) is named **"Lime"** and index 2 (`0x009302`, dark green) is **"Green"** to keep them distinct — easy one-line tweak in `PLAYER_COLOR_NAMES` if different wording is preferred.

## Test plan

- [x] `npx vitest run tests/ui/TitleScreen.test.js` — 15 passed
- [x] `npm run lint` clean on changed files