### PR TITLE
fix(ai): break strategist's all-8s endgame turtle with bank-aware aggression

### DIFF
--- a/src/ai/ai_strategist.js
+++ b/src/ai/ai_strategist.js
@@ -25,6 +25,16 @@
  * - Press harder when dominant or in a winning heads-up endgame
  * - Demand higher-EV attacks when weak
  *
+ * Bank-aware endgame aggression breaks all-8s stalemates. The cost of losing an
+ * attack — burned dice and a weakened source — is largely an illusion when the
+ * player holds a reinforcement reserve, because that reserve plus its income
+ * refills the holes at the end of the same turn, before any opponent can act. So
+ * once the field narrows to a few players, an attack's refundable cost is
+ * discounted by how completely the reserve will patch it, and a player trailing
+ * the leader with a real reserve will spend it chipping the leader down rather
+ * than turtling into a slow loss. (Kept to the endgame on purpose: with many
+ * players alive, patient play is stronger and the arena confirms it.)
+ *
  * Fully deterministic: no randomness; ties break toward the lowest area index.
  */
 
@@ -50,6 +60,14 @@ const OFF_TARGET_PENALTY = 0.15; // attacking minor players while a leader runs 
 const DOMINANCE_SHARE = 0.4; // dice share that marks a player as dominant
 const BASE_THRESHOLD = 0.05; // minimum EV to bother attacking
 const PRESS_THRESHOLD = -0.6; // accept negative-EV attacks to close out a win
