### PR TITLE
docs: ML/self-play bot initiative plan and tracking

### DIFF
--- a/docs/ml-bot/DECISIONS.md
+++ b/docs/ml-bot/DECISIONS.md
@@ -1,0 +1,106 @@
+# Decisions — ML / Self-Play Bot
+
+Lightweight ADR (Architecture Decision Record) log. Each entry: the decision, the
+context, why, and the alternatives rejected. Add an entry at each real
+fork-in-the-road. Supersede rather than delete — keep the history.
+
+Status values: **Accepted** · **Proposed** · **Superseded by D-x** · **Revisited**
+
+---
+
+## D-1 — Search first, learning second · Accepted (2026-06-21)
+
+**Decision.** Build a pure-JS chance-node search bot (Track A) _before_ investing
+in self-play RL (Track B), and gate every step on `arena:sweep` vs `ai_strategist`.
+
+**Why.** `ai_strategist` is a strong exact-odds baseline. Prior art on this game
+class (KTH Risk AlphaZero/ExIt thesis; Moy & Shekh hex-wargaming) shows naive
+self-play RL losing to good heuristics until bootstrapped. Search reuses the eval
+and odds we already have, likely wins in days, and tells us early whether the
+problem is even tractable before spending GPU-weeks.
+
+**Rejected.** Jumping straight to RL — high cost, high risk of plateauing at or
+below the heuristic with no cheap early signal.
+
+---
+
+## D-2 — Model-free PPO, not AlphaZero / MuZero · Accepted (2026-06-21)
+
+**Decision.** If we train a learned bot, use **self-play PPO with action masking**
+(SB3 MaskablePPO first; CleanRL/RLlib for leagues).
+
+**Why.** The game is **stochastic** (dice = chance nodes) **and 8-player
+free-for-all** (not 2-player zero-sum). PPO absorbs dice variance natively, handles
+N agents via parameter sharing, and consumes the `getValidMoves` mask directly.
+
+**Rejected.**
+
+- `alpha-zero-general` — hard-coded 2-player/deterministic/perfect-info.
+- `muzero-general` — explicitly lists >2 players _and_ stochasticity as
+  unsupported; and MuZero's model-learning is wasted when we already have a fast
+  exact simulator.
+- OpenSpiel bundled AlphaZero — game layer supports chance + multiplayer, but the
+  _trainer_ is 2-player-zero-sum only.
+
+---
+
+## D-3 — JS engine is the single source of truth; Python for training only · Accepted (2026-06-21)
+
+**Decision.** Keep the game engine in JS. Bridge to Python for _training only_ via
+a PettingZoo AEC env (subprocess/socket) wrapping the existing arena harness.
+
+**Why.** The JS engine is the product. Re-porting it to Python duplicates logic
+and invites drift (the trained bot would play a subtly different game than it
+ships into).
+
+**Rejected.**
+
+- Port the engine to Python (fastest training, but drift risk on the product).
+- Pure-tfjs training (avoids the bridge, but slow training + DIY RL ecosystem).
+
+**Open risk.** The subprocess/socket bridge adds per-step IPC latency that can
+dominate wall-clock — mitigate with many parallel env workers and a compact
+(non-JSON-per-step) state. Revisit if throughput is unacceptable.
+
+---
+
+## D-4 — Deploy via ONNX Runtime Web · Accepted (2026-06-21)
+
+**Decision.** Train in PyTorch → export to ONNX → run in-browser inference via
+ONNX Runtime Web, wrapped as a normal `(BotState) → {from,to}|null` bot.
+
+**Why.** It's the robust, future-proof deployment path and keeps the shipped bot a
+first-class in-browser bot like every other. A small MLP/GNN policy is trivially
+WASM-fast. **TensorFlow.js** is the fallback (pure-JS deploy, or no-Python
+train+infer for a small net).
+
+---
+
+## D-5 — Evaluation gate = `arena:sweep` vs `ai_strategist` with CIs · Accepted (2026-06-21)
+
+**Decision.** "Better" means a statistically significant win-rate/ELO edge over
+`ai_strategist` on multi-seed `arena:sweep`, controlling seat/turn-order.
+
+**Why.** Battles are high-variance (dice). Single-seed results are noise.
+Turn-order is shuffled, so seat effects must be controlled to measure skill, not
+first-mover luck.
+
+---
+
+## D-Encoding — MDP / state / action / reward shape · Proposed (2026-06-21)
+
+**Proposed (finalize in Phase 2).**
+
+- **State:** graph over ≤31 territory nodes (adjacency from `neighborAreaIds`);
+  node features = owner, dice (1–8), is-mine, is-border, per-edge win-prob from
+  `WIN_TABLE`; per-player globals dominated by largest-connected-group income.
+- **Action:** policy head over legal `(from,to)` border edges **plus an explicit
+  STOP**, masked by `getValidMoves` (a turn is a _sequence_ of single attacks, not
+  one batched move). Edge/pointer head, not a flat 31×31 head.
+- **Reward:** terminal win/placement + dense shaping (Δlargest-group income,
+  territory/dice deltas, eliminations).
+- **Self-play:** a single shared stateless policy over the per-player view; the
+  engine handles whose-turn via `turnOrder`/`currentPlayerIndex`.
+
+**Status:** to be validated empirically in Phase 2 (if a net can't _clone_
+`ai_strategist` under this encoding, the encoding is wrong).

