### PR TITLE
feat(ai): add Expectimax bot — chance-node search baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Built on the original [Dice Wars](https://www.gamedesign.jp/games/dicewars/) by 
 - **Configurable map size** — pick Small (20×24), Medium (28×32, default) or Large (36×40) before each game
 - **Bot SDK** — write a bot in a single function and compete in the arena
 - **Arena mode** — run tournaments with ELO ratings and match replays
-- **6 built-in AI strategies** — from random to exact-odds EV search
+- **7 built-in AI strategies** — from random to exact-odds EV and chance-node search
 - **PixiJS rendering** — WebGL-accelerated hex grid with dice animations
 - **Mobile-friendly** — responsive design with touch support
 
@@ -97,7 +97,7 @@ src/
 ├── renderer/     PixiJS rendering (hex grid, dice, animations)
 ├── ui/           Preact components (screens, HUD, overlays)
 ├── arena/        Bot SDK (validation, execution, tournaments, ELO, replays)
-├── ai/           6 AI strategies (example, default, defensive, adaptive, Strategist, Lookahead)
+├── ai/           7 AI strategies (example, default, defensive, adaptive, Strategist, Lookahead, Expectimax)
 ├── store/        Observable GameStore (pub/sub shared state)
 ├── controller/   GameController (game loop orchestrator)
 ├── audio/        Web Audio sound manager
@@ -108,16 +108,19 @@ See [Architecture](docs/ARCHITECTURE.md) for how data flows through the system.
 
 ## AI Strategies
 
-| Bot                                 | Strategy                                      |
-| ----------------------------------- | --------------------------------------------- |
-| **Example** (`ai_example.js`)       | Simple implementation to learn from           |
-| **Default** (`ai_default.js`)       | Original game's balanced AI                   |
-| **Defensive** (`ai_defensive.js`)   | Prioritizes protecting vulnerable territories |
-| **Adaptive** (`ai_adaptive.js`)     | Adjusts strategy based on game state          |
-| **Strategist** (`ai_strategist.js`) | Exact expected value using odds and income    |
-| **Lookahead** (`ai_lookahead.js`)   | Shallow expectimax over win/loss branches     |
+| Bot                                 | Strategy                                                  |
+| ----------------------------------- | --------------------------------------------------------- |
+| **Example** (`ai_example.js`)       | Simple implementation to learn from                       |
+| **Default** (`ai_default.js`)       | Original game's balanced AI                               |
+| **Defensive** (`ai_defensive.js`)   | Prioritizes protecting vulnerable territories             |
+| **Adaptive** (`ai_adaptive.js`)     | Adjusts strategy based on game state                      |
+| **Strategist** (`ai_strategist.js`) | Exact expected value using odds and income                |
+| **Lookahead** (`ai_lookahead.js`)   | Shallow expectimax over win/loss branches                 |
+| **Expectimax** (`ai_expectimax.js`) | Chance-node expectimax over the exact battle distribution |
 
 > **Strategist** and **Lookahead** are the two strongest built-in bots, each authored by an AI coding assistant: Strategist by **Claude Opus 4.8** and Lookahead by **GPT-5.5**. The names describe their technique (expected-value scoring vs. shallow search) rather than the tool that wrote them.
+>
+> **Expectimax** is the search-first baseline of the [ML-bot initiative](docs/ml-bot/) — a depth-2 chance-node search that scores the positions resulting from each attack's win/loss outcomes, weighted by exact dice odds.
 
 ## Documentation
 

--- a/docs/ml-bot/DECISIONS.md
+++ b/docs/ml-bot/DECISIONS.md
@@ -87,6 +87,38 @@ first-mover luck.
 
 ---
 
+## D-6 — Bot convention: legacy for the search baseline, modern for the learned bot · Accepted (2026-06-21)
+
+**Decision.** Write the **search baseline (`ai_expectimax`, Phase 0)** in the
+**legacy** convention — `(game) → 0|void`, mutating `game.area_from`/`area_to`,
+reading `game.adat`/`get_pn()` — like every other built-in. Write the eventual
+**learned bot (Phase 4 deploy, per [D-4](#d-4--deploy-via-onnx-runtime-web))** in the
+**modern** convention — a pure `(BotState) → {from,to}|null`.
+
+**Why.** The two conventions are interchangeable at the arena boundary
+(`adaptLegacyBot` synthesizes a legacy view from `BotState`), so this is about
+fit, not capability:
+
+- The search baseline exists to be measured against `ai_strategist` (D-5). Writing
+  it legacy-style lets it mirror the sibling's exact data-access patterns and reuse
+  the same connectivity economics — apples-to-apples is the whole point.
+- The learned bot is net-new, has no sibling to mirror, and benefits from the
+  clean read-only `BotState` contract (the documented public bot API). It carries
+  no reason to adopt the mutable legacy view.
+
+**Caveat (informational).** The synthesized legacy view is lossy in two fields —
+`adat[i].size` is hard-coded to `1` ("exists"), and turn order `jun` is synthetic.
+`ai_expectimax` (and `ai_strategist`) read neither: both rebuild ownership/dice/
+adjacency and compute largest-connected-group themselves. A future legacy bot that
+relied on real territory size or seat order would get degraded data — another
+reason new bots should prefer the modern convention.
+
+**Rejected.** Writing the search baseline in the modern convention — would have
+diverged from `ai_strategist`'s structure and muddied the head-to-head comparison
+the whole Phase 0 gate depends on.
+
+---
+
 ## D-Encoding — MDP / state / action / reward shape · Proposed (2026-06-21)
 
 **Proposed (finalize in Phase 2).**

--- a/src/ai/aiConfig.js
+++ b/src/ai/aiConfig.js
@@ -13,6 +13,7 @@ export const load_ai_example = async () => (await import('./ai_example.js')).ai_
 export const load_ai_adaptive = async () => (await import('./ai_adaptive.js')).ai_adaptive;
 export const load_ai_strategist = async () => (await import('./ai_strategist.js')).ai_strategist;
 export const load_ai_lookahead = async () => (await import('./ai_lookahead.js')).ai_lookahead;
+export const load_ai_expectimax = async () => (await import('./ai_expectimax.js')).ai_expectimax;
 
 /**
  * AI Strategy Registry
@@ -83,6 +84,16 @@ export const AI_STRATEGIES = {
     description: 'Searches win/loss branches with exact dice odds and board-value evaluation',
     difficulty: 5,
     loader: load_ai_lookahead,
+    implementation: null,
+  },
+
+  // Chance-node expectimax search over the exact battle distribution
+  ai_expectimax: {
+    id: 'ai_expectimax',
+    name: 'Expectimax AI',
+    description: 'Chance-node expectimax over win/loss outcomes weighted by exact dice odds',
+    difficulty: 5,
+    loader: load_ai_expectimax,
     implementation: null,
   },
 };

--- a/src/ai/ai_expectimax.js
+++ b/src/ai/ai_expectimax.js
@@ -1,0 +1,268 @@
+/**
+ * Expectimax — chance-node search over the exact battle distribution.
+ *
+ * Authored as the "search-first" baseline of the ML-bot initiative
+ * (see docs/ml-bot/). Where ai_strategist scores each candidate attack with a
+ * one-ply heuristic EV, this bot performs a genuine chance-node expectimax: it
+ * applies each attack's two real outcomes (win / loss) to copies of the board,
+ * scores the *resulting positions* with a positional evaluation, and weights
+ * them by the exact win probability:
+ *
+ *   EV(attack) = P(win) * search(boardAfterWin) + P(loss) * search(boardAfterLoss)
+ *
+ * A Dice Wars turn is a *sequence* of single attacks ended by stopping, so the
+ * search recurses on both outcome boards (a failed attack does not end the
+ * turn) up to SEARCH_DEPTH plies. This lets it plan combos a greedy scorer
+ * misses — e.g. take a low-EV cell now because it unlocks a high-value capture
+ * next. Opponent replies (which only happen after the turn ends) are proxied by
+ * the evaluation's border-vulnerability and rival-income terms.
+ *
+ * The bot is re-invoked once per attack decision, so it only commits the first
+ * move of the best plan and re-searches on the next call.
+ *
+ * Fully deterministic: no randomness; ties break toward the lowest area index
+ * (sort by score, then `from`, then `to`).
+ *
+ * NOTE: the evaluation weights below are a principled first pass aligned with
+ * ai_strategist's units. They are meant to be tuned against
+ * `npm run arena:sweep` vs ai_strategist (see docs/ml-bot/RESULTS.md). That
+ * baseline measurement waits on PR #35, which changes ai_strategist.
+ */
+
+import { MAX_DICE, WIN_TABLE } from './diceOdds.js';
+import { getPlayerCount } from './playerCount.js';
+
+// --- Search shape ---
+const SEARCH_DEPTH = 2; // plies of attack lookahead within the turn
+const TOP_K = 6; // candidate attacks expanded per node beyond the first ply
+const ATTACK_THRESHOLD = 0.05; // best attack must beat stopping by at least this EV
+
+// --- Evaluation weights (dice-equivalent units, aligned with ai_strategist) ---
+const INCOME_WEIGHT = 1.1; // value of +1 reinforcement/turn = +1 to largest group
+const TERRITORY_VALUE = 1.0; // value of holding one more territory
+const DICE_WEIGHT = 0.5; // value per die I own; also the cost of dice burned on a loss
+const THREAT_WEIGHT = 0.45; // cost of border cells an enemy can plausibly take
+const RIVAL_INCOME_WEIGHT = 0.5; // value of suppressing the strongest rival's income
+const ACTIVE_RIVAL_WEIGHT = 0.4; // value of every rival eliminated from the board
+
+const clampDie = n => (n > MAX_DICE ? MAX_DICE : n);
+
+/**
+ * Positional value of a board for `me`, in dice-equivalent units.
+ *
+ * Captures the same economics ai_strategist optimizes: reinforcement income is
+ * the size of my largest connected group (the real currency), plus territory
+ * count and striking dice, minus the exposure of takeable border cells and the
+ * income/standing of my strongest surviving rival.
+ *
+ * Ownership and dice come from the (mutated) `owner`/`dice` arrays; `alive` and
+ * `adj` are static across a search (capturing changes ownership, not which
+ * territories exist or how they connect).
+ */
+function evaluateBoard(owner, dice, alive, adj, areaMax, me, pmax) {
+  const largest = new Array(pmax).fill(0);
+  const territory = new Array(pmax).fill(0);
+  const diceTotal = new Array(pmax).fill(0);
+
+  for (let i = 1; i < areaMax; i++) {
+    if (!alive[i]) continue;
+    const o = owner[i];
+    territory[o] += 1;
+    diceTotal[o] += dice[i];
+  }
+
+  // Single all-owner connected-component pass → each player's largest group.
+  const comp = new Array(areaMax).fill(false);
+  for (let i = 1; i < areaMax; i++) {
+    if (!alive[i] || comp[i]) continue;
+    const o = owner[i];
+    const stack = [i];
+    comp[i] = true;
+    let size = 0;
+    while (stack.length > 0) {
+      const cur = stack.pop();
+      size += 1;
+      const ns = adj[cur];
+      for (let k = 0; k < ns.length; k++) {
+        const j = ns[k];
+        if (!comp[j] && owner[j] === o) {
+          comp[j] = true;
+          stack.push(j);
+        }
+      }
+    }
+    if (size > largest[o]) largest[o] = size;
+  }
+
+  /*
+   * Exposure: for each of my border cells, the best chance an enemy neighbor
+   * has of taking it. Rewards strong borders, punishes weak exposed cells.
+   */
+  let vulnerability = 0;
+  for (let i = 1; i < areaMax; i++) {
+    if (!alive[i] || owner[i] !== me) continue;
+    const ns = adj[i];
+    let worst = 0;
+    const myDie = clampDie(dice[i]);
+    for (let k = 0; k < ns.length; k++) {
+      const j = ns[k];
+      if (owner[j] === me) continue;
+      const ed = dice[j];
+      if (ed <= 1) continue;
+      const p = WIN_TABLE[clampDie(ed)][myDie];
+      if (p > worst) worst = p;
+    }
+    vulnerability += worst;
+  }
+
+  let bestRivalIncome = 0;
+  let activeRivals = 0;
+  for (let pl = 0; pl < pmax; pl++) {
+    if (pl === me) continue;
+    if (territory[pl] > 0) activeRivals += 1;
+    if (largest[pl] > bestRivalIncome) bestRivalIncome = largest[pl];
+  }
+
+  return (
+    INCOME_WEIGHT * largest[me] +
+    TERRITORY_VALUE * territory[me] +
+    DICE_WEIGHT * diceTotal[me] -
+    THREAT_WEIGHT * vulnerability -
+    RIVAL_INCOME_WEIGHT * bestRivalIncome -
+    ACTIVE_RIVAL_WEIGHT * activeRivals
+  );
+}
+
+/**
+ * Every legal attack `me` can make on this board, with the exact win
+ * probability and both pre-built outcome boards cached for reuse.
+ *
+ * Win board: defender cell becomes mine with (a-1) dice, source drops to 1.
+ * Loss board: only the source drops to 1 (ownership unchanged, so it shares the
+ * caller's `owner` array — no copy needed).
+ */
+function enumerateAttacks(owner, dice, alive, adj, areaMax, me) {
+  const moves = [];
+  for (let from = 1; from < areaMax; from++) {
+    if (!alive[from] || owner[from] !== me || dice[from] <= 1) continue;
+    const a = dice[from];
+    const ns = adj[from];
+    for (let k = 0; k < ns.length; k++) {
+      const to = ns[k];
+      if (owner[to] === me) continue;
+      const p = WIN_TABLE[clampDie(a)][clampDie(dice[to])];
+
+      const winOwner = owner.slice();
+      const winDice = dice.slice();
+      winOwner[to] = me;
+      winDice[to] = a - 1;
+      winDice[from] = 1;
+
+      const lossDice = dice.slice();
+      lossDice[from] = 1;
+
+      moves.push({ from, to, p, winOwner, winDice, lossDice });
+    }
+  }
+  return moves;
+}
+
+/**
+ * Chance-node expectimax. Returns the best continuation value for `me` from
+ * this board and the first attack that achieves it (`from === -1` ⇒ stop).
+ *
+ * At every node `me` may stop (value = evaluateBoard) or attack; each attack is
+ * a chance node mixing its win/loss continuations by the exact odds. Beyond the
+ * first ply only the TOP_K attacks (ranked by their one-ply EV) are expanded,
+ * bounding the branching of the otherwise quadratic-per-ply search.
+ */
+function search(owner, dice, alive, adj, areaMax, me, pmax, depth) {
+  const stopValue = evaluateBoard(owner, dice, alive, adj, areaMax, me, pmax);
+  if (depth <= 0) return { value: stopValue, from: -1, to: -1 };
+
+  const moves = enumerateAttacks(owner, dice, alive, adj, areaMax, me);
+  if (moves.length === 0) return { value: stopValue, from: -1, to: -1 };
+
+  // One-ply EV of each attack: weight the two outcome positions by the odds.
+  for (const m of moves) {
+    const vWin = evaluateBoard(m.winOwner, m.winDice, alive, adj, areaMax, me, pmax);
+    const vLoss = evaluateBoard(owner, m.lossDice, alive, adj, areaMax, me, pmax);
+    m.immediate = m.p * vWin + (1 - m.p) * vLoss;
+  }
+
+  let candidates;
+  if (depth === 1) {
+    // Leaf decision: the one-ply EV is the value.
+    for (const m of moves) m.value = m.immediate;
+    candidates = moves;
+  } else {
+    // Expand only the most promising attacks one ply deeper.
+    moves.sort((x, y) => y.immediate - x.immediate || x.from - y.from || x.to - y.to);
+    candidates = moves.slice(0, TOP_K);
+    for (const m of candidates) {
+      const win = search(m.winOwner, m.winDice, alive, adj, areaMax, me, pmax, depth - 1);
+      const loss = search(owner, m.lossDice, alive, adj, areaMax, me, pmax, depth - 1);
+      m.value = m.p * win.value + (1 - m.p) * loss.value;
+    }
+  }
+
+  // Deterministic best: highest value, then lowest from, then lowest to.
+  candidates.sort((x, y) => y.value - x.value || x.from - y.from || x.to - y.to);
+  const best = candidates[0];
+
+  if (best.value > stopValue + ATTACK_THRESHOLD) {
+    return { value: best.value, from: best.from, to: best.to };
+  }
+  return { value: stopValue, from: -1, to: -1 };
+}
+
+/**
+ * Expectimax AI entry point (legacy convention): reads the mutable game view,
+ * sets `game.area_from` / `game.area_to` for the chosen attack, and returns 0
+ * to end the turn when stopping is best.
+ *
+ * @param {Object} game - Legacy game view (get_pn, adat[], AREA_MAX, ...).
+ * @returns {0|undefined} 0 to end the turn; otherwise sets the attack in place.
+ */
+export const ai_expectimax = game => {
+  const me = game.get_pn();
+  const { adat, AREA_MAX } = game;
+  const pmax = getPlayerCount(game);
+
+  /*
+   * Build a compact, search-friendly snapshot once: ownership, dice, liveness,
+   * and adjacency restricted to live territories (all static under capture).
+   */
+  const alive = new Array(AREA_MAX).fill(false);
+  const owner = new Array(AREA_MAX).fill(-1);
+  const dice = new Array(AREA_MAX).fill(0);
+  const adj = new Array(AREA_MAX);
+  let myTerritories = 0;
+
+  for (let i = 1; i < AREA_MAX; i++) {
+    const area = adat[i];
+    if (!area || area.size === 0) {
+      adj[i] = [];
+      continue;
+    }
+    alive[i] = true;
+    owner[i] = area.arm;
+    dice[i] = area.dice;
+    if (area.arm === me) myTerritories += 1;
+    const list = [];
+    const { join } = area;
+    for (let j = 1; j < AREA_MAX; j++) {
+      if (join[j] && adat[j] && adat[j].size !== 0) list.push(j);
+    }
+    adj[i] = list;
+  }
+
+  if (myTerritories === 0) return 0;
+
+  const best = search(owner, dice, alive, adj, AREA_MAX, me, pmax, SEARCH_DEPTH);
+  if (best.from === -1) return 0;
+
+  game.area_from = best.from;
+  game.area_to = best.to;
+  return undefined;
+};

--- a/src/ai/ai_expectimax.js
+++ b/src/ai/ai_expectimax.js
@@ -172,9 +172,10 @@ function enumerateAttacks(owner, dice, alive, adj, areaMax, me) {
  * this board and the first attack that achieves it (`from === -1` ⇒ stop).
  *
  * At every node `me` may stop (value = evaluateBoard) or attack; each attack is
- * a chance node mixing its win/loss continuations by the exact odds. Beyond the
- * first ply only the TOP_K attacks (ranked by their one-ply EV) are expanded,
- * bounding the branching of the otherwise quadratic-per-ply search.
+ * a chance node mixing its win/loss continuations by the exact odds. Internal
+ * nodes (depth > 1) recurse into only the TOP_K attacks ranked by their one-ply
+ * EV, bounding the branching of the otherwise quadratic-per-ply search; leaf
+ * nodes (depth === 1) score every attack by that one-ply EV without recursing.
  */
 function search(owner, dice, alive, adj, areaMax, me, pmax, depth) {
   const stopValue = evaluateBoard(owner, dice, alive, adj, areaMax, me, pmax);

--- a/src/ai/ai_expectimax.js
+++ b/src/ai/ai_expectimax.js
@@ -25,8 +25,7 @@
  *
  * NOTE: the evaluation weights below are a principled first pass aligned with
  * ai_strategist's units. They are meant to be tuned against
- * `npm run arena:sweep` vs ai_strategist (see docs/ml-bot/RESULTS.md). That
- * baseline measurement waits on PR #35, which changes ai_strategist.
+ * `npm run arena:sweep` vs the current ai_strategist (see docs/ml-bot/RESULTS.md).
  */
 
 import { MAX_DICE, WIN_TABLE } from './diceOdds.js';
@@ -34,7 +33,7 @@ import { getPlayerCount } from './playerCount.js';
 
 // --- Search shape ---
 const SEARCH_DEPTH = 2; // plies of attack lookahead within the turn
-const TOP_K = 6; // candidate attacks expanded per node beyond the first ply
+const TOP_K = 6; // attacks recursed into per internal node (depth > 1); leaves score all
 const ATTACK_THRESHOLD = 0.05; // best attack must beat stopping by at least this EV
 
 // --- Evaluation weights (dice-equivalent units, aligned with ai_strategist) ---

--- a/src/arena/builtInBots.js
+++ b/src/arena/builtInBots.js
@@ -14,6 +14,7 @@ import { ai_defensive } from '../ai/ai_defensive.js';
 import { ai_adaptive } from '../ai/ai_adaptive.js';
 import { ai_strategist } from '../ai/ai_strategist.js';
 import { ai_lookahead } from '../ai/ai_lookahead.js';
+import { ai_expectimax } from '../ai/ai_expectimax.js';
 
 export const BUILT_IN_BOTS = [
   { id: 'ai_example', name: 'Example', fn: adaptLegacyBot(ai_example, 'Example') },
@@ -22,4 +23,5 @@ export const BUILT_IN_BOTS = [
   { id: 'ai_adaptive', name: 'Adaptive', fn: adaptLegacyBot(ai_adaptive, 'Adaptive') },
   { id: 'ai_strategist', name: 'Strategist', fn: adaptLegacyBot(ai_strategist, 'Strategist') },
   { id: 'ai_lookahead', name: 'Lookahead', fn: adaptLegacyBot(ai_lookahead, 'Lookahead') },
+  { id: 'ai_expectimax', name: 'Expectimax', fn: adaptLegacyBot(ai_expectimax, 'Expectimax') },
 ];

--- a/tests/ai/ai_expectimax.test.js
+++ b/tests/ai/ai_expectimax.test.js
@@ -1,0 +1,163 @@
+/**
+ * Tests for the Expectimax AI (chance-node search baseline).
+ *
+ * Mirrors the legacy-view test harness used by ai_strategist: a mutable
+ * `game` with an `adat` territory table, `get_pn()`, and `area_from/area_to`
+ * set in place by the bot.
+ */
+import { ai_expectimax } from '../../src/ai/ai_expectimax.js';
+
+describe('Expectimax AI', () => {
+  let mockGame;
+
+  /** Symmetrically connect two territories */
+  const link = (a, b) => {
+    mockGame.adat[a].join[b] = 1;
+    mockGame.adat[b].join[a] = 1;
+  };
+
+  /** Create a territory with owner and dice */
+  const territory = (id, arm, dice) => {
+    mockGame.adat[id].size = 10;
+    mockGame.adat[id].arm = arm;
+    mockGame.adat[id].dice = dice;
+  };
+
+  beforeEach(() => {
+    mockGame = {
+      AREA_MAX: 32,
+      adat: [],
+      area_from: 0,
+      area_to: 0,
+      jun: [0, 1, 2, 3, 4, 5, 6, 7],
+      ban: 1, // Current turn is player 1
+      player: [],
+      get_pn() {
+        return this.jun[this.ban];
+      },
+    };
+
+    for (let i = 0; i < 8; i++) {
+      mockGame.player[i] = { area_c: 0, dice_c: 0, area_tc: 0, dice_jun: 0, stock: 0 };
+    }
+
+    for (let i = 0; i < mockGame.AREA_MAX; i++) {
+      mockGame.adat[i] = { size: 0, arm: 0, dice: 0, join: Array(32).fill(0) };
+    }
+  });
+
+  test('ends turn when no valid moves are available', () => {
+    territory(1, 1, 1); // Own territory with only 1 die cannot attack
+
+    const result = ai_expectimax(mockGame);
+
+    expect(result).toBe(0);
+    expect(mockGame.area_from).toBe(0);
+    expect(mockGame.area_to).toBe(0);
+  });
+
+  test('ends turn when player has no territories', () => {
+    territory(1, 2, 3);
+    territory(2, 3, 2);
+    link(1, 2);
+
+    expect(ai_expectimax(mockGame)).toBe(0);
+  });
+
+  test('attacks with a clear dice advantage', () => {
+    territory(1, 1, 4);
+    territory(2, 2, 1);
+    territory(3, 2, 1); // Second enemy territory so no elimination skews it
+    link(1, 2);
+
+    const result = ai_expectimax(mockGame);
+
+    expect(result).not.toBe(0);
+    expect(mockGame.area_from).toBe(1);
+    expect(mockGame.area_to).toBe(2);
+  });
+
+  test('declines a clearly disadvantaged attack', () => {
+    territory(1, 1, 2);
+    territory(2, 2, 5); // Defender much stronger
+    territory(3, 2, 5);
+    link(1, 2);
+    link(2, 3);
+
+    const result = ai_expectimax(mockGame);
+
+    expect(result).toBe(0);
+  });
+
+  test('proposes only legal attacks on a mixed board', () => {
+    territory(1, 1, 3);
+    territory(2, 1, 2);
+    territory(3, 2, 2);
+    territory(4, 3, 1);
+    territory(5, 2, 8);
+    link(1, 3);
+    link(2, 4);
+    link(3, 5);
+    link(1, 2);
+
+    const result = ai_expectimax(mockGame);
+
+    if (result !== 0) {
+      const from = mockGame.adat[mockGame.area_from];
+      const to = mockGame.adat[mockGame.area_to];
+      expect(from.arm).toBe(1); // Attacks from own territory
+      expect(from.dice).toBeGreaterThan(1); // With more than 1 die
+      expect(to.arm).not.toBe(1); // Against an enemy
+      expect(from.join[mockGame.area_to]).toBe(1); // That is adjacent
+    }
+  });
+
+  test('prefers a near-certain elimination over a coin-flip non-cutting fight', () => {
+    territory(1, 1, 8); // My strong attacker
+    territory(2, 2, 1); // Player 2's only territory -> trivial 8v1 elimination
+    territory(3, 3, 8); // Player 3 cell: an 8v8 coin flip, and isolated...
+    territory(4, 3, 1); // ...Player 3's other cell is not adjacent (no group to cut)
+    link(1, 2);
+    link(1, 3);
+
+    ai_expectimax(mockGame);
+
+    expect(mockGame.area_from).toBe(1);
+    expect(mockGame.area_to).toBe(2);
+  });
+
+  test('is deterministic for identical states', () => {
+    const setup = game => {
+      const t = (id, arm, dice) => {
+        game.adat[id].size = 10;
+        game.adat[id].arm = arm;
+        game.adat[id].dice = dice;
+      };
+      const l = (a, b) => {
+        game.adat[a].join[b] = 1;
+        game.adat[b].join[a] = 1;
+      };
+      t(1, 1, 5);
+      t(2, 1, 3);
+      t(3, 2, 2);
+      t(4, 2, 2);
+      t(5, 3, 3);
+      l(1, 3);
+      l(2, 4);
+      l(3, 4);
+      l(4, 5);
+      l(1, 5);
+    };
+
+    setup(mockGame);
+    ai_expectimax(mockGame);
+    const firstMove = { from: mockGame.area_from, to: mockGame.area_to };
+
+    mockGame.area_from = 0;
+    mockGame.area_to = 0;
+    ai_expectimax(mockGame);
+
+    expect(mockGame.area_from).toBe(firstMove.from);
+    expect(mockGame.area_to).toBe(firstMove.to);
+  });
+});

--- a/tests/ai/ai_expectimax.test.js
+++ b/tests/ai/ai_expectimax.test.js
@@ -247,6 +247,27 @@ describe('Expectimax AI', () => {
     expect(mockGame.area_to).toBe(3);
   });
 
+  test('plays a legal move as the highest-indexed player in a 9-player game', () => {
+    /*
+     * The online tournament seats more than 8 players, so the bot must handle
+     * being player 8 — an owner index past the usual 8 slots. getPlayerCount
+     * sizes the census to one past the highest board owner (9 here) even though
+     * player[] holds only 8 entries, so evaluateBoard's per-player arrays must
+     * cover index 8 without going out of bounds. Guards that sizing path for the
+     * highest-indexed seat (a config unit board tests otherwise never exercise).
+     */
+    mockGame.jun = [0, 1, 2, 3, 4, 5, 6, 7, 8];
+    mockGame.ban = 8; // get_pn() -> 8
+    territory(1, 8, 5); // my cell (player 8)
+    territory(2, 2, 1); // weak enemy, a near-certain capture
+    territory(3, 2, 1); // second enemy cell so the capture is not an elimination
+    link(1, 2);
+
+    expect(() => ai_expectimax(mockGame)).not.toThrow();
+    expect(mockGame.area_from).toBe(1);
+    expect(mockGame.area_to).toBe(2);
+  });
+
   test('is deterministic for identical states', () => {
     const setup = game => {
       const t = (id, arm, dice) => {

--- a/tests/ai/ai_expectimax.test.js
+++ b/tests/ai/ai_expectimax.test.js
@@ -112,6 +112,31 @@ describe('Expectimax AI', () => {
     }
   });
 
+  test('plans a deeper combo than a one-ply scorer would (depth-2 differentiator)', () => {
+    /*
+     * Same board as the legality test above, chosen because it is a verified
+     * depth divergence and guards the bot's headline lookahead: a greedy
+     * one-ply scorer takes 2->4, but the depth-2 search prefers 1->3 (capturing
+     * area 3 opens a profitable continuation a one-ply scorer cannot see).
+     * Verified to flip to 2->4 when SEARCH_DEPTH is reduced to 1, so this
+     * assertion fails if the search silently collapses to greedy.
+     */
+    territory(1, 1, 3);
+    territory(2, 1, 2);
+    territory(3, 2, 2);
+    territory(4, 3, 1);
+    territory(5, 2, 8);
+    link(1, 3);
+    link(2, 4);
+    link(3, 5);
+    link(1, 2);
+
+    ai_expectimax(mockGame);
+
+    expect(mockGame.area_from).toBe(1);
+    expect(mockGame.area_to).toBe(3);
+  });
+
   test('prefers a near-certain elimination over a coin-flip non-cutting fight', () => {
     territory(1, 1, 8); // My strong attacker
     territory(2, 2, 1); // Player 2's only territory -> trivial 8v1 elimination

--- a/tests/ai/ai_expectimax.test.js
+++ b/tests/ai/ai_expectimax.test.js
@@ -137,11 +137,18 @@ describe('Expectimax AI', () => {
     expect(mockGame.area_to).toBe(3);
   });
 
-  test('prefers a near-certain elimination over a coin-flip non-cutting fight', () => {
+  test('prefers a safe near-certain capture over a coin-flip fight', () => {
+    /*
+     * The near-certain 8v1 (area 2) dominates the 8v8 coin-flip (area 3) on pure
+     * capture EV alone — this guards the bot's risk discipline, not its
+     * elimination logic. That area 2 is its owner's last cell is incidental; the
+     * active-rival/elimination term is isolated separately below in "eliminates a
+     * rival when the capture EV is otherwise equal".
+     */
     territory(1, 1, 8); // My strong attacker
-    territory(2, 2, 1); // Player 2's only territory -> trivial 8v1 elimination
-    territory(3, 3, 8); // Player 3 cell: an 8v8 coin flip, and isolated...
-    territory(4, 3, 1); // ...Player 3's other cell is not adjacent (no group to cut)
+    territory(2, 2, 1); // A near-certain 8v1 capture
+    territory(3, 3, 8); // vs an 8v8 coin flip...
+    territory(4, 3, 1); // ...whose owner has another, non-adjacent cell
     link(1, 2);
     link(1, 3);
 
@@ -149,6 +156,95 @@ describe('Expectimax AI', () => {
 
     expect(mockGame.area_from).toBe(1);
     expect(mockGame.area_to).toBe(2);
+  });
+
+  test('prefers a bridge capture that merges two groups (win-board income term)', () => {
+    /*
+     * Single attacker (area 1, 4 dice) with two equal near-certain 4v1 captures:
+     * area 4 BRIDGES my two isolated cells (1 and 2) into one group of 3, while
+     * area 3 is a dead-end capture leaving my largest group at 2. Personal gains
+     * (territory, dice), exposure, and rival terms are identical between the two;
+     * the ONLY differing input is my largest connected group on the win board, so
+     * this isolates the INCOME/largest-group term in evaluateBoard.
+     *
+     * Layout is chosen so the WRONG choice (dead-end, area 3) is the lower index:
+     * if the income term were ignored the two captures tie and the index
+     * tie-break would pick area 3, so asserting area 4 genuinely exercises income.
+     * Area 2 has 1 die so it cannot attack — no second-ply merge can skew it.
+     */
+    territory(1, 1, 4); // my only attacker
+    territory(2, 1, 1); // my other cell (isolated from 1; cannot attack)
+    territory(3, 2, 1); // dead-end: adjacent to 1 only (lower index = tie-break default)
+    territory(4, 2, 1); // bridge: adjacent to both 1 and 2
+    link(1, 3);
+    link(1, 4);
+    link(2, 4);
+
+    ai_expectimax(mockGame);
+
+    expect(mockGame.area_from).toBe(1);
+    expect(mockGame.area_to).toBe(4);
+  });
+
+  test('prefers the capture that leaves a safer border (enemy-perspective vulnerability)', () => {
+    /*
+     * Single attacker (area 1, 2 dice) with two equal 2v1 captures. Capturing
+     * area 2 backs my new cell onto a strong enemy (area 4, 8 dice); capturing
+     * area 3 backs onto a weak enemy (area 5, 2 dice). Personal gains and rival
+     * terms are identical; only the post-capture border exposure differs, so this
+     * pins the vulnerability term's orientation: WIN_TABLE[enemyDice][myDice] (the
+     * enemy's odds against my cell), not the reverse. The 8-dice neighbor also
+     * exercises the clampDie/MAX_DICE boundary.
+     *
+     * Captured cells end at 1 die (cannot counter-attack), so no second-ply bonus
+     * confounds the comparison. The safe choice (area 3) is the HIGHER index, so a
+     * reversed index — WIN_TABLE[8][1]=1 becomes WIN_TABLE[1][8]=0 — would zero
+     * both exposures and the tie-break would (wrongly) pick area 2, failing this.
+     */
+    territory(1, 1, 2); // my only attacker
+    territory(2, 2, 1); // capture backs onto a strong enemy (area 4) — exposed
+    territory(3, 2, 1); // capture backs onto a weak enemy (area 5) — safer
+    territory(4, 3, 8); // strong threat behind area 2
+    territory(5, 3, 2); // weak threat behind area 3
+    link(1, 2);
+    link(1, 3);
+    link(2, 4);
+    link(3, 5);
+
+    ai_expectimax(mockGame);
+
+    expect(mockGame.area_from).toBe(1);
+    expect(mockGame.area_to).toBe(3);
+  });
+
+  test('eliminates a rival when the capture EV is otherwise equal (active-rival term)', () => {
+    /*
+     * Single attacker (area 1, 8 dice) with two equal 8v2 captures. Capturing
+     * area 3 removes player 2 from the board (its only cell); capturing area 2
+     * leaves every player alive. Win probability, personal gain (territory, dice,
+     * largest group), post-capture exposure, and best-rival income are all
+     * identical between the two — the ONLY differing input is the active-rival
+     * count, so this isolates the elimination term.
+     *
+     * The eliminating move (area 3) is the HIGHER index, so if the active-rival
+     * term were ignored the two captures tie and the tie-break would (wrongly)
+     * pick area 2 — asserting area 3 genuinely exercises the elimination term.
+     * Player 3's second cell (area 4) is walled off, so no second-ply elimination
+     * can skew it.
+     */
+    territory(1, 1, 8); // my only attacker
+    territory(2, 3, 2); // player 3 survives this capture (still owns area 4)
+    territory(3, 2, 2); // player 2's ONLY cell -> capturing eliminates player 2
+    territory(4, 3, 1); // player 3's other cell, walled off behind area 5
+    territory(5, 4, 1); // neutral wall so area 4 is unreachable from my cells
+    link(1, 2);
+    link(1, 3);
+    link(4, 5);
+
+    ai_expectimax(mockGame);
+
+    expect(mockGame.area_from).toBe(1);
+    expect(mockGame.area_to).toBe(3);
   });
 
   test('is deterministic for identical states', () => {


### PR DESCRIPTION
Phase 0 of the ML-bot initiative (see `docs/ml-bot/`, PR #36): the "search-first" baseline — a depth-2 chance-node expectimax over the exact battle distribution.

## What it does
For each legal attack it applies the **real** win/loss outcomes to board copies, scores the resulting positions with a positional evaluation (largest connected-group income, territory count, dice, border exposure, rival-income suppression), and weights them by `WIN_TABLE` odds:

```
EV(attack) = P(win)·search(boardAfterWin) + P(loss)·search(boardAfterLoss)
```

It recurses on **both** outcomes because a failed attack does not end the turn, so it can plan intra-turn attack combos a greedy one-ply scorer misses. The bot is re-invoked per attack, so it commits only the first move of the best plan and re-searches.

## Implementation notes
- Pure-JS, **legacy convention** (`game => {…}`, sets `area_from`/`area_to`, returns `0` to stop) to match `ai_strategist` and reuse the `adat` board model.
- Reuses `src/ai/diceOdds.js` `WIN_TABLE` (exact odds) — no learned/approximate dice math.
- Fully deterministic; ties break toward the lowest area index.
- Registered as built-in bot **`Expectimax`**.

## Verification
- Unit tests added (`tests/ai/ai_expectimax.test.js`); full suite green (**723 tests**).
- Lint clean.
- Put through the **game-ai-reviewer** agent: no correctness/contract bugs — win/loss board mutations match `StateManager.applyAttack` exactly, only-legal-moves, deterministic, no crash risks.

## Strength (and what's deferred)
Smoke runs (single-seed, 6-bot field) show it **correct and competitive but not yet beating `ai_strategist`** — mid-pack, with one tuning pass lifting Attack-Win% from 70.5% → 79.1%. The eval weights are a documented **first pass**.

**Strength tuning is intentionally deferred** to the gated multi-seed `arena:sweep` vs the *canonical* `ai_strategist` — which PR #35 changes. Tuning against pre-#35 Strategist on single seeds would chase a moving target. See `docs/ml-bot/PLAN.md` (Phase 0 gate) and `RESULTS.md` (baseline waits on #35).

Merges independently of #35 and #36; this is a self-contained new bot.