+
+// --- Bank-aware aggression & trailing-leader disruption ---
+const ENDGAME_PLAYERS = 3; // unlock bank-aware aggression only once the field narrows to this many
+const REFILL_EFFICIENCY = 0.85; // fraction of an attack's refundable cost the reserve neutralizes
+const DISRUPT_MIN_BANK = MAX_DICE; // banked dice before gunning for the leader at a loss (~one full stack)
+const DISRUPT_MIN_P = 0.4; // only swing at the leader on coin-flip-or-better odds (8v8 = 0.471)
+const DISRUPT_BONUS = 0.6; // extra pull toward the leader when trailing with a reserve to spend
+const DISRUPT_THRESHOLD = -0.8; // accept a moderately negative swing at the leader to break a stalemate
 
 export const ai_strategist = game => {
   const pn = game.get_pn();
@@ -200,6 +218,16 @@ export const ai_strategist = game => {
   const myShare = totalDice > 0 ? diceByPlayer[pn] / totalDice : 0;
   const bestRivalDice = Math.max(...diceByPlayer.map((d, i) => (i === pn ? 0 : d)));
 
+  // Strongest rival by dice — the "leader" for anti-runaway and trailing disruption.
+  let leader = -1;
+  let leaderDice = -1;
+  for (let i = 0; i < pmax; i++) {
+    if (i !== pn && areasByPlayer[i] > 0 && diceByPlayer[i] > leaderDice) {
+      leaderDice = diceByPlayer[i];
+      leader = i;
+    }
+  }
+
   let threshold = BASE_THRESHOLD;
   if (myShare > 0.38 || (activePlayers === 2 && diceByPlayer[pn] > bestRivalDice)) {
     // Winning position: keep the pressure on rather than stalling
@@ -209,14 +237,41 @@ export const ai_strategist = game => {
     threshold = BASE_THRESHOLD + 0.15;
   }
 
-  // Reinforcements arriving at end of turn soften end-of-turn exposure
+  /*
+   * Bank-aware aggression. `stock` is the player's banked reinforcements; each
+   * end of turn it also earns income equal to its largest connected group. Both
+   * pour into the player's non-maxed cells at the END of this turn — before any
+   * opponent moves — so the holes an attack opens (a weakened source, a freshly
+   * taken cell) are largely refilled before they can be punished. A player
+   * sitting on a full board with a big reserve is effectively wasting income
+   * every turn it does not attack (the reserve caps out), which is exactly what
+   * freezes an all-8s board into a turtling stalemate.
+   */
   const stock = game.player[pn] ? game.player[pn].stock || 0 : 0;
-  const riskRelief = 1 / (1 + 0.04 * Math.min(stock, 16));
+  const refillPool = stock + myLargestGroup;
+  let myVacancy = 0;
+  for (let i = 1; i < AREA_MAX; i++) {
+    if (exists(i) && adat[i].arm === pn) myVacancy += MAX_DICE - adat[i].dice;
+  }
+  /*
+   * Only relax into bank-aware aggression in the endgame. With many players
+   * still alive, patient play is genuinely strong — let rivals spend themselves
+   * fighting. Once the field narrows, turtling at all-8s just hands a slow win to
+   * the leader, so this is where spending the reserve to break the stalemate (and
+   * to chip the leader) pays off. ENDGAME_PLAYERS gates both behaviors.
+   */
+  const endgame = activePlayers <= ENDGAME_PLAYERS;
+  const iAmTrailing = leader >= 0 && leaderDice > diceByPlayer[pn];
+  const disruptActive = endgame && iAmTrailing && stock >= DISRUPT_MIN_BANK;
 
   // --- Evaluate every legal attack ---
   let bestFrom = -1;
   let bestTo = -1;
   let bestScore = -Infinity;
+  // Best coin-flip-or-better swing aimed at the leader (the disruption fallback).
+  let bestLeaderFrom = -1;
+  let bestLeaderTo = -1;
+  let bestLeaderScore = -Infinity;
 
   for (let from = 1; from < AREA_MAX; from++) {
     if (!exists(from)) continue;
@@ -244,19 +299,37 @@ export const ai_strategist = game => {
         if (defender.arm === dominantPlayer) gains += GANG_UP_BONUS;
         else gains -= OFF_TARGET_PENALTY;
       }
+      // Trailing the leader with a reserve: extra pull toward chipping it down.
+      if (disruptActive && defender.arm === leader) gains += DISRUPT_BONUS;
 
       /*
-       * Discount gains by the chance the conquered cell is retaken (it will
-       * hold a-1 dice), and charge for leaving the source cell at 1 die —
-       * including the income I lose if a chokepoint source then falls.
+       * Refill discount: the fraction of the holes this attack opens that my
+       * reserve + income will patch this end of turn, before opponents act.
+       * `myVacancy` already reflects holes opened by earlier attacks this turn,
+       * so the discount fades as I spend down — I press while banked, then
+       * fortify once the reserve can no longer cover another swing.
+       */
+      const refillFactor =
+        !endgame || refillPool <= 0
+          ? 0
+          : Math.min(1, refillPool / Math.max(1, myVacancy + (a - 1)));
+      const refund = REFILL_EFFICIENCY * refillFactor;
+
+      /*
+       * Discount gains by the chance the conquered cell is retaken — but it is
+       * topped back up toward MAX_DICE by the refill before opponents move — and
+       * charge for leaving the source at 1 die (plus the income lost if a
+       * chokepoint source falls), net of the refill that patches it first.
        */
       const fromStake = EXPOSURE_WEIGHT + INCOME_WEIGHT * 0.5 * incomeLossIfCaptured(from);
-      const recaptureP = captureThreat(to, Math.max(1, a - 1), from) * riskRelief;
-      const exposureWin = captureThreat(from, 1, to) * riskRelief;
-      const exposureLoss = captureThreat(from, 1, -1) * riskRelief;
+      const heldDice = Math.round(a - 1 + refund * (MAX_DICE - (a - 1)));
+      const recaptureP = captureThreat(to, Math.max(1, heldDice), from);
+      const exposureWin = captureThreat(from, 1, to) * (1 - refund);
+      const exposureLoss = captureThreat(from, 1, -1) * (1 - refund);
 
       const winValue = gains * (1 - HOLD_DISCOUNT * recaptureP) - fromStake * exposureWin;
-      const lossCost = LOSS_WEIGHT * (a - 1) + fromStake * exposureLoss;
+      // Dice burned on a failed attack are refilled from the reserve next turn.
+      const lossCost = LOSS_WEIGHT * (a - 1) * (1 - refund) + fromStake * exposureLoss;
 
       const score = p * winValue - (1 - p) * lossCost;
 
@@ -265,11 +338,36 @@ export const ai_strategist = game => {
         bestFrom = from;
         bestTo = to;
       }
+      if (
+        disruptActive &&
+        defender.arm === leader &&
+        p >= DISRUPT_MIN_P &&
+        score > bestLeaderScore
+      ) {
+        bestLeaderScore = score;
+        bestLeaderFrom = from;
+        bestLeaderTo = to;
+      }
     }
   }
 
-  if (bestFrom === -1 || bestScore <= threshold) return 0;
+  if (bestFrom !== -1 && bestScore > threshold) {
+    game.area_from = bestFrom;
+    game.area_to = bestTo;
+    return;
+  }
 
-  game.area_from = bestFrom;
-  game.area_to = bestTo;
+  /*
+   * Stuck behind the leader but holding a reserve: rather than turtling into a
+   * slow loss, take the best even-odds-or-better swing at the leader. The refill
+   * discount keeps these swings cheap precisely because the reserve patches the
+   * holes they open before the leader can exploit them.
+   */
+  if (disruptActive && bestLeaderFrom !== -1 && bestLeaderScore > DISRUPT_THRESHOLD) {
+    game.area_from = bestLeaderFrom;
+    game.area_to = bestLeaderTo;
+    return;
+  }
+
+  return 0;
 };

--- a/src/ai/ai_strategist.js
+++ b/src/ai/ai_strategist.js
@@ -27,13 +27,13 @@
  *
  * Bank-aware endgame aggression breaks all-8s stalemates. The cost of losing an
  * attack — burned dice and a weakened source — is largely an illusion when the
- * player holds a reinforcement reserve, because that reserve plus its income
- * refills the holes at the end of the same turn, before any opponent can act. So
+ * player holds a reinforcement reserve, because that reserve plus its income tops
+ * its board back up at the end of the same turn, before any opponent can act. So
  * once the field narrows to a few players, an attack's refundable cost is
- * discounted by how completely the reserve will patch it, and a player trailing
+ * discounted by how completely the reserve will cover it, and a player trailing
  * the leader with a real reserve will spend it chipping the leader down rather
  * than turtling into a slow loss. (Kept to the endgame on purpose: with many
- * players alive, patient play is stronger and the arena confirms it.)
+ * players alive, patient play measured stronger in arena sweeps.)
  *
  * Fully deterministic: no randomness; ties break toward the lowest area index.
  */