--- a/docs/ml-bot/LOG.md
+++ b/docs/ml-bot/LOG.md
@@ -56,7 +56,7 @@ Entry template:
   reusing `ai_strategist`'s eval + `WIN_TABLE`, register it, and run the first
   `arena:sweep` vs `ai_strategist`. Record the baseline + first result in
   `RESULTS.md`.
-- **Blocker on the baseline:** PR #35 (`fix/strategist-endgame-turtle`) changes
-  `ai_strategist`. Run the baseline sweep only after #35 merges to master, and pin
-  the strategist SHA in `RESULTS.md`. Building/validating the expectimax bot itself
-  is not blocked.
+- **Baseline dependency (now cleared):** PR #35 (`fix/strategist-endgame-turtle`)
+  changed `ai_strategist`; it **merged to master the same day as `f5fedb2`**. Pin
+  that SHA in `RESULTS.md` when running the baseline sweep. Building/validating the
+  expectimax bot itself was never blocked.

--- a/docs/ml-bot/LOG.md
+++ b/docs/ml-bot/LOG.md
@@ -1,0 +1,62 @@
+# Session Log — ML / Self-Play Bot
+
+Append-only journal. **Add an entry at the end of each working session.** Newest
+at the top. This is how context — what we did, what we learned, what didn't work —
+survives across days and Claude Code sessions.
+
+Entry template:
+
+```
+## YYYY-MM-DD — <short title>
+**Phase:** <n>  ·  **Who:** <Ivan / Claude>
+**Did:**
+- ...
+**Learned / decided:**
+- ...
+**Dead ends / surprises:**
+- ...
+**Next:**
+- ...
+```
+
+---
+
+## 2026-06-21 — Feasibility analysis + plan created
+
+**Phase:** pre-0 · **Who:** Ivan + Claude
+
+**Did:**
+
+- Ran a multi-agent feasibility analysis: 3 agents read the codebase (bot
+  contract, headless throughput, MDP shape) and 2 researched the RL landscape +
+  prior art, then a synthesis pass.
+- Created this `docs/ml-bot/` folder: `README.md`, `PLAN.md`, `DECISIONS.md`,
+  `LOG.md`, `RESULTS.md`.
+
+**Learned / decided:**
+
+- Verdict: **large-but-doable**, not too big. Engine is a great RL environment.
+- The bar is **beating `ai_strategist`** — a strong exact-odds baseline. Prior art
+  says from-scratch self-play RL often _loses_ to good heuristics until
+  bootstrapped, so we go **search-first, learning-second**.
+- Measured throughput: ~150 games/s/core pure engine; ~77 g/s with Strategist;
+  near-linear across cores. Inference, not the engine, will be the bottleneck.
+- Key code facts captured in `README.md` (getValidMoves mask, WIN_TABLE odds,
+  seeded determinism, O(n²) history append to disable for training).
+- Decisions D-1…D-5 + D-Encoding recorded in `DECISIONS.md`.
+
+**Dead ends / surprises:**
+
+- AlphaZero/MuZero turnkey templates don't fit (stochastic + 8-player FFA);
+  model-free PPO is the right family. (D-2)
+
+**Next:**
+
+- Phase 0: scaffold the depth-1 chance-node expectimax bot (`ai_expectimax`)
+  reusing `ai_strategist`'s eval + `WIN_TABLE`, register it, and run the first
+  `arena:sweep` vs `ai_strategist`. Record the baseline + first result in
+  `RESULTS.md`.
+- **Blocker on the baseline:** PR #35 (`fix/strategist-endgame-turtle`) changes
+  `ai_strategist`. Run the baseline sweep only after #35 merges to master, and pin
+  the strategist SHA in `RESULTS.md`. Building/validating the expectimax bot itself
+  is not blocked.

--- a/docs/ml-bot/PLAN.md
+++ b/docs/ml-bot/PLAN.md
@@ -47,10 +47,11 @@ certainly won't either, and we've spent days, not weeks.
 - Runs a full `arena:sweep` vs `ai_strategist` and the result is recorded in
   `RESULTS.md`.
 