@@ -65,7 +65,7 @@ const PRESS_THRESHOLD = -0.6; // accept negative-EV attacks to close out a win
 const ENDGAME_PLAYERS = 3; // unlock bank-aware aggression only once the field narrows to this many
 const REFILL_EFFICIENCY = 0.85; // fraction of an attack's refundable cost the reserve neutralizes
 const DISRUPT_MIN_BANK = MAX_DICE; // banked dice before gunning for the leader at a loss (~one full stack)
-const DISRUPT_MIN_P = 0.4; // only swing at the leader on coin-flip-or-better odds (8v8 = 0.471)
+const DISRUPT_MIN_P = 0.4; // only swing at the leader on near-even odds or better (admits the 8v8 case, p=0.471)
 const DISRUPT_BONUS = 0.6; // extra pull toward the leader when trailing with a reserve to spend
 const DISRUPT_THRESHOLD = -0.8; // accept a moderately negative swing at the leader to break a stalemate
 
@@ -268,7 +268,7 @@ export const ai_strategist = game => {
   let bestFrom = -1;
   let bestTo = -1;
   let bestScore = -Infinity;
-  // Best coin-flip-or-better swing aimed at the leader (the disruption fallback).
+  // Best near-even-odds-or-better swing aimed at the leader (the disruption fallback).
   let bestLeaderFrom = -1;
   let bestLeaderTo = -1;
   let bestLeaderScore = -Infinity;
@@ -305,9 +305,12 @@ export const ai_strategist = game => {
       /*
        * Refill discount: the fraction of the holes this attack opens that my
        * reserve + income will patch this end of turn, before opponents act.
-       * `myVacancy` already reflects holes opened by earlier attacks this turn,
-       * so the discount fades as I spend down — I press while banked, then
-       * fortify once the reserve can no longer cover another swing.
+       * `myVacancy` is recomputed from the live board on every call, and the
+       * engine re-invokes this AI once per attack (runFullAITurn), so across a
+       * turn each landed attack leaves more vacancy on the next call — shrinking
+       * refillPool / vacancy until the reserve can no longer cover another swing.
+       * The effect plays out across calls, not within this loop: press while
+       * banked, then fortify as the reserve runs dry.
        */
       const refillFactor =
         !endgame || refillPool <= 0
@@ -322,13 +325,17 @@ export const ai_strategist = game => {
        * chokepoint source falls), net of the refill that patches it first.
        */
       const fromStake = EXPOSURE_WEIGHT + INCOME_WEIGHT * 0.5 * incomeLossIfCaptured(from);
-      const heldDice = Math.round(a - 1 + refund * (MAX_DICE - (a - 1)));
+      const heldDice = Math.min(MAX_DICE, Math.round(a - 1 + refund * (MAX_DICE - (a - 1))));
       const recaptureP = captureThreat(to, Math.max(1, heldDice), from);
       const exposureWin = captureThreat(from, 1, to) * (1 - refund);
       const exposureLoss = captureThreat(from, 1, -1) * (1 - refund);
 
       const winValue = gains * (1 - HOLD_DISCOUNT * recaptureP) - fromStake * exposureWin;
-      // Dice burned on a failed attack are refilled from the reserve next turn.
+      /*
+       * A failed swing is partly recouped: end-of-turn reinforcements (distributed
+       * this same turn, before opponents move) top the board back up on average, so
+       * discount the burned dice by `refund`.
+       */
       const lossCost = LOSS_WEIGHT * (a - 1) * (1 - refund) + fromStake * exposureLoss;
 
       const score = p * winValue - (1 - p) * lossCost;
@@ -359,7 +366,7 @@ export const ai_strategist = game => {
 
   /*
    * Stuck behind the leader but holding a reserve: rather than turtling into a
-   * slow loss, take the best even-odds-or-better swing at the leader. The refill
+   * slow loss, take the best near-even-odds-or-better swing at the leader. The refill
    * discount keeps these swings cheap precisely because the reserve patches the
    * holes they open before the leader can exploit them.
    */

--- a/tests/ai/ai_strategist.test.js
+++ b/tests/ai/ai_strategist.test.js
@@ -2,6 +2,7 @@
  * Tests for Strategist AI implementation
  */
 import { ai_strategist, winProbability } from '../../src/ai/ai_strategist.js';
+import { MAX_DICE } from '../../src/ai/diceOdds.js';
 
 describe('Strategist AI', () => {
   let mockGame;
@@ -261,6 +262,54 @@ describe('Strategist AI', () => {
       /*
        * Same reserve, same lone 8v8 into the leader, but the field is too wide:
        * patient play is stronger here, so it should not burn the attack.
+       */
+      expect(ai_strategist(mockGame)).toBe(0);
+    });
+
+    /*
+     * Board that exercises the disruption *fallback* specifically (distinct from
+     * the main attack path tested above). My only move is a 6v6 into the leader
+     * (area 1), whose target is recaptureable by two backing 8-die cells, and I
+     * hold six 1-die cells whose vacancy thins the refill discount. The result is
+     * a leader swing that scores *below* the normal attack threshold — so the
+     * main path declines (it would turtle) — yet stays above DISRUPT_THRESHOLD,
+     * so only the trailing-leader fallback can produce this attack.
+     */
+    const buildFallbackBoard = stock => {
+      territory(1, 0, 6); // leader's target cell, recaptureable by areas 2 and 3
+      territory(2, 0, 8);
+      territory(3, 0, 8);
+      territory(4, 1, 6); // my attacker: a 6v6 into the leader (p = 0.467)
+      for (let i = 10; i < 16; i++) territory(i, 1, 1); // vacancy thins the refill discount
+      territory(6, 2, 5); // third player -> 3 active, endgame gate open
+      link(1, 2);
+      link(1, 3);
+      link(2, 3);
+      link(4, 1); // my ONLY legal attack
+      link(6, 3);
+      mockGame.player[1].stock = stock;
+    };
+
+    test('falls back to a sub-threshold swing at the leader rather than turtling', () => {
+      buildFallbackBoard(MAX_DICE); // full-enough reserve -> disruptActive
+
+      const result = ai_strategist(mockGame);
+
+      /*
+       * The main path's best score is below threshold here, so without the
+       * fallback the bot would end its turn; instead it attacks the leader.
+       */
+      expect(result).not.toBe(0);
+      expect(mockGame.area_from).toBe(4);
+      expect(mockGame.adat[mockGame.area_to].arm).toBe(0); // the leader
+    });
+
+    test('fortifies instead of swinging when the reserve is below the bank threshold', () => {
+      buildFallbackBoard(MAX_DICE - 1); // one die short of DISRUPT_MIN_BANK
+
+      /*
+       * Same board, same lone sub-threshold leader swing, but the reserve no
+       * longer clears DISRUPT_MIN_BANK, so disruption is off and the bot fortifies.
        */
       expect(ai_strategist(mockGame)).toBe(0);
     });

--- a/tests/ai/ai_strategist.test.js
+++ b/tests/ai/ai_strategist.test.js
@@ -220,6 +220,52 @@ describe('Strategist AI', () => {
     expect(mockGame.area_to).toBe(firstMove.to);
   });
 
+  describe('bank-aware endgame aggression', () => {
+    /*
+     * Shared all-8s stalemate: player 1 (me) trails the leader (player 0) and
+     * its ONLY legal attack is an 8v8 into the leader. Extra players are placed
+     * away from player 1 purely to set the active-player count.
+     */
+    const buildStalemate = () => {
+      territory(1, 0, 8); // leader
+      territory(2, 0, 8);
+      territory(3, 0, 8);
+      territory(4, 1, 8); // me
+      territory(5, 1, 8);
+      link(1, 2);
+      link(2, 3);
+      link(4, 5);
+      link(4, 1); // my only enemy border: an 8v8 into the leader
+      mockGame.player[1].stock = 16; // a full reserve to spend
+    };
+
+    test('spends its reserve to chip the leader once the field has narrowed', () => {
+      buildStalemate();
+      territory(6, 2, 8); // third player -> 3 active, endgame gate open
+      link(6, 3);
+
+      const result = ai_strategist(mockGame);
+
+      expect(result).not.toBe(0);
+      expect(mockGame.area_from).toBe(4);
+      expect(mockGame.adat[mockGame.area_to].arm).toBe(0); // attacked the leader
+    });
+
+    test('stays patient at the same all-8s board while many players are alive', () => {
+      buildStalemate();
+      territory(6, 2, 8); // four active players -> endgame gate closed
+      territory(7, 3, 8);
+      link(6, 3);
+      link(7, 3);
+
+      /*
+       * Same reserve, same lone 8v8 into the leader, but the field is too wide:
+       * patient play is stronger here, so it should not burn the attack.
+       */
+      expect(ai_strategist(mockGame)).toBe(0);
+    });
+  });
+
   test('only proposes legal attacks on a mixed board', () => {
     territory(1, 1, 3);
     territory(2, 1, 2);


### PR DESCRIPTION
## Problem

In endgame stalemates where every territory holds 8 dice, both `ai_strategist` and `ai_lookahead` freeze — they refuse to attack 8v8 (which wins only **47.1%**, since ties favor the defender) because a capture leaves the source at 1 die and the taken cell recapturable, scoring ~**−1.5**. Their posture logic only relaxes the attack threshold when the bot is *winning*, so the **trailing** player — the one that most needs to act — is the most passive. Once a player edges ahead, everyone turtles at 8/8 and the leader slowly grinds out a boring win. (Spotted in human play vs. these two bots.)

## Root cause: the reinforcement reserve is barely modeled

A player's banked `stock` **plus its income** (largest connected group) is distributed to its non-maxed cells at the **end of its own turn — before any opponent moves** (`applyEndTurn` → `distributeReinforcements`). So the holes an attack opens are refilled before they can be punished: with a reserve, an 8v8 is nearly free. The old bot only had a weak `riskRelief` that touched exposure terms and never the burned-dice cost, and `ai_lookahead` ignored the bank entirely for move selection.

## Change (scoped to `ai_strategist`)

- **Bank-aware cost.** An attack's *refundable* costs (dice burned on a loss, source/recapture exposure) are discounted by how fully `stock + income` will patch the holes that turn. More headroom → bigger discount → more willing to take the 8v8 (see the thin-reserve caveat under Follow-ups).
- **Leader-disruption.** A player trailing the leader with a reserve gets an extra pull toward the leader and will take its best coin-flip-or-better swing at them rather than turtle.
- **Endgame gate (`ENDGAME_PLAYERS = 3`).** Both behaviors only unlock once the field narrows. With a wider field, patient play is genuinely stronger — and the arena confirms it.

## Validation

Arena sweep, 2250 games (15 runs × 150), 6-bot field:

| Version | Strategist win% | ELO | Rank |
|---|---|---|---|
| Baseline (turtles) | 20.0 ± 1.2 | 1257 | 2 |
| Fix, ungated | 17.2 ± 1.6 | 1224 | 3 |
| **Fix, endgame-gated** | **18.8 ± 1.5** | **1242** | **2** |

The gate keeps competitive strength within CI of baseline while the all-8s stalemate now breaks. Verified behavior: in a balanced 3-player endgame the bots gang up on the leader; when one player is dominant they take the best available target; with 4+ players alive they stay patient.

**3-player-field stress test** (4000 games each, discount active all game, vs. master baseline): Strategist win% 31.5→30.6 and ELO 1221→1208 — both **within CI** (no regression) — while stalemates dropped from **6.6%→1.4%**.

- ✅ `npm test` — 720 passing (incl. 4 new strategist tests: the endgame gate, the trailing-leader disruption fallback, and the bank-threshold fortify)
- ✅ `npm run lint` clean
- ✅ `npm run build` succeeds

## Follow-ups / notes

- **`ai_lookahead` still turtles** — same flaw, not addressed here (its search doesn't model the end-of-turn refill at all). Worth a separate pass since players face both bots.
- **`ENDGAME_PLAYERS` is a tunable dial.** Raising it makes the fix trigger with larger fields at some arena-ELO cost.
- **Thin-reserve caveat (the discount is funded by `stock + income`, not `stock` alone).** The refill discount is gated by the *endgame*, not by reserve size — and `income` (the largest-connected-group reinforcement) funds a substantial discount on its own. So a thin bank does **not** by itself force fortify-first: on the canonical all-8s board the bot still takes the 8v8 even at `stock = 4`. The reserve threshold (`DISRUPT_MIN_BANK`) gates only the trailing-leader **disruption** bonus/fallback, not the core bank-aware cost. ("Fortify first on a thin reserve" holds for the disruption path — see the paired fallback / below-threshold tests — but not for the all-8s main-path swing.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