-> **Baseline timing.** `ai_strategist` is being changed by PR #35
-> (`fix/strategist-endgame-turtle`). Run the baseline sweep **after #35 merges to
-> master**, and pin the strategist commit SHA in the `RESULTS.md` row — otherwise
-> the baseline is an in-flight, moving target. See `RESULTS.md` for the convention.
+> **Baseline timing.** PR #35 (`fix/strategist-endgame-turtle`) changed
+> `ai_strategist` and **merged to master on 2026-06-21 as `f5fedb2`** — the
+> blocker is cleared. Pin that strategist SHA in the `RESULTS.md` row so the
+> baseline isn't measured against an in-flight version. See `RESULTS.md` for the
+> convention.
 
 **Go/No-Go gate.**
 

--- a/docs/ml-bot/PLAN.md
+++ b/docs/ml-bot/PLAN.md
@@ -1,0 +1,196 @@
+# Plan — ML / Self-Play Bot
+
+Detailed, trackable phases. Each phase has an **objective**, the **tasks** to do,
+**acceptance criteria** (measurable "done"), and a **go/no-go gate** — the
+decision we make before investing in the next phase. The gates are the whole
+point: they let us find out _early and cheaply_ whether learning is worth the
+GPU-weeks.
+
+See [`README.md`](./README.md) for the high-level strategy and the status
+dashboard. Record results in [`RESULTS.md`](./RESULTS.md), session notes in
+[`LOG.md`](./LOG.md), and decisions in [`DECISIONS.md`](./DECISIONS.md).
+
+> **Evaluation gate (applies to every phase that produces a bot):** beat
+> `ai_strategist` on `npm run arena:sweep` (multi-seed, 95% CIs), seat/turn-order
+> controlled, edge statistically significant.
+
+---
+
+## Phase 0 — Quick-win search bot · ⬜ Not started · ~2–4 days
+
+**Objective.** A pure-JS chance-node expectimax bot that needs no ML, no Python,
+no GPU, and no engine changes — and very plausibly becomes the new strongest bot.
+
+**Why first.** Bank a likely win, and _answer the critical question early_: does
+**search alone** beat `ai_strategist`? If it doesn't, plain self-play RL almost
+certainly won't either, and we've spent days, not weeks.
+
+**Tasks.**
+
+- [ ] New bot file (e.g. `src/ai/ai_expectimax.js`) using the modern contract.
+- [ ] Depth-1: for each move in `getValidMoves`, compute the `WIN_TABLE`-weighted
+      expectation of `ai_strategist`'s board evaluation over the two battle
+      outcomes (win → captured territory gets `attackerDice-1`, source → 1; loss →
+      source → 1). Pick the argmax; return `null` (STOP) when nothing beats
+      holding.
+- [ ] Reuse `ai_strategist`'s evaluation as the leaf heuristic (extract/share it
+      rather than copy-pasting if practical).
+- [ ] Register in `src/arena/builtInBots.js`.
+- [ ] Extend to depth-2 (expand the best-K moves one ply deeper) and compare.
+- [ ] Benchmark with `npm run benchmark-bot`; record timing (must stay playable
+      in-browser — see the Lookahead bot's ~243 ms/game as the "too slow" marker).
+
+**Acceptance criteria.**
+
+- Passes `npm run validate-bot` (syntax, compile, runtime) and is deterministic
+  given a seed (no `Math.random`).
+- Runs a full `arena:sweep` vs `ai_strategist` and the result is recorded in
+  `RESULTS.md`.
+
+> **Baseline timing.** `ai_strategist` is being changed by PR #35
+> (`fix/strategist-endgame-turtle`). Run the baseline sweep **after #35 merges to
+> master**, and pin the strategist commit SHA in the `RESULTS.md` row — otherwise
+> the baseline is an in-flight, moving target. See `RESULTS.md` for the convention.
+
+**Go/No-Go gate.**
+
+- **Beats `ai_strategist` significantly** → ship it as a built-in (Phase 4 wiring
+  is trivial since it's already a normal bot), AND proceed to Phase 1 for Track B.
+- **Roughly ties / loses** → important early signal that this game rewards
+  heuristics over depth here. Reconsider whether Track B is worth it before
+  committing; record the reasoning in `DECISIONS.md`.
+
+---
+
+## Phase 1 — Harness hardening for self-play · ⬜ Not started · ~3–5 days
+
+**Objective.** Turn the headless arena into a fast, reproducible, _instrumented_
+self-play environment. No learning yet.
+
+**Tasks.**
+
+- [ ] Add a self-play/training mode flag that **disables the O(n²) `history`
+      append** (`StateManager.js:199,244`) — pure overhead for training.
+- [ ] Force explicit seeds end-to-end; add a determinism regression test
+      (same seed → identical winner/turns/placements).
+- [ ] (Optional, only if profiling says so) trim per-move allocation in
+      `cloneAreas`/`clonePlayers`/`recalcPlayerStats`.
+- [ ] Add a thin **trajectory export**: one game emits
+      `(BotState, legal-mask, chosen-move, outcome)` tuples, plus terminal
+      win/placement. This is the training-data and replay substrate.
+- [ ] Confirm parallel self-play across Node workers/processes (the engine is
+      pure — near-linear scaling already measured).
+
+**Acceptance criteria.**
+
+- Determinism test green.
+- Measured self-play throughput recorded in `RESULTS.md` (games/s with the
+  history fix vs without).
+- A sample exported trajectory file exists and round-trips (can replay a game
+  from its recorded actions).
+
+**Go/No-Go gate.** Reproducible + instrumented + fast enough (target: ≥100 g/s/core
+heuristic self-play) → proceed to Phase 2.
+
+---
+
+## Phase 2 — Imitation baseline (de-risk learning before RL) · ⬜ Not started · ~1–2 weeks
+
+**Objective.** Prove the **entire** JS → train → ONNX → in-browser pipeline on an
+_easy_ objective: clone `ai_strategist` with a small neural net. This de-risks
+everything technical before we gamble on RL.
+
+**Tasks.**
+
+- [ ] Generate ~100k–1M `ai_strategist` self-play games; export trajectories
+      (minutes-to-hours on 8 cores).
+- [ ] Decide the encoding (see `DECISIONS.md` D-Encoding): graph over ≤31
+      territory nodes (features: owner, dice, is-mine, is-border, per-edge
+      win-prob from `WIN_TABLE`); policy head over legal `(from,to)` edges + an
+      explicit STOP; masked by `getValidMoves`.
+- [ ] Train a small masked policy/value net (GNN or per-edge MLP) by behavioral
+      cloning to predict `ai_strategist`'s move.
+- [ ] Export to ONNX; load in-browser via ONNX Runtime Web; wrap as a normal bot.
+- [ ] Evaluate the in-browser net on `arena:sweep` vs `ai_strategist`.
+
+**Acceptance criteria.**
+
+- The cloned net **matches `ai_strategist`'s strength** (within CI) on
+  `arena:sweep` — it's imitating it, so parity is the bar.
+- The same ONNX model runs in Node and in-browser with identical action choices
+  on fixed seeds (cross-bridge action-encoding test passes).
+
+**Go/No-Go gate.**
+
+- **Reaches ~parity** → the pipeline works; proceed to Phase 3 (RL).
+- **Can't reach parity** → the encoding (not RL) is the problem. Fix encoding
+  before any RL. Do **not** proceed until a net can at least clone the heuristic.
+
+---
+
+## Phase 3 — Self-play RL (PPO) · ⬜ Not started · ~3–6 weeks (real plateau risk)
+
+**Objective.** Train a self-play policy that is _genuinely stronger_ than
+`ai_strategist` — the ambitious, uncertain part.
+
+**Tasks.**
+
+- [ ] Stand up a **PettingZoo AEC** env (turn-based, per-agent obs + action mask)
+      wrapping the headless arena via subprocess/socket. Keep the JS engine as the
+      source of truth (no Python re-port).
+- [ ] Train **MaskablePPO** (SB3 + sb3-contrib) with parameter sharing across
+      seats.
+- [ ] Use an **opponent league**: snapshots of past policies + `ai_strategist` as
+      a fixed baseline (naive simultaneous self-play collapses/cycles).
+- [ ] Add reward shaping (Δlargest-group income, territory/dice deltas,
+      eliminations) and/or value bootstrapping for the sparse, long-horizon
+      terminal reward.
+- [ ] Curriculum: start at **3–4 players**, move to **8-player FFA last** (8-FFA
+      self-play at scale is a research frontier).
+- [ ] Warm-start from the Phase-2 imitation weights (prior art: from-scratch
+      stalls; bootstrapped wins).
+
+**Acceptance criteria.**
+
+- Training is reproducible (seeded) and logged.
+- Gated on `arena:sweep` ELO vs `ai_strategist` with CIs at each checkpoint.
+
+**Go/No-Go gate (and kill criterion).**
+
+- **Statistically significant win-rate edge over `ai_strategist`** → proceed to
+  Phase 4 with the RL bot as the candidate.
+- **No significant edge after a few training iterations** → treat as a **plateau
+  signal** (exactly what the Risk thesis hit). Don't pour unbounded compute in.
+  Record in `DECISIONS.md`; fall back to shipping the best of Track A / Phase 2.
+
+---
+
+## Phase 4 — Ship the strongest bot · ⬜ Not started · ~2–4 days on top of the winner
+
+**Objective.** Wire whichever candidate won `arena:sweep` most decisively (Track A
+search bot, the imitation net, or the RL net) as a real shipped bot.
+
+**Tasks.**
+
+- [ ] Finalize as a built-in or community bot running **purely in-browser** (ONNX
+      Runtime Web for a learned net; nothing extra for the JS search bot).
+- [ ] Add to the tournament pool (`npm run tournament`).
+- [ ] Document the bot in `docs/BOT_GUIDE.md` and update `README.md`.
+- [ ] Final `arena:sweep` + tournament numbers recorded in `RESULTS.md`.
+
+**Acceptance criteria.** The bot is selectable in-game, runs in-browser, and its
+strength vs the field is recorded.
+
+**Done = the dashboard in `README.md` shows the winner shipped.**
+
+---
+
+## Effort summary
+
+| Track / milestone                              | Effort             | Compute               |
+| ---------------------------------------------- | ------------------ | --------------------- |
+| Track A search bot (Phase 0)                   | 2–4 days           | none, no GPU          |
+| End-to-end pipeline via imitation (Phases 1–2) | ~1.5–3 weeks       | CPU only              |
+| Self-play PPO that _plausibly_ wins (Phase 3)  | 1–2 months focused | single-GPU days–weeks |
+
+**Likely win in days (search); uncertain win in weeks-to-months (learned RL).**

--- a/docs/ml-bot/README.md
+++ b/docs/ml-bot/README.md
@@ -113,8 +113,9 @@ Verified against the code during the 2026-06-21 analysis:
   opponents.)
 - **Measured throughput:** ~150 games/s/core pure engine (~6.6 ms/game, ~12
   µs/`applyAction`), ~77 g/s with the Strategist heuristic, near-linear across
-  cores (~266 g/s on 4 procs). 1M engine-bound games ≈ 14–28 min on 8 cores.
-  **Inference, not the engine, will be the bottleneck.**
+  cores (the Strategist run hit ~266 g/s on 4 procs ≈ 3.4× its 77 g/s single
+  core). 1M engine-bound games ≈ 14–28 min on 8 cores. **Inference, not the
+  engine, will be the bottleneck.**
 - **Training-mode perf fixes:** disable the O(n²) `history` append
   (`StateManager.js:199,244`); per-move `cloneAreas`/`recalcPlayerStats`
   trimmable later if needed.

--- a/docs/ml-bot/README.md
+++ b/docs/ml-bot/README.md
@@ -1,0 +1,127 @@
+# ML / Self-Play Bot Initiative
+
+> **Status:** Active — Phase 0 not started
+> **Last updated:** 2026-06-21
+> **Owners:** Ivan (+ Claude)
+
+A tracked, multi-session effort to produce a DiceWars bot whose play is shaped by
+machine learning / self-play. This folder is the persistent home for the plan,
+decisions, running log, and empirical results so progress survives across days
+and Claude Code sessions.
+
+---
+
+## Goal
+
+Produce a DiceWars bot that:
+
+1. Runs **in-browser as just another bot** — same contract as every other bot:
+   `(BotState) → { from, to } | null`.
+2. Is **measurably stronger than `ai_strategist`** (the current strongest bot),
+   judged by the evaluation gate below.
+
+## Verdict (from the 2026-06-21 feasibility analysis)
+
+**Large-but-doable — not too big.** The engine is an excellent RL environment:
+pure, immutable, seedable, ~150 games/s/core headless, with a free legal-action
+mask (`getValidMoves`) and an exact dice-odds table (`WIN_TABLE`). The plumbing is
+mostly already in place.
+
+The **hard, uncertain** part is not the plumbing — it's that from-scratch
+self-play RL has a real chance of **never beating `ai_strategist`**. The most
+relevant prior art (a KTH Risk AlphaZero/ExIt thesis; Moy & Shekh's hex-grid
+wargaming) shows naive self-play nets _losing_ to good heuristics until they're
+bootstrapped with heuristic/supervised data. `ai_strategist` is a strong,
+exact-odds baseline — not a strawman.
+
+**Strategy: search first, learning second.** Bank a likely win with a pure-JS
+search bot before spending GPU-weeks on RL, and gate every step on the same
+empirical bar.
+
+## The bar — evaluation gate (used at EVERY phase)
+
+A candidate is only "better" if it beats `ai_strategist` on
+**`npm run arena:sweep`** (multi-seed, mean win%/ELO with 95% confidence
+intervals), controlling for seat/turn-order so we measure skill not first-mover
+luck. The edge must be **statistically significant**, not a single-seed fluke.
+Every run gets a row in [`RESULTS.md`](./RESULTS.md).
+
+---
+
+## Two-track strategy
+
+- **Track A — pure-JS search (no ML).** Chance-node expectimax reusing
+  `ai_strategist`'s evaluation as the leaf heuristic and `WIN_TABLE` for exact
+  chance-node expectation. Days of work, likely beats the baseline, and validates
+  the arena as the evaluation gate. (Phases 0–1 also serve Track B.)
+- **Track B — learned bot.** Keep the JS engine as the single source of truth;
+  bridge to Python for **training only** (PettingZoo + MaskablePPO self-play),
+  export the small policy net to ONNX, and run it in-browser via ONNX Runtime
+  Web. (Phases 2–4.)
+
+---
+
+## Status dashboard
+
+| Phase | Title                                 | Status         | Go/No-Go gate                                                    |
+| ----: | ------------------------------------- | -------------- | ---------------------------------------------------------------- |
+|     0 | Quick-win search bot                  | ⬜ Not started | Does expectimax beat `ai_strategist` on sweep?                   |
+|     1 | Harness hardening for self-play       | ⬜ Not started | Reproducible, fast, instrumented self-play loop?                 |
+|     2 | Imitation baseline (de-risk learning) | ⬜ Not started | Can a net clone `ai_strategist` to ~parity, in-browser via ONNX? |
+|     3 | Self-play RL (PPO)                    | ⬜ Not started | Does PPO beat `ai_strategist` with significance?                 |
+|     4 | Ship the strongest bot                | ⬜ Not started | Winner wired as in-browser bot + in tournament pool              |
+
+**Legend:** ⬜ Not started · 🟨 In progress · ✅ Done · ⛔ Blocked · ❌ Killed (gate failed)
+
+> Update this table whenever a phase changes state. Full phase detail —
+> tasks, acceptance criteria, kill-gates — lives in [`PLAN.md`](./PLAN.md).
+
+---
+
+## How to use this folder (future sessions — read this first)
+
+- **[`PLAN.md`](./PLAN.md)** — the phases in detail: tasks (checkboxes),
+  acceptance criteria, and the go/no-go gate per phase. The source of truth for
+  "what's next."
+- **[`LOG.md`](./LOG.md)** — append-only session journal. **At the end of each
+  working session, add an entry** (what changed, what we learned, dead ends).
+  This is how context survives across days and sessions.
+- **[`RESULTS.md`](./RESULTS.md)** — the empirical scoreboard. Every
+  `arena:sweep` run gets a row. This is how we decide "better."
+- **[`DECISIONS.md`](./DECISIONS.md)** — why we chose what we chose (PPO over
+  AlphaZero, JS-engine-as-source-of-truth, etc.). Add an entry at each real
+  fork-in-the-road.
+
+---
+
+## Key grounded facts (so future sessions don't re-derive them)
+
+Verified against the code during the 2026-06-21 analysis:
+
+- **Bot contract:** `(BotState) → { from, to } | null`; `null` ends the turn.
+  Deploy via `adaptModernBot` + an entry in `src/arena/builtInBots.js` (or a
+  community-bot registry entry).
+- **Legal-action mask:** `getValidMoves(state)` — `src/engine/StateManager.js:254`.
+  Enumerates exactly the legal `(from, to)` attacks each step. Use it to mask.
+- **Exact dice odds:** `WIN_TABLE[a][d] = P(a dice beat d dice)` —
+  `src/ai/diceOdds.js`. Don't make the model learn dice math; feed win-prob as a
+  feature.
+- **Determinism:** Mulberry32 RNG state lives inside `GameState`, threaded
+  through every `applyAction`; same seed → identical game. Pass an explicit
+  `config.seed`, and the policy must avoid `Math.random`. (Note: `ai_default`,
+  `ai_example`, `ai_adaptive` call `Math.random` and are non-reproducible
+  opponents.)
+- **Measured throughput:** ~150 games/s/core pure engine (~6.6 ms/game, ~12
+  µs/`applyAction`), ~77 g/s with the Strategist heuristic, near-linear across
+  cores (~266 g/s on 4 procs). 1M engine-bound games ≈ 14–28 min on 8 cores.
+  **Inference, not the engine, will be the bottleneck.**
+- **Training-mode perf fixes:** disable the O(n²) `history` append
+  (`StateManager.js:199,244`); per-move `cloneAreas`/`recalcPlayerStats`
+  trimmable later if needed.
+- **A turn is a _sequence_ of single attacks** ended by STOP (returning `null`) —
+  model an explicit STOP action, not one batched move per turn.
+- **Reward:** terminal win/placement; free dense shaping available =
+  Δlargest-connected-group income, territory/dice deltas, eliminations (the same
+  quantities `ai_strategist` optimizes).
+- **Board:** up to 31 real territories (index 0 unused), MAX_DICE 8, default 7
+  players, maps vary in size — pad/mask, don't assume a fixed node count.

--- a/docs/ml-bot/RESULTS.md
+++ b/docs/ml-bot/RESULTS.md
@@ -1,0 +1,62 @@
+# Results Scoreboard — ML / Self-Play Bot
+
+The empirical record. **Every `arena:sweep` (or tournament) run that informs a
+go/no-go gets a row.** This is how we judge "better than `ai_strategist`."
+
+How to produce a row:
+
+```bash
+npm run arena:sweep      # multi-seed mean win%/ELO with 95% CIs
+# or, for the full field:
+npm run tournament       # built-in + community bots, persisted ELO/leaderboard
+```
+
+Record: date, the candidate bot, opponents/field, number of seeds/games, the
+candidate's win% (with CI), ELO, whether it **beats `ai_strategist` significantly**
+(✅/❌/~tie), the **`ai_strategist` commit SHA** it was measured against, and a
+notes/commit ref. Control seat/turn-order across seeds.
+
+> **`ai_strategist` is a moving target — pin it.** It is the baseline _and_ an
+> evolving bot (e.g. PR #35 changes its endgame behavior). Every row MUST record
+> the strategist commit SHA in the "Strategist @" column, so results measured
+> against different strategist versions are never compared apples-to-oranges. When
+> strategist changes, re-baseline before trusting a new candidate's edge.
+
+> **First baseline waits on PR #35.** The endgame-turtle fix (`fix/strategist-
+endgame-turtle`, PR #35) changes `ai_strategist`. Run the Phase 0 baseline sweep
+> **only after #35 has merged to master**, so the baseline is the canonical
+> strategist, not an in-flight version.
+
+> **Baseline to beat:** `ai_strategist` (post-#35). Fill its head-to-head numbers
+> on the first sweep so every later candidate has a reference.
+
+---
+
+## Headline: best bot vs `ai_strategist` over time
+
+| Date         | Candidate    | Phase | Field | Seeds/Games | Win% (95% CI) | ELO | Beats strategist? | Strategist @ | Notes / commit                                            |
+| ------------ | ------------ | ----: | ----- | ----------- | ------------- | --- | ----------------- | ------------ | --------------------------------------------------------- |
+| _2026-06-21_ | _(none yet)_ |     — | —     | —           | —             | —   | —                 | _(pin SHA)_  | Plan created; no runs yet — baseline pending PR #35 merge |
+
+---
+
+## Throughput / training-cost measurements
+
+Self-play and training throughput, so we can size compute. (Phase 1 fills the
+training-mode numbers.)
+
+| Date       | What                          | Config          | Throughput                               | Notes                                |
+| ---------- | ----------------------------- | --------------- | ---------------------------------------- | ------------------------------------ |
+| 2026-06-21 | Pure engine, random policy    | 7p, single core | ~150 games/s (~6.6 ms/game, ~12 µs/step) | From feasibility probe               |
+| 2026-06-21 | Engine + Strategist heuristic | 7p, single core | ~77 games/s                              | From feasibility probe               |
+| 2026-06-21 | Engine, parallel              | 7p, 4 procs     | ~266 games/s aggregate (~3.4×)           | Near-linear scaling                  |
+| 2026-06-21 | Engine + Lookahead bot        | 7p, single core | ~4 games/s (~243 ms/game)                | Search-heavy bot = "too slow" marker |
+
+---
+
+## Run detail (optional longer notes)
+
+Use this section for anything that doesn't fit a table cell — config files, seed
+lists, anomalies, links to replay files.
+
+_(none yet)_

--- a/docs/ml-bot/RESULTS.md
+++ b/docs/ml-bot/RESULTS.md
@@ -17,15 +17,16 @@ candidate's win% (with CI), ELO, whether it **beats `ai_strategist` significantl
 notes/commit ref. Control seat/turn-order across seeds.
 
 > **`ai_strategist` is a moving target — pin it.** It is the baseline _and_ an
-> evolving bot (e.g. PR #35 changes its endgame behavior). Every row MUST record
+> evolving bot (e.g. PR #35 changed its endgame behavior). Every row MUST record
 > the strategist commit SHA in the "Strategist @" column, so results measured
 > against different strategist versions are never compared apples-to-oranges. When
 > strategist changes, re-baseline before trusting a new candidate's edge.
 
-> **First baseline waits on PR #35.** The endgame-turtle fix (`fix/strategist-
-endgame-turtle`, PR #35) changes `ai_strategist`. Run the Phase 0 baseline sweep
-> **only after #35 has merged to master**, so the baseline is the canonical
-> strategist, not an in-flight version.
+> **First baseline: pin post-#35 strategist.** The endgame-turtle fix
+> (`fix/strategist-endgame-turtle`, PR #35) changed `ai_strategist` and **merged
+> to master on 2026-06-21 as `f5fedb2`**. Measure the Phase 0 baseline against
+> that commit (the canonical strategist) and record `f5fedb2` in the
+> "Strategist @" column.
 
 > **Baseline to beat:** `ai_strategist` (post-#35). Fill its head-to-head numbers
 > on the first sweep so every later candidate has a reference.
@@ -34,9 +35,9 @@ endgame-turtle`, PR #35) changes `ai_strategist`. Run the Phase 0 baseline sweep
 
 ## Headline: best bot vs `ai_strategist` over time
 
-| Date         | Candidate    | Phase | Field | Seeds/Games | Win% (95% CI) | ELO | Beats strategist? | Strategist @ | Notes / commit                                            |
-| ------------ | ------------ | ----: | ----- | ----------- | ------------- | --- | ----------------- | ------------ | --------------------------------------------------------- |
-| _2026-06-21_ | _(none yet)_ |     — | —     | —           | —             | —   | —                 | _(pin SHA)_  | Plan created; no runs yet — baseline pending PR #35 merge |
+| Date         | Candidate    | Phase | Field | Seeds/Games | Win% (95% CI) | ELO | Beats strategist? | Strategist @ | Notes / commit                                                          |
+| ------------ | ------------ | ----: | ----- | ----------- | ------------- | --- | ----------------- | ------------ | ----------------------------------------------------------------------- |
+| _2026-06-21_ | _(none yet)_ |     — | —     | —           | —             | —   | —                 | `f5fedb2`    | Plan created; no runs yet. #35 merged (`f5fedb2`); baseline can proceed |
 
 ---
 
@@ -45,12 +46,12 @@ endgame-turtle`, PR #35) changes `ai_strategist`. Run the Phase 0 baseline sweep
 Self-play and training throughput, so we can size compute. (Phase 1 fills the
 training-mode numbers.)
 
-| Date       | What                          | Config          | Throughput                               | Notes                                |
-| ---------- | ----------------------------- | --------------- | ---------------------------------------- | ------------------------------------ |
-| 2026-06-21 | Pure engine, random policy    | 7p, single core | ~150 games/s (~6.6 ms/game, ~12 µs/step) | From feasibility probe               |
-| 2026-06-21 | Engine + Strategist heuristic | 7p, single core | ~77 games/s                              | From feasibility probe               |
-| 2026-06-21 | Engine, parallel              | 7p, 4 procs     | ~266 games/s aggregate (~3.4×)           | Near-linear scaling                  |
-| 2026-06-21 | Engine + Lookahead bot        | 7p, single core | ~4 games/s (~243 ms/game)                | Search-heavy bot = "too slow" marker |
+| Date       | What                          | Config          | Throughput                                            | Notes                                |
+| ---------- | ----------------------------- | --------------- | ----------------------------------------------------- | ------------------------------------ |
+| 2026-06-21 | Pure engine, random policy    | 7p, single core | ~150 games/s (~6.6 ms/game, ~12 µs/step)              | From feasibility probe               |
+| 2026-06-21 | Engine + Strategist heuristic | 7p, single core | ~77 games/s                                           | From feasibility probe               |
+| 2026-06-21 | Engine + Strategist, parallel | 7p, 4 procs     | ~266 games/s aggregate (~3.4× the 77 g/s single core) | Near-linear scaling                  |
+| 2026-06-21 | Engine + Lookahead bot        | 7p, single core | ~4 games/s (~243 ms/game)                             | Search-heavy bot = "too slow" marker |
 
 ---
 


### PR DESCRIPTION
Adds a persistent, multi-session tracking folder under `docs/ml-bot/` for the ML/self-play bot effort, based on a feasibility analysis of the engine, the headless arena harness, and the RL landscape.

## Files
- **README.md** — north star, status dashboard, grounded code facts (bot contract, `getValidMoves` mask, `WIN_TABLE`, measured throughput).
- **PLAN.md** — phases 0–4 with tasks, acceptance criteria, and go/no-go gates.
- **DECISIONS.md** — ADRs: search-first/learning-second, model-free PPO over AlphaZero/MuZero, JS-engine-as-source-of-truth (Python for training only), ONNX Runtime Web deploy, `arena:sweep`-vs-`ai_strategist` as the eval gate.
- **LOG.md** — append-only session journal.
- **RESULTS.md** — empirical scoreboard; every run pins the `ai_strategist` commit SHA it was measured against.

## Verdict captured
**Large-but-doable.** The engine is an excellent RL environment (pure, seedable, ~150 games/s/core, free legal-action mask, exact dice odds). The uncertain part is beating `ai_strategist` — prior art shows naive self-play RL losing to good heuristics until bootstrapped. Strategy: bank a likely win with a pure-JS chance-node search bot (Phase 0) before spending GPU-weeks on RL.

## Notes
- **Docs only** — no code/engine changes; decoupled from the `ai_strategist` change in #35.
- The Phase 0 **baseline measurement** waits on #35 merging (it changes `ai_strategist`); building the search bot itself does not.