### PR TITLE
feat(arena): parallel self-play harness (ml-bot Phase 1, task 5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ benchmark-results/
 # ES Module cache
 .esm-cache/
 
+# Self-play training data (scripts/selfplay.mjs) — large generated JSONL
+data/selfplay/
+
 # Specific files to ignore
 **/.claude/settings.local.json
 

--- a/docs/ml-bot/LOG.md
+++ b/docs/ml-bot/LOG.md
@@ -21,6 +21,66 @@ Entry template:
 
 ---
 
+## 2026-06-22 — Phase-1 task 5: parallel self-play harness scaffolded
+
+**Phase:** 1 · **Who:** Ivan + Claude
+
+**Did:**
+
+- Built the committed parallel self-play harness (D-12) on branch
+  `ml-bot/selfplay-harness`. Three files + a test + `npm run selfplay`:
+  - `scripts/lib/selfplay-core.mjs` — worker-agnostic core. `generateShard` runs a
+    seed block through `runMatch` in training mode (`recordHistory:false` +
+    `recordTrajectory:true`), streams each **clean** lean trajectory via an injected
+    `write` callback, and keeps only tiny per-game summaries — the heavy
+    `MatchResult`/`finalState`/`trajectory` drop out of scope each iteration (the
+    RAM-safety crux at 100k–1M games). `forcedEndReason` is the D-14 quarantine
+    predicate (drop any game where a bot's `errors`/`invalidMoves`/`maxMovesHit > 0`).
+    `aggregateStats` is the single-threaded, path-dependent ELO post-pass replayed over
+    summaries sorted by seed (scheduler-independent). `makeFileWriter` is a
+    backpressure-free batched `fs.writeSync` JSONL sink.
+  - `scripts/lib/selfplay-worker.mjs` — `worker_threads` entry; receives bot **names**,
+    not closures (D-12), resolves them itself, streams its shard to its own part-file.
+  - `scripts/selfplay.mjs` — CLI. Seed-range sharding
+    (`--seed-start`/`--seed-count`/`--out`), worker pool (default ~50% cores) or an
+    inline single-core baseline (`--workers 1`), `--no-write` throughput-only mode,
+    contiguous seed blocks concatenated in seed order. Defaults to the seed-pure
+    heterogeneous decisive field (Strategist/Expectimax/Lookahead/Defensive); warns on
+    `Math.random` bots (break the same-seed→same-game sharding guarantee). Prints
+    throughput, clean-rate + per-signal quarantine breakdown, action-count distribution,
+    and ELO.
+  - `tests/scripts/selfplay.test.js` — 18 tests (all green): round-trip per clean game,
+    determinism modulo timestamp, the D-14 quarantine for all three signals (throw →
+    `errors`; repeated invalid → `invalidMoves`; cap → `maxMovesHit`), the abort-on-failure
+    guard, order-independent ELO aggregation, writer flush boundary, and a worker-pool
+    **e2e** that asserts seed-ordered, round-trippable JSONL with no orphaned part-files.
+- Ran an adversarial multi-agent review of the scaffold (17 agents; 12 findings → 7
+  confirmed, 5 refuted) and fixed all 7: hardened the worker-pool error path (terminate
+  stragglers + clean up `.partN` files in a `finally`; `concatParts` destroys its stream
+  on error and no longer owns deletion), made `writer.close()` idempotent and
+  `finally`-guarded in the worker and inline paths (no fd leak on a `generateShard` throw),
+  and added a `runMatchFn` test seam so the `maxMovesHit` and abort paths (not triggerable
+  with real games) are deterministically tested. Full suite **821 passing**, lint clean,
+  build green.
+
+**Learned / decided:**
+
+- Used `fs.writeSync` (batched), not a `WriteStream`: `generateShard` is a tight sync
+  loop that never yields, so a stream's `'drain'` backpressure can't run mid-shard and
+  its buffer could grow unbounded on a fast/cheap field. Blocking writes from a worker
+  sidestep that and keep the core synchronous + unit-testable.
+- The lean record carries a wall-clock `metadata.timestamp`, so the determinism test
+  compares games with the timestamp stripped — game _content_ (seed/actions/outcome) is
+  deterministic; the stamp isn't. Harmless for the merge story (no collisions).
+- Smoke numbers (tiny N, overhead-dominated): ~10 g/s 1-worker vs ~22 g/s 3-worker on
+  the decisive seed-pure field. Real scaling numbers belong in `RESULTS.md` once task 3's
+  trims land — deferred per the gate.
+
+**Next:**
+
+- Task 3 (per-move allocation trims), then record before/after + single-core-vs-N-worker
+  throughput and the action-count distribution in `RESULTS.md` to close the Phase-1 gate.
+
 ## 2026-06-22 — PR #42 review hardening (boundary + forced-end signal)
 
 **Phase:** 1 · **Who:** Ivan + Claude

--- a/docs/ml-bot/PLAN.md
+++ b/docs/ml-bot/PLAN.md
@@ -226,6 +226,21 @@ _parallel_ self-play environment. No learning yet.
       counter (not derived from turn length), so the whole game is dropped uniformly
       across all three signals. Keeps the lean record pure; no per-action markers in the
       format.
+      **Scaffold landed (2026-06-22):** committed `scripts/selfplay.mjs` + `npm run selfplay`,
+      with the worker-agnostic core split into `scripts/lib/selfplay-core.mjs`
+      (`generateShard` streams clean trajectories via an injected writer and never retains
+      `MatchResult`/`finalState`; `forcedEndReason` is the D-14 quarantine predicate;
+      `aggregateStats` is the single-threaded path-dependent ELO post-pass over seeds;
+      `makeFileWriter` is a backpressure-free `fs.writeSync` JSONL sink) and the
+      `worker_threads` entry in `scripts/lib/selfplay-worker.mjs` (receives bot **names**,
+      not closures). CLI is shardable by seed range (`--seed-start`/`--seed-count`/`--out`,
+      contiguous blocks concatenated in seed order), defaults to a seed-pure heterogeneous
+      decisive field, warns on `Math.random` bots, and reports throughput + clean-rate +
+      action-count distribution + ELO. Tests: `tests/scripts/selfplay.test.js` (16, incl. a
+      worker-pool e2e that round-trips seed-ordered JSONL). **Still open before the checkbox
+      flips:** the before/after-trims and single-core-vs-N-worker throughput numbers in
+      `RESULTS.md` (gated on task 3's per-move trims) and the near-linear-scaling
+      confirmation.
 
 **Acceptance criteria.**
 

--- a/docs/ml-bot/PLAN.md
+++ b/docs/ml-bot/PLAN.md
@@ -236,8 +236,9 @@ _parallel_ self-play environment. No learning yet.
       not closures). CLI is shardable by seed range (`--seed-start`/`--seed-count`/`--out`,
       contiguous blocks concatenated in seed order), defaults to a seed-pure heterogeneous
       decisive field, warns on `Math.random` bots, and reports throughput + clean-rate +
-      action-count distribution + ELO. Tests: `tests/scripts/selfplay.test.js` (16, incl. a
-      worker-pool e2e that round-trips seed-ordered JSONL). **Still open before the checkbox
+      action-count distribution + ELO. Tests: `tests/scripts/selfplay.test.js` (covers the
+      core, worker plumbing, CLI validation, the single-core inline path, and a worker-pool
+      e2e that round-trips seed-ordered JSONL). **Still open before the checkbox
       flips:** the before/after-trims and single-core-vs-N-worker throughput numbers in
       `RESULTS.md` (gated on task 3's per-move trims) and the near-linear-scaling
       confirmation.

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "validate-bot": "node scripts/validate-bot.mjs",
     "benchmark-bot": "node scripts/benchmark-bot.mjs",
     "validate-community-bots": "node scripts/validate-community-bots.mjs",
-    "tournament": "node scripts/run-online-tournament.mjs"
+    "tournament": "node scripts/run-online-tournament.mjs",
+    "selfplay": "node scripts/selfplay.mjs"
   },
   "keywords": [
     "game",

--- a/scripts/lib/selfplay-core.mjs
+++ b/scripts/lib/selfplay-core.mjs
@@ -262,7 +262,7 @@ export function generateShard({
       quarantined: reason !== null,
       quarantineSignal: reason?.signal ?? null,
     });
-    // `result` (with finalState + trajectory) drops out of scope here — not retained.
+    // `result` (with finalState + trajectory) is overwritten next iteration, never collected into an array — not retained.
 
     if (progressEvery && onProgress && (idx + 1) % progressEvery === 0) {
       onProgress({ done: idx + 1, total: seeds.length, written, quarantined, failed });
@@ -358,7 +358,7 @@ export function aggregateStats(summaries, botNames) {
     if (s.failed) {
       failedGames++;
       quarantineBySignal.failed++;
-      const msg = s.error ?? 'unknown error';
+      const msg = s.error || 'unknown error'; // a blank '' message must still be labeled (|| not ??)
       const prev = failureMessages.get(msg);
       if (prev) {
         prev.count++;
@@ -433,6 +433,21 @@ export function aggregateStats(summaries, botNames) {
     },
     bots,
   };
+}
+
+/**
+ * The CLI's non-zero-exit policy, factored out as a pure predicate so the exit contract
+ * is unit-testable without spawning the CLI. A run is "unusable" — and the process should
+ * exit non-zero so an unattended/pipeline caller doesn't consume it as success — when it
+ * aborted (excessive game failures), or it was meant to write data (`wroteOutput`) but
+ * produced zero clean games. A `--no-write` throughput probe (`wroteOutput:false`) is never
+ * unusable on the clean-count alone.
+ *
+ * @param {{ aborted: boolean, wroteOutput: boolean, cleanGames: number }} run
+ * @returns {boolean}
+ */
+export function isUnusableRun({ aborted, wroteOutput, cleanGames }) {
+  return aborted || (wroteOutput && cleanGames === 0);
 }
 
 /**

--- a/scripts/lib/selfplay-core.mjs
+++ b/scripts/lib/selfplay-core.mjs
@@ -320,10 +320,25 @@ const FAILURE_SAMPLE_LIMIT = 5;
  * got them dropped.
  *
  * @param {GameSummary[]} summaries - All per-game summaries (any order)
- * @param {string[]} botNames - Bot names by player index (constant across self-play games)
+ * @param {string[]} botNames - Bot names by player index (constant across self-play games);
+ *   must be distinct (ELO/wins are keyed by name, so duplicates would collide two seats)
  * @returns {SelfPlayStats}
+ * @throws {Error} If `botNames` contains a duplicate.
  */
 export function aggregateStats(summaries, botNames) {
+  /*
+   * ELO/wins are keyed by bot name below, so two seats sharing a name would
+   * silently collapse into one rating and skew the result. The CLI can't reach
+   * this (matchRunner rejects a duplicate-name field before any game runs), but
+   * this is an exported, independently-callable function — fail loud rather than
+   * return a quietly-wrong ranking.
+   */
+  if (new Set(botNames).size !== botNames.length) {
+    throw new Error(
+      `aggregateStats requires distinct bot names (ELO/wins are keyed by name); got [${botNames.join(', ')}]`
+    );
+  }
+
   const totalGames = summaries.length;
   const clean = summaries.filter(s => !s.quarantined);
   // Deterministic ELO order: replay clean games by ascending seed.

--- a/scripts/lib/selfplay-core.mjs
+++ b/scripts/lib/selfplay-core.mjs
@@ -20,7 +20,7 @@
  *   2. {@link forcedEndReason} — the D-14 data-quality filter. A self-play game
  *      is *quarantined* (its trajectory dropped, not written) when any bot's
  *      `errors`, `invalidMoves`, or `maxMovesHit` counter on `MatchResult.botStats`
- *      is > 0. These are the four forced-turn-end signals the lean record cannot
+ *      is > 0. These are the three forced-turn-end signals the lean record cannot
  *      self-describe (a forced END_TURN is recorded as a voluntary STOP — D-14);
  *      enforcement lives *here*, at the data-gen boundary, not in the per-step
  *      record.
@@ -87,6 +87,46 @@ export function resolveBotsByName(names) {
     }
     return { id: bot.id, name: bot.name, fn: bot.fn };
   });
+}
+
+/**
+ * Build a contiguous seed range `[start, start+count)` as an array.
+ *
+ * @param {number} start - First seed
+ * @param {number} count - Number of seeds
+ * @returns {number[]}
+ */
+export function rangeToSeeds(start, count) {
+  const seeds = new Array(count);
+  for (let i = 0; i < count; i++) seeds[i] = start + i;
+  return seeds;
+}
+
+/**
+ * Split `[start, start+count)` into `n` contiguous ascending blocks, spreading
+ * the remainder over the first blocks. Contiguous + ascending so concatenating
+ * each worker's part-file in worker order reproduces strict seed order on disk —
+ * the lossless cross-machine merge story (D-13). Zero-size blocks are skipped, so
+ * `n > count` yields `count` singletons rather than empty chunks.
+ *
+ * @param {number} start - First seed
+ * @param {number} count - Total seeds to split
+ * @param {number} n - Number of blocks (workers)
+ * @returns {number[][]} Up to `n` contiguous ascending seed blocks
+ */
+export function chunkSeeds(start, count, n) {
+  const base = Math.floor(count / n);
+  const rem = count % n;
+  const chunks = [];
+  let next = start;
+  for (let w = 0; w < n; w++) {
+    const size = base + (w < rem ? 1 : 0);
+    if (size > 0) {
+      chunks.push(rangeToSeeds(next, size));
+      next += size;
+    }
+  }
+  return chunks;
 }
 
 /**
@@ -247,6 +287,9 @@ function percentile(sorted, p) {
   return sorted[lo] + (sorted[hi] - sorted[lo]) * (rank - lo);
 }
 
+/** Cap on distinct failure-message groups surfaced by {@link aggregateStats}. */
+const FAILURE_SAMPLE_LIMIT = 5;
+
 /**
  * @typedef {Object} SelfPlayStats
  * @property {number} totalGames
@@ -255,6 +298,10 @@ function percentile(sorted, p) {
  * @property {number} failedGames       - Subset of quarantined where `runMatch` threw
  * @property {number} cleanRate         - cleanGames / totalGames (0–1)
  * @property {{errors: number, invalidMoves: number, maxMovesHit: number, failed: number}} quarantineBySignal
+ * @property {Array<{error: string, count: number, firstSeed: number}>} failureSamples
+ *   Distinct `runMatch`-throw messages (capped at {@link FAILURE_SAMPLE_LIMIT}), each with its
+ *   occurrence count and lowest seed — so a systemic failure is diagnosable from the report,
+ *   not merely counted. Empty unless `runMatch` actually threw.
  * @property {{min: number, p50: number, mean: number, p95: number, max: number}} actionCounts - Over clean games
  * @property {Array<{name: string, wins: number, gamesPlayed: number, winRate: number, elo: number}>} bots
  *   Per-bot stats over clean games, sorted by ELO descending.
@@ -284,15 +331,39 @@ export function aggregateStats(summaries, botNames) {
 
   const quarantineBySignal = { errors: 0, invalidMoves: 0, maxMovesHit: 0, failed: 0 };
   let failedGames = 0;
+  /*
+   * Distinct runMatch-throw messages → { count, firstSeed }. Keyed by message and
+   * reduced by MIN seed so the sample is independent of summary order — the same
+   * invariant the ELO replay relies on (a shuffled `summaries` must aggregate
+   * identically).
+   */
+  const failureMessages = new Map();
   for (const s of summaries) {
     if (!s.quarantined) continue;
     if (s.failed) {
       failedGames++;
       quarantineBySignal.failed++;
+      const msg = s.error ?? 'unknown error';
+      const prev = failureMessages.get(msg);
+      if (prev) {
+        prev.count++;
+        prev.firstSeed = Math.min(prev.firstSeed, s.seed);
+      } else {
+        failureMessages.set(msg, { count: 1, firstSeed: s.seed });
+      }
     } else if (s.quarantineSignal && s.quarantineSignal in quarantineBySignal) {
       quarantineBySignal[s.quarantineSignal]++;
     }
   }
+
+  /*
+   * Most frequent first, ties broken by lowest seed; capped so a pathological run
+   * with thousands of distinct messages can't flood the report.
+   */
+  const failureSamples = [...failureMessages.entries()]
+    .map(([error, { count, firstSeed }]) => ({ error, count, firstSeed }))
+    .sort((a, b) => b.count - a.count || a.firstSeed - b.firstSeed)
+    .slice(0, FAILURE_SAMPLE_LIMIT);
 
   const ratings = {};
   const wins = {};
@@ -337,6 +408,7 @@ export function aggregateStats(summaries, botNames) {
     failedGames,
     cleanRate: totalGames > 0 ? +(clean.length / totalGames).toFixed(4) : 0,
     quarantineBySignal,
+    failureSamples,
     actionCounts: {
       min: actionCountsSorted[0] ?? 0,
       p50: Math.round(percentile(actionCountsSorted, 50)),

--- a/scripts/lib/selfplay-core.mjs
+++ b/scripts/lib/selfplay-core.mjs
@@ -1,0 +1,403 @@
+/**
+ * Self-Play Core
+ *
+ * Shared, worker-agnostic core of the parallel self-play harness
+ * (`scripts/selfplay.mjs`, ML-bot Phase 1 task 5 — see docs/ml-bot/PLAN.md and
+ * DECISIONS D-12/D-13/D-14). Everything here is pure Node with no
+ * `worker_threads` dependency, so it runs identically in the main thread (the
+ * `--workers 1` single-core baseline) and inside a worker, and is unit-testable
+ * without spawning a pool.
+ *
+ * Responsibilities:
+ *
+ *   1. {@link generateShard} — run a contiguous block of seeds through
+ *      `runMatch` in *training mode* (`recordHistory:false` +
+ *      `recordTrajectory:true`), stream each *clean* lean trajectory out via an
+ *      injected `write` callback, and return only tiny per-game summaries. The
+ *      heavy `MatchResult`/`finalState`/`trajectory` objects are dropped each
+ *      iteration (never retained in an array) — the RAM-safety crux at 100k–1M
+ *      games (D-12).
+ *   2. {@link forcedEndReason} — the D-14 data-quality filter. A self-play game
+ *      is *quarantined* (its trajectory dropped, not written) when any bot's
+ *      `errors`, `invalidMoves`, or `maxMovesHit` counter on `MatchResult.botStats`
+ *      is > 0. These are the four forced-turn-end signals the lean record cannot
+ *      self-describe (a forced END_TURN is recorded as a voluntary STOP — D-14);
+ *      enforcement lives *here*, at the data-gen boundary, not in the per-step
+ *      record.
+ *   3. {@link aggregateStats} — the single-threaded, deterministic ELO/stats
+ *      post-pass. ELO is path-dependent (order matters), so it is replayed over
+ *      summaries sorted by seed, never computed per-worker.
+ *   4. {@link makeFileWriter} — a synchronous, backpressure-free JSONL sink
+ *      (`fs.writeSync`) shared by the inline and worker write paths.
+ *
+ * @module scripts/lib/selfplay-core
+ */
+
+import fs from 'node:fs';
+import { runMatch } from '../../src/arena/matchRunner.js';
+import { serializeTrajectory } from '../../src/arena/trajectoryExport.js';
+import { BUILT_IN_BOTS } from '../../src/arena/builtInBots.js';
+import { updateEloRatings, DEFAULT_RATING } from '../../src/arena/elo.js';
+
+/**
+ * Default self-play field: a *heterogeneous, decisive, seed-pure* set of
+ * built-in bots. Heterogeneous + decisive so games actually resolve (a field of
+ * identical Strategists 0-attacks and stalemates to `maxTurns` every game — the
+ * PLAN's explicit warning); seed-pure so the same seed reproduces the same game
+ * on every machine, which is what makes seed-range sharding merge losslessly
+ * across boxes (D-13). The three `Math.random` bots (default/example/adaptive)
+ * are deliberately excluded — see {@link NON_DETERMINISTIC_BOT_IDS}.
+ *
+ * @type {string[]}
+ */
+export const DEFAULT_FIELD = ['Strategist', 'Expectimax', 'Lookahead', 'Defensive'];
+
+/**
+ * Built-in bots that call `Math.random` and are therefore NOT reproducible from
+ * a seed (README "Key grounded facts"). Including one breaks the "same seed →
+ * same game" guarantee that seed-range sharding relies on (a given seed yields
+ * different games on different machines), so the harness warns when one is
+ * selected. The recorded trajectory itself is still valid and replayable — we
+ * store the actual moves taken — it just is not reproducible from the seed.
+ *
+ * @type {Set<string>}
+ */
+export const NON_DETERMINISTIC_BOT_IDS = new Set(['ai_default', 'ai_example', 'ai_adaptive']);
+
+/**
+ * Resolve bot display names to `{ id, name, fn }` from the built-in registry.
+ *
+ * The harness passes bot *names* (identifiers), not closures, across the worker
+ * boundary — bot functions are not structured-cloneable, so each worker imports
+ * the registry and resolves names itself (D-12). Names are matched
+ * case-insensitively (mirrors `cli-utils.resolveBot`).
+ *
+ * @param {string[]} names
+ * @returns {Array<{ id: string, name: string, fn: Function }>}
+ * @throws {Error} If any name is unknown (lists the available names).
+ */
+export function resolveBotsByName(names) {
+  return names.map(rawName => {
+    const name = rawName.trim();
+    const bot = BUILT_IN_BOTS.find(b => b.name.toLowerCase() === name.toLowerCase());
+    if (!bot) {
+      throw new Error(
+        `Unknown bot "${name}". Available: ${BUILT_IN_BOTS.map(b => b.name).join(', ')}`
+      );
+    }
+    return { id: bot.id, name: bot.name, fn: bot.fn };
+  });
+}
+
+/**
+ * The D-14 quarantine predicate. Inspects a match's per-bot stats for any
+ * forced-turn-end signal and returns the first one found, or `null` if the game
+ * is clean.
+ *
+ * Priority is fixed (errors → invalidMoves → maxMovesHit) only so the reported
+ * `signal` is stable; quarantine triggers on *any* of them being > 0. We check
+ * every seat because in self-play every bot is a "teacher" and a misbehaving bot
+ * distorts the board for all players after it, so the whole game is dropped
+ * (D-14).
+ *
+ * @param {import('../../src/arena/matchRunner.js').MatchBotStat[]} botStats
+ * @returns {{ bot: string, signal: 'errors'|'invalidMoves'|'maxMovesHit', count: number }|null}
+ */
+export function forcedEndReason(botStats) {
+  for (const s of botStats) {
+    if (s.errors > 0) return { bot: s.name, signal: 'errors', count: s.errors };
+    if (s.invalidMoves > 0) return { bot: s.name, signal: 'invalidMoves', count: s.invalidMoves };
+    if (s.maxMovesHit > 0) return { bot: s.name, signal: 'maxMovesHit', count: s.maxMovesHit };
+  }
+  return null;
+}
+
+/**
+ * @typedef {Object} GameSummary
+ * @property {number}        seed       - The game's seed (the aggregation sort key)
+ * @property {number[]}      [placements] - Player indices ordered by placement (for ELO/win%)
+ * @property {number|null}   [winner]   - Winning player index (null = stalemate)
+ * @property {number}        [turnCount] - Turns played
+ * @property {number}        [actionCount] - Lean action-list length (action-count distribution)
+ * @property {boolean}       quarantined - True if dropped by {@link forcedEndReason}
+ * @property {string|null}   [quarantineSignal] - Which forced-end signal triggered the drop
+ * @property {boolean}       [failed]   - True if `runMatch` threw (game unplayable)
+ * @property {string}        [error]    - The thrown message (failed games only)
+ *
+ * Summaries are intentionally tiny (≈10 numbers/game): they are the *only*
+ * per-game state the harness retains, so the ELO post-pass and stats stay
+ * RAM-bounded while the heavy match objects are GC'd each iteration.
+ */
+
+/**
+ * @typedef {Object} ShardResult
+ * @property {GameSummary[]} summaries  - One per seed (clean, quarantined, and failed)
+ * @property {number}        written    - Clean trajectories handed to `write`
+ * @property {number}        quarantined - Games dropped by the D-14 filter
+ * @property {number}        failed     - Games where `runMatch` threw
+ * @property {boolean}       aborted    - True if the run bailed on an excessive failure rate
+ */
+
+/** Abort a shard if the failure rate exceeds this after at least 5 games (mirrors arenaRunner). */
+const ABORT_FAILURE_RATE = 0.5;
+const ABORT_MIN_GAMES = 5;
+
+/**
+ * Run one shard: every seed in `seeds`, in order, streaming clean trajectories.
+ *
+ * Each game runs in training mode (`recordHistory:false` so retained immutable
+ * states don't carry a growing history array, `recordTrajectory:true` to capture
+ * the lean record out-of-band). Clean games are serialized to a single JSONL
+ * line and handed to `write`; quarantined/failed games are counted but not
+ * written. The match objects are never collected into an array — only the tiny
+ * {@link GameSummary} is kept — so a shard of any length is RAM-bounded (D-12).
+ *
+ * @param {Object} opts
+ * @param {Array<{name: string, fn: Function}>} opts.bots - Resolved bots, seat order = bots[i] → player i
+ * @param {number[]} opts.seeds - Seeds to play (typically a contiguous block)
+ * @param {number}  [opts.maxTurns=500] - Stalemate cap per game
+ * @param {(line: string) => void} [opts.write] - JSONL sink for clean trajectories (newline-terminated)
+ * @param {(p: {done: number, total: number, written: number, quarantined: number, failed: number}) => void} [opts.onProgress]
+ * @param {number}  [opts.progressEvery=0] - Emit progress every N games (0 = only at end)
+ * @param {typeof runMatch} [opts.runMatchFn=runMatch] - Match runner (a test seam; the
+ *   `maxMovesHit`/`runMatch`-throw cases can't be triggered deterministically with real games)
+ * @returns {ShardResult}
+ */
+export function generateShard({
+  bots,
+  seeds,
+  maxTurns = 500,
+  write = () => {},
+  onProgress,
+  progressEvery = 0,
+  runMatchFn = runMatch,
+}) {
+  const summaries = [];
+  let written = 0;
+  let quarantined = 0;
+  let failed = 0;
+  let aborted = false;
+
+  for (let idx = 0; idx < seeds.length; idx++) {
+    const seed = seeds[idx];
+
+    let result;
+    try {
+      result = runMatchFn({
+        bots,
+        seed,
+        maxTurns,
+        recordHistory: false,
+        recordTrajectory: true,
+      });
+    } catch (err) {
+      failed++;
+      summaries.push({ seed, quarantined: true, failed: true, error: err.message });
+      /*
+       * Bail fast on a systemic failure (e.g. a misconfigured field) rather than
+       * burn hours producing nothing — same guard as arenaRunner.
+       */
+      const attempted = idx + 1;
+      if (attempted >= ABORT_MIN_GAMES && failed / attempted > ABORT_FAILURE_RATE) {
+        aborted = true;
+        break;
+      }
+      continue;
+    }
+
+    const reason = forcedEndReason(result.botStats);
+    if (reason === null) {
+      write(`${serializeTrajectory(result.trajectory)}\n`);
+      written++;
+    } else {
+      quarantined++;
+    }
+
+    summaries.push({
+      seed,
+      placements: result.placements,
+      winner: result.winner,
+      turnCount: result.turnCount,
+      actionCount: result.trajectory.actions.length,
+      quarantined: reason !== null,
+      quarantineSignal: reason?.signal ?? null,
+    });
+    // `result` (with finalState + trajectory) drops out of scope here — not retained.
+
+    if (progressEvery && onProgress && (idx + 1) % progressEvery === 0) {
+      onProgress({ done: idx + 1, total: seeds.length, written, quarantined, failed });
+    }
+  }
+
+  if (onProgress) {
+    onProgress({ done: summaries.length, total: seeds.length, written, quarantined, failed });
+  }
+
+  return { summaries, written, quarantined, failed, aborted };
+}
+
+/** Linear-interpolated percentile of an already-sorted numeric array. */
+function percentile(sorted, p) {
+  if (sorted.length === 0) return 0;
+  if (sorted.length === 1) return sorted[0];
+  const rank = (p / 100) * (sorted.length - 1);
+  const lo = Math.floor(rank);
+  const hi = Math.ceil(rank);
+  if (lo === hi) return sorted[lo];
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (rank - lo);
+}
+
+/**
+ * @typedef {Object} SelfPlayStats
+ * @property {number} totalGames
+ * @property {number} cleanGames        - Games kept (written to JSONL)
+ * @property {number} quarantinedGames  - Dropped by the D-14 filter (incl. failures)
+ * @property {number} failedGames       - Subset of quarantined where `runMatch` threw
+ * @property {number} cleanRate         - cleanGames / totalGames (0–1)
+ * @property {{errors: number, invalidMoves: number, maxMovesHit: number, failed: number}} quarantineBySignal
+ * @property {{min: number, p50: number, mean: number, p95: number, max: number}} actionCounts - Over clean games
+ * @property {Array<{name: string, wins: number, gamesPlayed: number, winRate: number, elo: number}>} bots
+ *   Per-bot stats over clean games, sorted by ELO descending.
+ */
+
+/**
+ * Single-threaded, deterministic ELO/stats aggregation over a shard's (or the
+ * whole run's) summaries.
+ *
+ * ELO is path-dependent — the rating after a game depends on the ratings before
+ * it — so summaries are sorted by seed and replayed in that order, exactly as a
+ * serial `runArena` would, giving a result independent of worker scheduling
+ * (D-12). ELO and win% are computed over *clean* games only; quarantined/failed
+ * games are reported separately (the field-quality signal) but excluded from
+ * strength estimates, since their outcomes are distorted by the misbehavior that
+ * got them dropped.
+ *
+ * @param {GameSummary[]} summaries - All per-game summaries (any order)
+ * @param {string[]} botNames - Bot names by player index (constant across self-play games)
+ * @returns {SelfPlayStats}
+ */
+export function aggregateStats(summaries, botNames) {
+  const totalGames = summaries.length;
+  const clean = summaries.filter(s => !s.quarantined);
+  // Deterministic ELO order: replay clean games by ascending seed.
+  clean.sort((a, b) => a.seed - b.seed);
+
+  const quarantineBySignal = { errors: 0, invalidMoves: 0, maxMovesHit: 0, failed: 0 };
+  let failedGames = 0;
+  for (const s of summaries) {
+    if (!s.quarantined) continue;
+    if (s.failed) {
+      failedGames++;
+      quarantineBySignal.failed++;
+    } else if (s.quarantineSignal && s.quarantineSignal in quarantineBySignal) {
+      quarantineBySignal[s.quarantineSignal]++;
+    }
+  }
+
+  const ratings = {};
+  const wins = {};
+  for (const name of botNames) {
+    ratings[name] = DEFAULT_RATING;
+    wins[name] = 0;
+  }
+
+  for (const game of clean) {
+    const eloPlayers = game.placements.map(playerIdx => ({
+      name: botNames[playerIdx],
+      elo: ratings[botNames[playerIdx]],
+    }));
+    for (const r of updateEloRatings(eloPlayers)) {
+      ratings[r.name] = r.elo;
+    }
+    if (game.winner !== null && game.winner !== undefined) {
+      wins[botNames[game.winner]]++;
+    }
+  }
+
+  const actionCountsSorted = clean.map(g => g.actionCount).sort((a, b) => a - b);
+  const meanActions =
+    actionCountsSorted.length > 0
+      ? actionCountsSorted.reduce((a, b) => a + b, 0) / actionCountsSorted.length
+      : 0;
+
+  const bots = botNames
+    .map(name => ({
+      name,
+      wins: wins[name],
+      gamesPlayed: clean.length,
+      winRate: clean.length > 0 ? +(wins[name] / clean.length).toFixed(3) : 0,
+      elo: Math.round(ratings[name]),
+    }))
+    .sort((a, b) => b.elo - a.elo);
+
+  return {
+    totalGames,
+    cleanGames: clean.length,
+    quarantinedGames: totalGames - clean.length,
+    failedGames,
+    cleanRate: totalGames > 0 ? +(clean.length / totalGames).toFixed(4) : 0,
+    quarantineBySignal,
+    actionCounts: {
+      min: actionCountsSorted[0] ?? 0,
+      p50: Math.round(percentile(actionCountsSorted, 50)),
+      mean: +meanActions.toFixed(1),
+      p95: Math.round(percentile(actionCountsSorted, 95)),
+      max: actionCountsSorted[actionCountsSorted.length - 1] ?? 0,
+    },
+    bots,
+  };
+}
+
+/**
+ * @typedef {Object} FileWriter
+ * @property {(line: string) => void} write - Buffer a line; flushes synchronously in batches
+ * @property {() => void} close - Flush the remainder and close the fd
+ */
+
+/** Flush the line buffer to disk once it reaches this many lines. */
+const WRITER_FLUSH_AT = 256;
+
+/**
+ * A synchronous, backpressure-free JSONL sink.
+ *
+ * Uses `fs.writeSync` (batched) rather than a `WriteStream`: `generateShard` is a
+ * tight synchronous loop that never yields to the event loop, so a stream's
+ * `'drain'` backpressure protocol can't run mid-shard and its buffer could grow
+ * unbounded on a fast/cheap field. Blocking writes from a dedicated worker (or
+ * the inline path) sidestep that entirely — disk easily outpaces game generation
+ * — and keep the core synchronous and testable. `outPath:null` yields a no-op
+ * writer (the `--no-write` throughput-only mode).
+ *
+ * @param {string|null} outPath - File to (over)write, or null for a no-op sink
+ * @returns {FileWriter}
+ */
+export function makeFileWriter(outPath) {
+  if (!outPath) {
+    return { write: () => {}, close: () => {} };
+  }
+  const fd = fs.openSync(outPath, 'w');
+  let buf = [];
+  let closed = false;
+  const flush = () => {
+    if (buf.length > 0) {
+      fs.writeSync(fd, buf.join(''));
+      buf = [];
+    }
+  };
+  return {
+    write: line => {
+      buf.push(line);
+      if (buf.length >= WRITER_FLUSH_AT) flush();
+    },
+    /*
+     * Idempotent: callers close on the success path AND in a finally, so a
+     * double-close must not double-free the fd.
+     */
+    close: () => {
+      if (closed) return;
+      closed = true;
+      flush();
+      fs.closeSync(fd);
+    },
+  };
+}

--- a/scripts/lib/selfplay-worker.mjs
+++ b/scripts/lib/selfplay-worker.mjs
@@ -1,0 +1,58 @@
+/**
+ * Self-Play Worker
+ *
+ * `worker_threads` entry point for the parallel self-play harness
+ * (`scripts/selfplay.mjs`, ML-bot Phase 1 task 5). One worker owns a contiguous
+ * seed sub-range and streams its trajectories to its own shard part-file; the
+ * main thread concatenates the parts in order and runs the deterministic ELO/stats
+ * post-pass.
+ *
+ * The boundary contract (D-12): the main thread sends bot **names**, never bot
+ * functions — closures are not structured-cloneable — so the worker imports the
+ * registry and resolves them here. All heavy lifting is in
+ * {@link module:scripts/lib/selfplay-core}; this file is just the message plumbing.
+ *
+ * @module scripts/lib/selfplay-worker
+ */
+
+import { parentPort, workerData } from 'node:worker_threads';
+import { resolveBotsByName, generateShard, makeFileWriter } from './selfplay-core.mjs';
+
+const { workerId, botNames, seeds, maxTurns, outPath } = workerData;
+
+let writer = null;
+try {
+  const bots = resolveBotsByName(botNames).map(b => ({ name: b.name, fn: b.fn }));
+  writer = makeFileWriter(outPath ?? null);
+
+  const { summaries, written, quarantined, failed, aborted } = generateShard({
+    bots,
+    seeds,
+    maxTurns,
+    write: writer.write,
+    onProgress: p => parentPort.postMessage({ type: 'progress', workerId, ...p }),
+    progressEvery: 50,
+  });
+
+  /*
+   * Close (flush) BEFORE signaling 'done' — the main thread concatenates this
+   * part-file as soon as it sees 'done', so every buffered line must be on disk
+   * first. The finally below is the fd-leak backstop for the throw path; close()
+   * is idempotent so this isn't a double-free.
+   */
+  writer.close();
+
+  parentPort.postMessage({
+    type: 'done',
+    workerId,
+    summaries,
+    written,
+    quarantined,
+    failed,
+    aborted,
+  });
+} catch (err) {
+  parentPort.postMessage({ type: 'error', workerId, message: err.message, stack: err.stack });
+} finally {
+  writer?.close();
+}

--- a/scripts/lib/selfplay-worker.mjs
+++ b/scripts/lib/selfplay-worker.mjs
@@ -54,5 +54,13 @@ try {
 } catch (err) {
   parentPort.postMessage({ type: 'error', workerId, message: err.message, stack: err.stack });
 } finally {
-  writer?.close();
+  /*
+   * fd-leak backstop only. A flush-throw here (e.g. disk full) must not escape and
+   * mask the real failure already posted as {type:error} above, so swallow it.
+   */
+  try {
+    writer?.close();
+  } catch {
+    // original cause already reported; nothing actionable in cleanup
+  }
 }

--- a/scripts/selfplay.mjs
+++ b/scripts/selfplay.mjs
@@ -49,6 +49,8 @@ import {
   generateShard,
   aggregateStats,
   makeFileWriter,
+  chunkSeeds,
+  rangeToSeeds,
 } from './lib/selfplay-core.mjs';
 import { getArg, hasFlag, colors } from './lib/cli-utils.mjs';
 
@@ -281,6 +283,23 @@ function report(stats, { elapsed: elapsedSec, workers: nWorkers }) {
     `  Clean: ${stats.cleanGames} (${cleanPct}%) · Quarantined: ${stats.quarantinedGames}${breakdown}`
   );
 
+  /*
+   * Surface WHY games failed, not just how many: on an unattended 100k–1M-game run
+   * a bare `failed:N` is undiagnosable. Print the distinct runMatch-throw messages.
+   */
+  if (stats.failedGames > 0 && stats.failureSamples.length > 0) {
+    console.log(`  ${colors.red}runMatch threw — distinct failure messages:${colors.reset}`);
+    for (const f of stats.failureSamples) {
+      console.log(
+        `    ${colors.red}×${f.count}${colors.reset} (first seed ${f.firstSeed}): ${f.error}`
+      );
+    }
+    const sampled = stats.failureSamples.reduce((n, f) => n + f.count, 0);
+    if (stats.failedGames > sampled) {
+      console.log(`    …and ${stats.failedGames - sampled} more in other message group(s)`);
+    }
+  }
+
   const a = stats.actionCounts;
   console.log(
     `  Action-count/game (clean): min ${a.min} · p50 ${a.p50} · mean ${a.mean} · p95 ${a.p95} · max ${a.max}\n`
@@ -312,33 +331,6 @@ function report(stats, { elapsed: elapsedSec, workers: nWorkers }) {
 }
 
 // --- Helpers ---
-
-/** Build a contiguous seed range as an array. */
-function rangeToSeeds(start, count) {
-  const seeds = new Array(count);
-  for (let i = 0; i < count; i++) seeds[i] = start + i;
-  return seeds;
-}
-
-/**
- * Split [start, start+count) into `n` contiguous ascending blocks (remainder
- * spread over the first blocks). Contiguous + ascending so concatenating each
- * worker's part-file in worker order reproduces strict seed order on disk.
- */
-function chunkSeeds(start, count, n) {
-  const base = Math.floor(count / n);
-  const rem = count % n;
-  const chunks = [];
-  let next = start;
-  for (let w = 0; w < n; w++) {
-    const size = base + (w < rem ? 1 : 0);
-    if (size > 0) {
-      chunks.push(rangeToSeeds(next, size));
-      next += size;
-    }
-  }
-  return chunks;
-}
 
 /**
  * Concatenate part-files into `dest`, in order. Removing the parts is the

--- a/scripts/selfplay.mjs
+++ b/scripts/selfplay.mjs
@@ -1,0 +1,408 @@
+#!/usr/bin/env node
+
+/**
+ * Parallel Self-Play Harness (ML-bot Phase 1, task 5)
+ *
+ * Generates self-play training data for the ML-bot initiative (docs/ml-bot/):
+ * runs a field of bots over a range of seeds and streams each game's *lean*
+ * trajectory (seed + action list + terminal label) to JSONL. Built per
+ * DECISIONS D-12/D-13/D-14:
+ *
+ *   - **Parallel.** A `worker_threads` pool (default ~50% of cores, to respect
+ *     the machine policy in CLAUDE.md). Workers receive bot *names*, not
+ *     closures (bot fns aren't structured-cloneable — D-12), and each owns a
+ *     contiguous seed sub-range written to its own shard part-file.
+ *   - **Streaming, RAM-bounded.** Trajectories stream to disk; the heavy
+ *     `MatchResult`/`finalState` objects are never retained (a blow-up at
+ *     100k–1M games). Only tiny per-game summaries survive, for the stats pass.
+ *   - **Deterministic aggregation.** ELO is path-dependent, so it is replayed
+ *     single-threaded over summaries sorted by seed — independent of worker
+ *     scheduling.
+ *   - **Shardable by seed range.** `--seed-start`/`--seed-count`/`--out` make the
+ *     output concatenate losslessly across machines (engine determinism + game
+ *     independence), so data-gen fans out across every available box (D-13).
+ *   - **Data-quality filter (D-14).** A game where any bot's
+ *     `errors`/`invalidMoves`/`maxMovesHit` counter is > 0 is *quarantined* — its
+ *     trajectory dropped, the game counted but not written. This harness owns
+ *     forced-end cleanup; the lean record stays pure.
+ *
+ * Usage:
+ *   npm run selfplay                                   # default field, seeds 1..1000
+ *   npm run selfplay -- --seed-count 100000            # 100k games
+ *   npm run selfplay -- --bots Lookahead,Strategist,Expectimax,Defensive
+ *   npm run selfplay -- --seed-start 1000000 --seed-count 100000 --out shard-b.jsonl
+ *   npm run selfplay -- --workers 1                    # single-core baseline
+ *   npm run selfplay -- --no-write --seed-count 2000   # throughput only (no JSONL)
+ *
+ * @module scripts/selfplay
+ */
+
+import os from 'node:os';
+import fs from 'node:fs';
+import path from 'node:path';
+import { Worker } from 'node:worker_threads';
+import { pipeline } from 'node:stream/promises';
+import {
+  DEFAULT_FIELD,
+  NON_DETERMINISTIC_BOT_IDS,
+  resolveBotsByName,
+  generateShard,
+  aggregateStats,
+  makeFileWriter,
+} from './lib/selfplay-core.mjs';
+import { getArg, hasFlag, colors } from './lib/cli-utils.mjs';
+
+const ROOT = path.resolve(import.meta.dirname, '..');
+const DEFAULT_OUT_DIR = path.join(ROOT, 'data', 'selfplay');
+const WORKER_URL = new URL('./lib/selfplay-worker.mjs', import.meta.url);
+
+// --- Parse CLI args ---
+
+const args = process.argv.slice(2);
+
+if (hasFlag(args, 'help')) {
+  printHelp();
+  process.exit(0);
+}
+
+const seedStart = parseInt(getArg(args, 'seed-start', '1'), 10);
+if (!Number.isInteger(seedStart)) {
+  fail('--seed-start must be an integer.');
+}
+
+// --seed-count is canonical; --games is accepted as a familiar alias.
+const seedCount = parseInt(getArg(args, 'seed-count', getArg(args, 'games', '1000')), 10);
+if (!Number.isInteger(seedCount) || seedCount < 1) {
+  fail('--seed-count (a.k.a. --games) must be a positive integer.');
+}
+
+const maxTurns = parseInt(getArg(args, 'max-turns', '500'), 10);
+if (!Number.isInteger(maxTurns) || maxTurns < 1) {
+  fail('--max-turns must be a positive integer.');
+}
+
+const cpuCount = os.cpus().length;
+const defaultWorkers = Math.max(1, Math.floor(cpuCount / 2));
+let workers = parseInt(getArg(args, 'workers', String(defaultWorkers)), 10);
+if (!Number.isInteger(workers) || workers < 1) {
+  fail('--workers must be a positive integer.');
+}
+if (workers > cpuCount) {
+  warnLine(
+    `--workers ${workers} exceeds ${cpuCount} CPU cores; oversubscription will slow each worker.`
+  );
+}
+// No point spawning more workers than games.
+workers = Math.min(workers, seedCount);
+
+const noWrite = hasFlag(args, 'no-write');
+
+const fieldNames = (getArg(args, 'bots', DEFAULT_FIELD.join(',')) || '')
+  .split(',')
+  .map(s => s.trim())
+  .filter(Boolean);
+
+// Resolve + validate the field up front (workers re-resolve from names).
+let resolved;
+try {
+  resolved = resolveBotsByName(fieldNames);
+} catch (err) {
+  fail(err.message);
+}
+if (resolved.length < 2) {
+  fail('Need at least 2 bots for a self-play field.');
+}
+
+const botNames = resolved.map(b => b.name);
+const bots = resolved.map(b => ({ name: b.name, fn: b.fn }));
+
+/*
+ * Warn (don't block) on non-reproducible bots — the seed-sharding merge story
+ * assumes "same seed → same game", which Math.random bots break (D-13).
+ */
+const nonDeterministic = resolved.filter(b => NON_DETERMINISTIC_BOT_IDS.has(b.id));
+if (nonDeterministic.length > 0) {
+  warnLine(
+    `Field includes non-reproducible bot(s): ${nonDeterministic.map(b => b.name).join(', ')}. ` +
+      'Same seed will NOT reproduce the same game across machines; seed-range shards no longer ' +
+      'merge deterministically (the recorded trajectories are still valid and replayable).'
+  );
+}
+
+const outPath = noWrite
+  ? null
+  : path.resolve(
+      ROOT,
+      getArg(args, 'out', path.join(DEFAULT_OUT_DIR, defaultOutName(seedStart, seedCount)))
+    );
+
+// --- Run ---
+
+console.log(
+  `${colors.bold}Self-play data generation${colors.reset}\n` +
+    `  Field:   ${botNames.join(', ')}\n` +
+    `  Seeds:   ${seedStart}..${seedStart + seedCount - 1} (${seedCount} games)\n` +
+    `  Workers: ${workers} of ${cpuCount} cores\n` +
+    `  Output:  ${outPath ? displayPath(outPath) : '(none — throughput only)'}\n`
+);
+
+if (outPath) fs.mkdirSync(path.dirname(outPath), { recursive: true });
+
+const startTime = Date.now();
+let summaries;
+let aborted;
+let effectiveWorkers;
+
+try {
+  if (workers === 1) {
+    ({ summaries, aborted } = await runInline());
+    effectiveWorkers = 1;
+  } else {
+    ({ summaries, aborted, effectiveWorkers } = await runPool());
+  }
+} catch (err) {
+  console.error(`\n${colors.red}Self-play run failed: ${err.message}${colors.reset}`);
+  process.exit(1);
+}
+
+const elapsed = (Date.now() - startTime) / 1000;
+process.stdout.write('\n\n');
+
+if (aborted) {
+  console.error(
+    `${colors.red}Run aborted: excessive game failures (likely a misconfigured field).${colors.reset}\n`
+  );
+}
+
+report(aggregateStats(summaries, botNames), { elapsed, workers: effectiveWorkers });
+
+// --- Execution paths ---
+
+/** Single-core baseline: run the whole range inline (no worker overhead). */
+async function runInline() {
+  const writer = makeFileWriter(outPath);
+  try {
+    return generateShard({
+      bots,
+      seeds: rangeToSeeds(seedStart, seedCount),
+      maxTurns,
+      write: writer.write,
+      onProgress: p => process.stdout.write(`\rGames: ${p.done}/${seedCount}`),
+      progressEvery: 50,
+    });
+  } finally {
+    // Flush + release the fd even if generateShard throws (idempotent close).
+    writer.close();
+  }
+}
+
+/** Worker pool: contiguous seed shards, concatenated in order on completion. */
+async function runPool() {
+  const shards = chunkSeeds(seedStart, seedCount, workers);
+  const partPaths = outPath ? shards.map((_, w) => `${outPath}.part${w}`) : shards.map(() => null);
+
+  const done = new Map();
+  const printCombined = () => {
+    const total = [...done.values()].reduce((a, b) => a + b, 0);
+    process.stdout.write(`\rGames: ${total}/${seedCount}`);
+  };
+
+  /*
+   * Track every spawned worker so the finally can terminate any that are still
+   * running if one rejects (Promise.all rejects on the first failure but leaves
+   * its siblings alive), and so part-files are never orphaned on a partial
+   * failure. spawned[] is populated synchronously as the executors run.
+   */
+  const spawned = [];
+  try {
+    const results = await Promise.all(
+      shards.map(
+        (seeds, w) =>
+          new Promise((resolve, reject) => {
+            const worker = new Worker(WORKER_URL, {
+              workerData: { workerId: w, seeds, botNames, maxTurns, outPath: partPaths[w] },
+            });
+            spawned.push(worker);
+            worker.on('message', msg => {
+              if (msg.type === 'progress') {
+                done.set(msg.workerId, msg.done);
+                printCombined();
+              } else if (msg.type === 'done') {
+                resolve(msg);
+              } else if (msg.type === 'error') {
+                reject(new Error(`worker ${msg.workerId}: ${msg.message}`));
+              }
+            });
+            worker.on('error', reject);
+            worker.on('exit', code => {
+              if (code !== 0) reject(new Error(`worker ${w} exited with code ${code}`));
+            });
+          })
+      )
+    );
+
+    if (outPath) {
+      await concatParts(partPaths, outPath);
+    }
+
+    return {
+      summaries: results.flatMap(r => r.summaries),
+      aborted: results.some(r => r.aborted),
+      effectiveWorkers: shards.length,
+    };
+  } finally {
+    // terminate() on an already-exited worker is a harmless no-op.
+    await Promise.allSettled(spawned.map(w => w.terminate()));
+    // Parts are merged into `dest` on success; on any failure they'd be orphaned. Remove either way.
+    cleanupParts(partPaths);
+  }
+}
+
+// --- Reporting ---
+
+function report(stats, { elapsed: elapsedSec, workers: nWorkers }) {
+  const gamesPerSec = elapsedSec > 0 ? stats.totalGames / elapsedSec : 0;
+  const perWorker = nWorkers > 0 ? gamesPerSec / nWorkers : 0;
+
+  console.log(`${colors.bold}Throughput${colors.reset}`);
+  console.log(`  ${stats.totalGames} games in ${elapsedSec.toFixed(1)}s`);
+  console.log(
+    `  ${gamesPerSec.toFixed(1)} games/s total · ${perWorker.toFixed(1)} games/s/worker (${nWorkers} worker(s))\n`
+  );
+
+  const q = stats.quarantineBySignal;
+  const breakdown =
+    stats.quarantinedGames > 0
+      ? ` [errors:${q.errors} invalidMoves:${q.invalidMoves} maxMovesHit:${q.maxMovesHit} failed:${q.failed}]`
+      : '';
+  const cleanPct = (stats.cleanRate * 100).toFixed(2);
+  console.log(`${colors.bold}Data quality (D-14 forced-end quarantine)${colors.reset}`);
+  console.log(
+    `  Clean: ${stats.cleanGames} (${cleanPct}%) · Quarantined: ${stats.quarantinedGames}${breakdown}`
+  );
+
+  const a = stats.actionCounts;
+  console.log(
+    `  Action-count/game (clean): min ${a.min} · p50 ${a.p50} · mean ${a.mean} · p95 ${a.p95} · max ${a.max}\n`
+  );
+
+  console.log(`${colors.bold}Field (clean games, ELO order)${colors.reset}`);
+  const header = ['Rank', 'Bot', 'ELO', 'Wins', 'Win%'];
+  const rows = stats.bots.map((b, i) => [
+    String(i + 1),
+    b.name,
+    String(b.elo),
+    String(b.wins),
+    `${(b.winRate * 100).toFixed(1)}%`,
+  ]);
+  const table = [header, ...rows];
+  const widths = header.map((_, c) => Math.max(...table.map(r => r[c].length)));
+  const fmt = r => r.map((cell, i) => cell.padStart(widths[i])).join('  ');
+  console.log(`  ${fmt(header)}`);
+  console.log(`  ${widths.map(w => '-'.repeat(w)).join('  ')}`);
+  rows.forEach(r => console.log(`  ${fmt(r)}`));
+
+  if (outPath) {
+    const sizeMb = fs.existsSync(outPath) ? fs.statSync(outPath).size / 1e6 : 0;
+    console.log(
+      `\n${colors.green}Wrote ${stats.cleanGames} trajectories (${sizeMb.toFixed(1)} MB) to ` +
+        `${displayPath(outPath)}${colors.reset}`
+    );
+  }
+}
+
+// --- Helpers ---
+
+/** Build a contiguous seed range as an array. */
+function rangeToSeeds(start, count) {
+  const seeds = new Array(count);
+  for (let i = 0; i < count; i++) seeds[i] = start + i;
+  return seeds;
+}
+
+/**
+ * Split [start, start+count) into `n` contiguous ascending blocks (remainder
+ * spread over the first blocks). Contiguous + ascending so concatenating each
+ * worker's part-file in worker order reproduces strict seed order on disk.
+ */
+function chunkSeeds(start, count, n) {
+  const base = Math.floor(count / n);
+  const rem = count % n;
+  const chunks = [];
+  let next = start;
+  for (let w = 0; w < n; w++) {
+    const size = base + (w < rem ? 1 : 0);
+    if (size > 0) {
+      chunks.push(rangeToSeeds(next, size));
+      next += size;
+    }
+  }
+  return chunks;
+}
+
+/**
+ * Concatenate part-files into `dest`, in order. Removing the parts is the
+ * caller's job (runPool's finally), so a mid-concat I/O failure can't leave them
+ * orphaned. On error the write stream is destroyed (no dangling fd) and the
+ * exception propagates.
+ */
+async function concatParts(parts, dest) {
+  const out = fs.createWriteStream(dest, { flags: 'w' });
+  try {
+    for (const part of parts) {
+      if (part && fs.existsSync(part)) {
+        await pipeline(fs.createReadStream(part), out, { end: false });
+      }
+    }
+    await new Promise((resolve, reject) => out.end(err => (err ? reject(err) : resolve())));
+  } catch (err) {
+    out.destroy();
+    throw err;
+  }
+}
+
+/** Best-effort removal of shard part-files (force: no throw if already gone). */
+function cleanupParts(parts) {
+  for (const part of parts) {
+    if (part) fs.rmSync(part, { force: true });
+  }
+}
+
+function defaultOutName(start, count) {
+  return `selfplay-seed-${start}-${start + count - 1}.jsonl`;
+}
+
+/** Repo-relative path when inside the repo, else the absolute path (no ugly `../../`). */
+function displayPath(p) {
+  const rel = path.relative(ROOT, p);
+  return rel.startsWith('..') ? p : rel;
+}
+
+function warnLine(msg) {
+  console.warn(`${colors.yellow}Warning: ${msg}${colors.reset}`);
+}
+
+function fail(msg) {
+  console.error(`${colors.red}${msg}${colors.reset}`);
+  process.exit(1);
+}
+
+function printHelp() {
+  console.log(`Parallel self-play data generation (ML-bot Phase 1, task 5)
+
+Usage:
+  npm run selfplay -- [options]
+
+Options:
+  --bots <names>        Comma-separated field (default: ${DEFAULT_FIELD.join(',')})
+  --seed-start <n>      First seed in the range (default: 1)
+  --seed-count <n>      Number of games/seeds to run (default: 1000; alias: --games)
+  --workers <n>         Worker threads (default: ~50% of cores = ${Math.max(1, Math.floor(os.cpus().length / 2))})
+  --max-turns <n>       Stalemate cap per game (default: 500)
+  --out <path>          Output JSONL (default: data/selfplay/selfplay-seed-<start>-<end>.jsonl)
+  --no-write            Run games for throughput only; write no JSONL
+  --help                Show this help
+
+Shard across machines by giving each a disjoint --seed-start/--seed-count and a
+distinct --out; the resulting JSONL files concatenate losslessly.`);
+}

--- a/scripts/selfplay.mjs
+++ b/scripts/selfplay.mjs
@@ -34,6 +34,9 @@
  *   npm run selfplay -- --workers 1                    # single-core baseline
  *   npm run selfplay -- --no-write --seed-count 2000   # throughput only (no JSONL)
  *
+ * Exit code: 0 on a usable run; non-zero if the run aborts (excessive game failures) or a
+ * write run produces zero clean games — so a pipeline caller can trust it.
+ *
  * @module scripts/selfplay
  */
 
@@ -48,6 +51,7 @@ import {
   resolveBotsByName,
   generateShard,
   aggregateStats,
+  isUnusableRun,
   makeFileWriter,
   chunkSeeds,
   rangeToSeeds,
@@ -182,7 +186,27 @@ if (aborted) {
   );
 }
 
-report(aggregateStats(summaries, botNames), { elapsed, workers: effectiveWorkers });
+const runStats = aggregateStats(summaries, botNames);
+report(runStats, { elapsed, workers: effectiveWorkers });
+
+const wroteOutput = Boolean(outPath);
+if (wroteOutput && runStats.cleanGames === 0) {
+  console.error(
+    `${colors.red}No clean games were produced — nothing usable was written.${colors.reset}`
+  );
+}
+
+/*
+ * Exit non-zero so unattended/pipeline callers don't treat a failed run as success: an
+ * aborted run (excessive game failures) or a write run with zero clean games means the
+ * output JSONL is empty/garbage. Reporting already ran, so the full breakdown above is
+ * still visible. This deliberately differs from the interactive `arena` CLI — this
+ * generator feeds a downstream training pipeline that must be able to trust its exit code.
+ * The policy lives in the pure isUnusableRun predicate so it's unit-tested without a subprocess.
+ */
+if (isUnusableRun({ aborted, wroteOutput, cleanGames: runStats.cleanGames })) {
+  process.exit(1);
+}
 
 // --- Execution paths ---
 
@@ -288,7 +312,7 @@ async function runPool() {
   } finally {
     // terminate() on an already-exited worker is a harmless no-op.
     await Promise.allSettled(spawned.map(w => w.terminate()));
-    // Parts are merged into `dest` on success; on any failure they'd be orphaned. Remove either way.
+    // Parts are merged into the output file on success; on any failure they'd be orphaned. Remove either way.
     cleanupParts(partPaths);
   }
 }
@@ -427,6 +451,9 @@ Options:
   --out <path>          Output JSONL (default: data/selfplay/selfplay-seed-<start>-<end>.jsonl)
   --no-write            Run games for throughput only; write no JSONL
   --help                Show this help
+
+Exit code: non-zero if the run aborts (excessive game failures) or a write run produces
+zero clean games — so pipeline callers can trust it.
 
 Shard across machines by giving each a disjoint --seed-start/--seed-count and a
 distinct --out; the resulting JSONL files concatenate losslessly.`);

--- a/scripts/selfplay.mjs
+++ b/scripts/selfplay.mjs
@@ -164,6 +164,12 @@ try {
   }
 } catch (err) {
   console.error(`\n${colors.red}Self-play run failed: ${err.message}${colors.reset}`);
+  /*
+   * Print the trace for diagnosability — the in-worker stack for a worker failure
+   * (the original site, in another thread), else this error's own stack.
+   */
+  const trace = err.workerStack ?? err.stack;
+  if (trace) console.error(trace);
   process.exit(1);
 }
 
@@ -221,6 +227,26 @@ async function runPool() {
       shards.map(
         (seeds, w) =>
           new Promise((resolve, reject) => {
+            /*
+             * Settle exactly once. A worker emits several terminal-ish events
+             * (a 'done'/'error' message, then an 'exit'); a Promise ignores all
+             * but the first settle, but we gate explicitly so the 'exit' guard
+             * below can reject a worker that dies *without* delivering a result
+             * (any exit code) instead of leaving Promise.all to hang forever.
+             */
+            let settled = false;
+            const ok = msg => {
+              if (!settled) {
+                settled = true;
+                resolve(msg);
+              }
+            };
+            const bad = err => {
+              if (!settled) {
+                settled = true;
+                reject(err);
+              }
+            };
             const worker = new Worker(WORKER_URL, {
               workerData: { workerId: w, seeds, botNames, maxTurns, outPath: partPaths[w] },
             });
@@ -230,14 +256,21 @@ async function runPool() {
                 done.set(msg.workerId, msg.done);
                 printCombined();
               } else if (msg.type === 'done') {
-                resolve(msg);
+                ok(msg);
               } else if (msg.type === 'error') {
-                reject(new Error(`worker ${msg.workerId}: ${msg.message}`));
+                // Carry the in-worker stack so the top-level catch can print it.
+                const err = new Error(`worker ${msg.workerId}: ${msg.message}`);
+                err.workerStack = msg.stack;
+                bad(err);
               }
             });
-            worker.on('error', reject);
+            worker.on('error', bad);
             worker.on('exit', code => {
-              if (code !== 0) reject(new Error(`worker ${w} exited with code ${code}`));
+              /*
+               * No-op once 'done'/'error' has settled; otherwise a premature exit
+               * (e.g. an OOM kill that posts nothing) becomes a loud failure, not a hang.
+               */
+              bad(new Error(`worker ${w} exited before completing (code ${code})`));
             });
           })
       )

--- a/tests/scripts/selfplay.test.js
+++ b/tests/scripts/selfplay.test.js
@@ -18,6 +18,7 @@ import {
   forcedEndReason,
   generateShard,
   aggregateStats,
+  isUnusableRun,
   makeFileWriter,
   chunkSeeds,
   rangeToSeeds,
@@ -355,6 +356,98 @@ describe('aggregateStats (deterministic ELO/stats post-pass)', () => {
     // ELO/wins are keyed by name; a duplicate would skew the ranking. Fail loud.
     expect(() => aggregateStats([], ['A', 'B', 'A'])).toThrow(/distinct bot names/);
   });
+
+  it('keeps a stalemate (winner null) as a clean game that credits no win but still moves ELO', () => {
+    /*
+     * A maxTurns stalemate is clean (not a forced-end quarantine) and a real engine outcome;
+     * it must rank by placement without crediting anyone a win.
+     */
+    const withStalemate = [
+      {
+        seed: 1,
+        placements: [0, 1, 2],
+        winner: 0,
+        turnCount: 10,
+        actionCount: 50,
+        quarantined: false,
+      },
+      {
+        seed: 2,
+        placements: [1, 0, 2],
+        winner: null,
+        turnCount: 500,
+        actionCount: 999,
+        quarantined: false,
+      },
+    ];
+    const stats = aggregateStats(withStalemate, botNames);
+    expect(stats.cleanGames).toBe(2);
+    // Only the decisive game (seed 1, winner A) credits a win.
+    expect(stats.bots.reduce((n, b) => n + b.wins, 0)).toBe(1);
+    // The stalemate still updated ratings by placement, so not everyone sits at the default.
+    expect(stats.bots.some(b => b.elo !== 1200)).toBe(true);
+  });
+
+  it('labels a blank runMatch-throw message as "unknown error" instead of grouping on ""', () => {
+    /*
+     * `new Error()` yields an empty message; `??` keeps '' (only null/undefined fall through),
+     * so the report must use `||` to surface a usable label.
+     */
+    const stats = aggregateStats(
+      [{ seed: 4, quarantined: true, failed: true, error: '' }],
+      botNames
+    );
+    expect(stats.failedGames).toBe(1);
+    expect(stats.failureSamples).toEqual([{ error: 'unknown error', count: 1, firstSeed: 4 }]);
+  });
+
+  it('reports an all-zero action-count distribution when no games are clean (no NaN/throw)', () => {
+    const allDirty = [
+      { seed: 1, quarantined: true, quarantineSignal: 'errors' },
+      { seed: 2, quarantined: true, failed: true, error: 'boom' },
+    ];
+    const stats = aggregateStats(allDirty, botNames);
+    expect(stats.cleanGames).toBe(0);
+    expect(stats.cleanRate).toBe(0);
+    expect(stats.actionCounts).toEqual({ min: 0, p50: 0, mean: 0, p95: 0, max: 0 });
+    // Every bot is reported at the default rating with a zero win rate.
+    expect(stats.bots.every(b => b.elo === 1200 && b.winRate === 0)).toBe(true);
+  });
+
+  it('interpolates the p95 action-count over clean games', () => {
+    // actionCounts 0..100 (101 values): p95 rank = 0.95 * 100 = 95 → value 95.
+    const many = Array.from({ length: 101 }, (_, i) => ({
+      seed: i,
+      placements: [0, 1, 2],
+      winner: 0,
+      turnCount: 1,
+      actionCount: i,
+      quarantined: false,
+    }));
+    const stats = aggregateStats(many, botNames);
+    expect(stats.actionCounts.min).toBe(0);
+    expect(stats.actionCounts.max).toBe(100);
+    expect(stats.actionCounts.p95).toBe(95);
+  });
+});
+
+describe('isUnusableRun (CLI non-zero-exit policy)', () => {
+  it('flags an aborted run regardless of output mode or clean count', () => {
+    expect(isUnusableRun({ aborted: true, wroteOutput: true, cleanGames: 100 })).toBe(true);
+    expect(isUnusableRun({ aborted: true, wroteOutput: false, cleanGames: 0 })).toBe(true);
+  });
+
+  it('flags a write run that produced zero clean games', () => {
+    expect(isUnusableRun({ aborted: false, wroteOutput: true, cleanGames: 0 })).toBe(true);
+  });
+
+  it('passes a write run with at least one clean game', () => {
+    expect(isUnusableRun({ aborted: false, wroteOutput: true, cleanGames: 1 })).toBe(false);
+  });
+
+  it('does not flag a --no-write throughput run on clean-count alone', () => {
+    expect(isUnusableRun({ aborted: false, wroteOutput: false, cleanGames: 0 })).toBe(false);
+  });
 });
 
 describe('makeFileWriter', () => {
@@ -485,4 +578,80 @@ describe('selfplay worker error plumbing', () => {
     expect(typeof msg.stack).toBe('string');
     expect(msg.stack.length).toBeGreaterThan(0);
   }, 30_000);
+});
+
+describe('selfplay CLI argument validation', () => {
+  /** Run the CLI and capture exit code + stderr (execFileSync throws on non-zero exit). */
+  const runCli = args => {
+    try {
+      execFileSync('node', ['scripts/selfplay.mjs', ...args], { cwd: REPO_ROOT, stdio: 'pipe' });
+      return { code: 0, stderr: '' };
+    } catch (err) {
+      return { code: err.status ?? 1, stderr: String(err.stderr ?? '') };
+    }
+  };
+
+  it('rejects a non-positive --seed-count with a helpful message', () => {
+    const { code, stderr } = runCli(['--seed-count', '0']);
+    expect(code).not.toBe(0);
+    expect(stderr).toMatch(/--seed-count .* must be a positive integer/);
+  }, 30_000);
+
+  it('rejects a non-positive --workers', () => {
+    const { code, stderr } = runCli(['--workers', '0', '--seed-count', '2']);
+    expect(code).not.toBe(0);
+    expect(stderr).toMatch(/--workers must be a positive integer/);
+  }, 30_000);
+
+  it('rejects a field of fewer than two bots', () => {
+    const { code, stderr } = runCli(['--bots', 'Strategist', '--seed-count', '2']);
+    expect(code).not.toBe(0);
+    expect(stderr).toMatch(/Need at least 2 bots/);
+  }, 30_000);
+
+  it('rejects an unknown bot name and lists the available bots', () => {
+    const { code, stderr } = runCli(['--bots', 'NotABot,Strategist', '--seed-count', '2']);
+    expect(code).not.toBe(0);
+    expect(stderr).toMatch(/Unknown bot "NotABot"/);
+    expect(stderr).toMatch(/Available:.*Strategist/);
+  }, 30_000);
+});
+
+describe('selfplay CLI end-to-end (single-core inline path)', () => {
+  it('runs the --workers 1 inline path and writes seed-ordered JSONL with no part-files', () => {
+    const out = path.join(tmpDir, 'inline.jsonl');
+    execFileSync(
+      'node',
+      [
+        'scripts/selfplay.mjs',
+        '--workers',
+        '1',
+        '--seed-count',
+        '4',
+        '--out',
+        out,
+        '--bots',
+        DEFAULT_FIELD.join(','),
+      ],
+      { cwd: REPO_ROOT, stdio: 'pipe' }
+    );
+
+    expect(fs.existsSync(out)).toBe(true);
+    const records = fs
+      .readFileSync(out, 'utf-8')
+      .trim()
+      .split('\n')
+      .map(line => deserializeTrajectory(line));
+
+    expect(records.length).toBeGreaterThan(0);
+    expect(records.length).toBeLessThanOrEqual(4);
+
+    // Inline output is strictly seed-ordered over the requested range.
+    const seeds = records.map(r => r.config.seed);
+    expect(seeds).toEqual([...seeds].sort((a, b) => a - b));
+    expect(seeds.every(s => s >= 1 && s <= 4)).toBe(true);
+
+    // The inline path writes outPath directly — it must NOT create any .part shard files.
+    expect(fs.readdirSync(tmpDir).filter(f => f.includes('.part'))).toHaveLength(0);
+  }, 60_000);
 });

--- a/tests/scripts/selfplay.test.js
+++ b/tests/scripts/selfplay.test.js
@@ -9,6 +9,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
+import { Worker } from 'node:worker_threads';
 import { fileURLToPath } from 'node:url';
 
 import {
@@ -24,6 +25,7 @@ import {
 import { deserializeTrajectory } from '../../src/arena/trajectoryExport.js';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const WORKER_PATH = path.join(REPO_ROOT, 'scripts', 'lib', 'selfplay-worker.mjs');
 
 let tmpDir;
 beforeEach(() => {
@@ -348,6 +350,11 @@ describe('aggregateStats (deterministic ELO/stats post-pass)', () => {
     const shuffled = [summaries[2], summaries[0], summaries[4], summaries[1], summaries[3]];
     expect(aggregateStats(shuffled, botNames)).toEqual(aggregateStats(summaries, botNames));
   });
+
+  it('throws on duplicate bot names rather than silently collapsing two seats', () => {
+    // ELO/wins are keyed by name; a duplicate would skew the ranking. Fail loud.
+    expect(() => aggregateStats([], ['A', 'B', 'A'])).toThrow(/distinct bot names/);
+  });
 });
 
 describe('makeFileWriter', () => {
@@ -409,4 +416,73 @@ describe('selfplay CLI end-to-end (worker pool)', () => {
     // Shard part-files are cleaned up after a successful merge (none orphaned).
     expect(fs.readdirSync(tmpDir).filter(f => f.includes('.part'))).toHaveLength(0);
   }, 60_000);
+
+  it('cleans up shard part-files when the merge fails (no orphans on error)', () => {
+    /*
+     * Point --out at an existing *directory* so the final concat
+     * (createWriteStream) fails with EISDIR *after* the workers have written
+     * their part-files — exercising the runPool finally cleanup + concatParts
+     * error path, which the success-path e2e above can't reach.
+     */
+    const outDir = path.join(tmpDir, 'out-is-a-dir');
+    fs.mkdirSync(outDir);
+
+    let threw = false;
+    let stderr = '';
+    try {
+      execFileSync(
+        'node',
+        [
+          'scripts/selfplay.mjs',
+          '--workers',
+          '2',
+          '--seed-count',
+          '4',
+          '--out',
+          outDir,
+          '--bots',
+          DEFAULT_FIELD.join(','),
+        ],
+        { cwd: REPO_ROOT, stdio: 'pipe' }
+      );
+    } catch (err) {
+      threw = true;
+      stderr = String(err.stderr ?? '');
+    }
+
+    expect(threw).toBe(true); // non-zero exit
+    expect(stderr).toMatch(/Self-play run failed/);
+    // The finally removed both .part files even though the merge threw — no orphans.
+    expect(fs.readdirSync(tmpDir).filter(f => f.includes('.part'))).toHaveLength(0);
+  }, 60_000);
+});
+
+describe('selfplay worker error plumbing', () => {
+  it('posts {type:error} carrying the message and in-worker stack on a failure', async () => {
+    /*
+     * Drive the worker's catch → postMessage({type:error}) path directly: an
+     * unknown bot name makes resolveBotsByName throw inside the worker. This
+     * verifies the worker reports the failure as a message (not a crash) and
+     * forwards the stack the main thread now surfaces.
+     */
+    const msg = await new Promise((resolve, reject) => {
+      const worker = new Worker(WORKER_PATH, {
+        workerData: {
+          workerId: 3,
+          botNames: ['NotARealBot'],
+          seeds: [1],
+          maxTurns: 500,
+          outPath: null,
+        },
+      });
+      worker.on('message', resolve);
+      worker.on('error', reject); // a real crash (not the expected error message) fails the test
+    });
+
+    expect(msg.type).toBe('error');
+    expect(msg.workerId).toBe(3);
+    expect(msg.message).toMatch(/Unknown bot "NotARealBot"/);
+    expect(typeof msg.stack).toBe('string');
+    expect(msg.stack.length).toBeGreaterThan(0);
+  }, 30_000);
 });

--- a/tests/scripts/selfplay.test.js
+++ b/tests/scripts/selfplay.test.js
@@ -1,0 +1,345 @@
+/**
+ * Tests for the parallel self-play harness (scripts/selfplay.mjs + lib).
+ *
+ * Node environment (touches fs + child_process, no DOM). Covers the testable
+ * core directly and the worker-pool CLI end-to-end.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import {
+  DEFAULT_FIELD,
+  resolveBotsByName,
+  forcedEndReason,
+  generateShard,
+  aggregateStats,
+  makeFileWriter,
+} from '../../scripts/lib/selfplay-core.mjs';
+import { deserializeTrajectory } from '../../src/arena/trajectoryExport.js';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+let tmpDir;
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'selfplay-test-'));
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/** A clean game's record compared for determinism must ignore the wall-clock stamp. */
+const stripTimestamp = record => {
+  const meta = { ...record.metadata };
+  delete meta.timestamp;
+  return { ...record, metadata: meta };
+};
+
+describe('forcedEndReason (D-14 quarantine predicate)', () => {
+  const stat = over => ({ name: 'X', errors: 0, invalidMoves: 0, maxMovesHit: 0, ...over });
+
+  it('returns null when every bot is clean', () => {
+    expect(forcedEndReason([stat(), stat({ name: 'Y' })])).toBeNull();
+  });
+
+  it('flags errors, invalidMoves, and maxMovesHit', () => {
+    expect(forcedEndReason([stat({ errors: 2 })])).toMatchObject({ signal: 'errors', count: 2 });
+    expect(forcedEndReason([stat({ invalidMoves: 1 })])).toMatchObject({ signal: 'invalidMoves' });
+    expect(forcedEndReason([stat({ maxMovesHit: 1 })])).toMatchObject({ signal: 'maxMovesHit' });
+  });
+
+  it('reports errors first when multiple signals are present (stable signal)', () => {
+    expect(forcedEndReason([stat({ errors: 1, invalidMoves: 5, maxMovesHit: 3 })])).toMatchObject({
+      signal: 'errors',
+    });
+  });
+
+  it('checks every seat, not just the first', () => {
+    const reason = forcedEndReason([stat(), stat({ name: 'Z', invalidMoves: 4 })]);
+    expect(reason).toMatchObject({ bot: 'Z', signal: 'invalidMoves' });
+  });
+});
+
+describe('generateShard', () => {
+  const field = () => resolveBotsByName(DEFAULT_FIELD).map(b => ({ name: b.name, fn: b.fn }));
+
+  it('streams one round-trippable trajectory per clean game', () => {
+    const lines = [];
+    const { summaries, written } = generateShard({
+      bots: field(),
+      seeds: [1, 2, 3],
+      write: l => lines.push(l),
+    });
+
+    expect(summaries).toHaveLength(3);
+    expect(written).toBe(lines.length);
+    expect(written).toBe(summaries.filter(s => !s.quarantined).length);
+
+    for (const line of lines) {
+      expect(line.endsWith('\n')).toBe(true);
+      const record = deserializeTrajectory(line); // throws if malformed/poisoned
+      expect(record.config.seed).toBeGreaterThanOrEqual(1);
+      // The summary's actionCount matches the serialized lean action list.
+      const summary = summaries.find(s => s.seed === record.config.seed);
+      expect(summary.actionCount).toBe(record.actions.length);
+    }
+  });
+
+  it('is deterministic: same seeds reproduce the same games (modulo timestamp)', () => {
+    const run = () => {
+      const lines = [];
+      generateShard({ bots: field(), seeds: [10, 11, 12], write: l => lines.push(l) });
+      return lines.map(l => stripTimestamp(JSON.parse(l)));
+    };
+    expect(run()).toEqual(run());
+  });
+
+  it('never retains heavy match objects — summaries stay tiny', () => {
+    const { summaries } = generateShard({ bots: field(), seeds: [1], write: () => {} });
+    // A summary carries only scalars + the placements array — no finalState/trajectory.
+    expect(Object.keys(summaries[0]).sort()).toEqual(
+      [
+        'actionCount',
+        'placements',
+        'quarantineSignal',
+        'quarantined',
+        'seed',
+        'turnCount',
+        'winner',
+      ].sort()
+    );
+  });
+
+  describe('D-14 quarantine drops dirty games but counts them', () => {
+    const strategist = resolveBotsByName(['Strategist'])[0];
+
+    it('quarantines a game where a bot throws (errors signal)', () => {
+      const lines = [];
+      const thrower = {
+        name: 'Thrower',
+        fn: () => {
+          throw new Error('boom');
+        },
+      };
+      const { summaries, written, quarantined } = generateShard({
+        bots: [thrower, { name: strategist.name, fn: strategist.fn }],
+        seeds: [1, 2],
+        write: l => lines.push(l),
+      });
+
+      expect(written).toBe(0);
+      expect(lines).toHaveLength(0);
+      expect(quarantined).toBe(2);
+      expect(summaries.every(s => s.quarantined && s.quarantineSignal === 'errors')).toBe(true);
+    });
+
+    it('quarantines a game with repeated invalid moves (invalidMoves signal)', () => {
+      const lines = [];
+      const invalidBot = { name: 'BadMover', fn: () => ({ from: 0, to: 0 }) }; // illegal every time
+      const { summaries, written } = generateShard({
+        bots: [invalidBot, { name: strategist.name, fn: strategist.fn }],
+        seeds: [3],
+        write: l => lines.push(l),
+      });
+
+      expect(written).toBe(0);
+      expect(summaries[0].quarantined).toBe(true);
+      expect(summaries[0].quarantineSignal).toBe('invalidMoves');
+    });
+
+    /*
+     * maxMovesHit (a turn force-ended by the MAX_MOVES_PER_TURN cap) and a runMatch
+     * throw can't be triggered deterministically with real games (<0.1% — PLAN/D-14),
+     * so these drive generateShard through its injectable runMatch seam.
+     */
+    const fakeResult = (overrides = {}) => ({
+      winner: 0,
+      placements: [0, 1],
+      turnCount: 5,
+      trajectory: { actions: [] },
+      botStats: [
+        { name: 'A', errors: 0, invalidMoves: 0, maxMovesHit: 0 },
+        { name: 'B', errors: 0, invalidMoves: 0, maxMovesHit: 0 },
+      ],
+      ...overrides,
+    });
+
+    it('quarantines a game force-ended by the move cap (maxMovesHit signal)', () => {
+      const lines = [];
+      const { summaries, written } = generateShard({
+        bots: [
+          { name: 'A', fn: () => null },
+          { name: 'B', fn: () => null },
+        ],
+        seeds: [1],
+        write: l => lines.push(l),
+        runMatchFn: () =>
+          fakeResult({
+            botStats: [
+              { name: 'A', errors: 0, invalidMoves: 0, maxMovesHit: 1 },
+              { name: 'B', errors: 0, invalidMoves: 0, maxMovesHit: 0 },
+            ],
+          }),
+      });
+
+      expect(written).toBe(0);
+      expect(lines).toHaveLength(0);
+      expect(summaries[0].quarantined).toBe(true);
+      expect(summaries[0].quarantineSignal).toBe('maxMovesHit');
+    });
+
+    it('aborts when the failure rate exceeds the threshold after the minimum games', () => {
+      const { summaries, failed, aborted } = generateShard({
+        bots: [
+          { name: 'A', fn: () => null },
+          { name: 'B', fn: () => null },
+        ],
+        seeds: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        runMatchFn: () => {
+          throw new Error('match exploded');
+        },
+      });
+
+      // 100% failure trips the >50%-after-5 guard, so it bails early (does not run all 10).
+      expect(aborted).toBe(true);
+      expect(failed).toBe(5);
+      expect(summaries).toHaveLength(5);
+      expect(summaries.every(s => s.quarantined && s.failed)).toBe(true);
+    });
+  });
+});
+
+describe('aggregateStats (deterministic ELO/stats post-pass)', () => {
+  const botNames = ['A', 'B', 'C'];
+  // A wins every clean game; one quarantined game must be excluded from ELO/win%.
+  const summaries = [
+    {
+      seed: 3,
+      placements: [0, 1, 2],
+      winner: 0,
+      turnCount: 20,
+      actionCount: 100,
+      quarantined: false,
+    },
+    {
+      seed: 1,
+      placements: [0, 2, 1],
+      winner: 0,
+      turnCount: 30,
+      actionCount: 200,
+      quarantined: false,
+    },
+    {
+      seed: 2,
+      placements: [0, 1, 2],
+      winner: 0,
+      turnCount: 25,
+      actionCount: 150,
+      quarantined: false,
+    },
+    { seed: 4, quarantined: true, quarantineSignal: 'errors' },
+    { seed: 5, quarantined: true, failed: true, error: 'boom' },
+  ];
+
+  it('separates clean from quarantined/failed games', () => {
+    const stats = aggregateStats(summaries, botNames);
+    expect(stats.totalGames).toBe(5);
+    expect(stats.cleanGames).toBe(3);
+    expect(stats.quarantinedGames).toBe(2);
+    expect(stats.failedGames).toBe(1);
+    expect(stats.cleanRate).toBeCloseTo(0.6, 5);
+    expect(stats.quarantineBySignal).toEqual({
+      errors: 1,
+      invalidMoves: 0,
+      maxMovesHit: 0,
+      failed: 1,
+    });
+  });
+
+  it('ranks the consistent winner first by ELO and reports win rate over clean games', () => {
+    const stats = aggregateStats(summaries, botNames);
+    expect(stats.bots[0].name).toBe('A');
+    expect(stats.bots[0].wins).toBe(3);
+    expect(stats.bots[0].winRate).toBe(1);
+    expect(stats.bots[0].gamesPlayed).toBe(3);
+    // Loser ELO sits below the default; winner above.
+    expect(stats.bots[0].elo).toBeGreaterThan(stats.bots[stats.bots.length - 1].elo);
+  });
+
+  it('computes the action-count distribution over clean games', () => {
+    const stats = aggregateStats(summaries, botNames);
+    expect(stats.actionCounts.min).toBe(100);
+    expect(stats.actionCounts.max).toBe(200);
+    expect(stats.actionCounts.p50).toBe(150);
+    expect(stats.actionCounts.mean).toBe(150);
+  });
+
+  it('is independent of summary order (path-dependent ELO replayed by seed)', () => {
+    const shuffled = [summaries[2], summaries[0], summaries[4], summaries[1], summaries[3]];
+    expect(aggregateStats(shuffled, botNames)).toEqual(aggregateStats(summaries, botNames));
+  });
+});
+
+describe('makeFileWriter', () => {
+  it('writes batched lines across the flush boundary and closes cleanly', () => {
+    const out = path.join(tmpDir, 'w.jsonl');
+    const writer = makeFileWriter(out);
+    const lines = Array.from({ length: 300 }, (_, i) => `line-${i}\n`);
+    lines.forEach(writer.write);
+    writer.close();
+
+    const contents = fs.readFileSync(out, 'utf-8');
+    expect(contents).toBe(lines.join(''));
+    expect(contents.trimEnd().split('\n')).toHaveLength(300);
+  });
+
+  it('is a no-op when given a null path (--no-write)', () => {
+    const writer = makeFileWriter(null);
+    expect(() => {
+      writer.write('ignored\n');
+      writer.close();
+    }).not.toThrow();
+  });
+});
+
+describe('selfplay CLI end-to-end (worker pool)', () => {
+  it('runs a sharded pool and writes seed-ordered, round-trippable JSONL', () => {
+    const out = path.join(tmpDir, 'e2e.jsonl');
+    execFileSync(
+      'node',
+      [
+        'scripts/selfplay.mjs',
+        '--workers',
+        '2',
+        '--seed-count',
+        '6',
+        '--out',
+        out,
+        '--bots',
+        DEFAULT_FIELD.join(','),
+      ],
+      { cwd: REPO_ROOT, stdio: 'pipe' }
+    );
+
+    expect(fs.existsSync(out)).toBe(true);
+    const records = fs
+      .readFileSync(out, 'utf-8')
+      .trim()
+      .split('\n')
+      .map(line => deserializeTrajectory(line));
+
+    expect(records.length).toBeGreaterThan(0);
+    expect(records.length).toBeLessThanOrEqual(6);
+
+    // Concatenation preserves strict seed order across the two shard part-files.
+    const seeds = records.map(r => r.config.seed);
+    expect(seeds).toEqual([...seeds].sort((a, b) => a - b));
+    expect(seeds.every(s => s >= 1 && s <= 6)).toBe(true);
+
+    // Shard part-files are cleaned up after a successful merge (none orphaned).
+    expect(fs.readdirSync(tmpDir).filter(f => f.includes('.part'))).toHaveLength(0);
+  }, 60_000);
+});

--- a/tests/scripts/selfplay.test.js
+++ b/tests/scripts/selfplay.test.js
@@ -18,6 +18,8 @@ import {
   generateShard,
   aggregateStats,
   makeFileWriter,
+  chunkSeeds,
+  rangeToSeeds,
 } from '../../scripts/lib/selfplay-core.mjs';
 import { deserializeTrajectory } from '../../src/arena/trajectoryExport.js';
 
@@ -60,6 +62,54 @@ describe('forcedEndReason (D-14 quarantine predicate)', () => {
   it('checks every seat, not just the first', () => {
     const reason = forcedEndReason([stat(), stat({ name: 'Z', invalidMoves: 4 })]);
     expect(reason).toMatchObject({ bot: 'Z', signal: 'invalidMoves' });
+  });
+});
+
+describe('resolveBotsByName', () => {
+  it('resolves known names case-insensitively to { id, name, fn }', () => {
+    const [bot] = resolveBotsByName(['strategist']);
+    expect(bot.name).toBe('Strategist');
+    expect(bot.id).toBeTruthy();
+    expect(typeof bot.fn).toBe('function');
+  });
+
+  it('throws a helpful error listing the available bots for an unknown name', () => {
+    expect(() => resolveBotsByName(['NotABot'])).toThrow(/Unknown bot "NotABot"/);
+    // The message names the valid options so the operator can self-correct.
+    expect(() => resolveBotsByName(['NotABot'])).toThrow(/Available:.*Strategist/);
+  });
+});
+
+describe('chunkSeeds / rangeToSeeds (D-13 seed-range sharding)', () => {
+  it('builds a contiguous ascending seed range', () => {
+    expect(rangeToSeeds(5, 4)).toEqual([5, 6, 7, 8]);
+    expect(rangeToSeeds(1, 1)).toEqual([1]);
+    expect(rangeToSeeds(10, 0)).toEqual([]);
+  });
+
+  it('splits evenly when the count divides by the worker count', () => {
+    expect(chunkSeeds(1, 6, 3)).toEqual([
+      [1, 2],
+      [3, 4],
+      [5, 6],
+    ]);
+  });
+
+  it('spreads the remainder over the first blocks, staying contiguous and ascending', () => {
+    expect(chunkSeeds(1, 10, 3)).toEqual([
+      [1, 2, 3, 4],
+      [5, 6, 7],
+      [8, 9, 10],
+    ]);
+  });
+
+  it('concatenates back to the original strict-ascending range (lossless merge)', () => {
+    const flat = chunkSeeds(100, 17, 4).flat();
+    expect(flat).toEqual(rangeToSeeds(100, 17));
+  });
+
+  it('skips zero-size blocks when workers exceed the seed count (no empty chunks)', () => {
+    expect(chunkSeeds(1, 2, 5)).toEqual([[1], [2]]);
   });
 });
 
@@ -257,6 +307,23 @@ describe('aggregateStats (deterministic ELO/stats post-pass)', () => {
       maxMovesHit: 0,
       failed: 1,
     });
+    // The failed game's message is surfaced (not just counted) for diagnosability.
+    expect(stats.failureSamples).toEqual([{ error: 'boom', count: 1, firstSeed: 5 }]);
+  });
+
+  it('aggregates failures by message (count + lowest seed), most frequent first', () => {
+    const withFailures = [
+      { seed: 7, quarantined: true, failed: true, error: 'boom' },
+      { seed: 2, quarantined: true, failed: true, error: 'boom' },
+      { seed: 9, quarantined: true, failed: true, error: 'kaboom' },
+    ];
+    const stats = aggregateStats(withFailures, botNames);
+    expect(stats.failedGames).toBe(3);
+    // 'boom' collapses to one group (count 2, lowest seed 2) and outranks the rarer 'kaboom'.
+    expect(stats.failureSamples).toEqual([
+      { error: 'boom', count: 2, firstSeed: 2 },
+      { error: 'kaboom', count: 1, firstSeed: 9 },
+    ]);
   });
 
   it('ranks the consistent winner first by ELO and reports win rate over clean games', () => {


### PR DESCRIPTION
## What

Committed, reusable **parallel self-play data generator** for the ML-bot initiative (`docs/ml-bot/`) — `scripts/selfplay.mjs` + `npm run selfplay`. Phase 1, task 5; implements DECISIONS **D-12** (parallel/streaming/aggregation), **D-13** (seed-range sharding), **D-14** (forced-end quarantine).

This is the generator Phase 2 reuses to produce its 100k–1M imitation games.

## How it works

- **Parallel** — `worker_threads` pool (default ~50% cores, per the CLAUDE.md machine policy). Workers receive bot **names**, not closures (bot fns aren't structured-cloneable — D-12); each owns a contiguous seed sub-range written to its own shard part-file, merged in seed order on completion.
- **Streaming, RAM-bounded** — trajectories stream to JSONL; the heavy `MatchResult`/`finalState` objects are never retained (a blow-up at scale). Only tiny per-game summaries survive, for the stats pass.
- **Deterministic aggregation** — ELO is path-dependent, so it's replayed single-threaded over summaries sorted by seed — independent of worker scheduling.
- **Shardable by seed range** — `--seed-start`/`--seed-count`/`--out` make output concatenate losslessly across machines (engine determinism + game independence — D-13). Also an inline single-core baseline (`--workers 1`) and a `--no-write` throughput-only mode.
- **D-14 forced-end quarantine** — a game where any bot's `errors`/`invalidMoves`/`maxMovesHit > 0` is dropped (not written), counted, and reported by signal. Keeps the lean record pure; this harness owns the cleanup.

## Files

- `scripts/lib/selfplay-core.mjs` — worker-agnostic, unit-testable core: `generateShard`, `forcedEndReason`, `aggregateStats`, `makeFileWriter`, `chunkSeeds`/`rangeToSeeds`.
- `scripts/lib/selfplay-worker.mjs` — `worker_threads` entry.
- `scripts/selfplay.mjs` — CLI + reporting (throughput / clean-rate / action-count distribution / ELO / failure messages).
- `tests/scripts/selfplay.test.js` — 29 tests, incl. worker-pool e2e, a failure-cleanup e2e, and a direct worker error-plumbing test.
- `package.json` (`npm run selfplay`), `.gitignore` (`data/selfplay/`), `docs/ml-bot/{PLAN,LOG}.md`.

## Quality

Ran an **adversarial multi-agent review** of the scaffold (17 agents; 12 findings → 7 confirmed, 5 refuted) and fixed all 7:
- Worker-pool error-path hardening — terminate straggler workers + clean up `.partN` files in a `finally`; `concatParts` destroys its stream on error and no longer owns deletion.
- Idempotent, `finally`-guarded `writer.close()` in the worker and inline paths (no fd leak on a `generateShard` throw).
- Added a `runMatchFn` test seam so the `maxMovesHit` and abort-on-failure paths (not triggerable with real games) are tested deterministically.

## Review fixes (follow-up)

A second multi-agent review (code / tests / errors / comments / types) found **no correctness blockers**; the follow-up commits address its observability and coverage findings:

**`f768be3` — observability + testable seed helpers**
- `aggregateStats` now surfaces *distinct* `runMatch`-throw messages (`failureSamples`: message, count, lowest seed) and the report prints them — a systemic failure on an unattended 100k–1M-game run is diagnosable, not just counted.
- Moved `chunkSeeds`/`rangeToSeeds` into the importable core and unit-tested them (even split, remainder spread, lossless round-trip, zero-size-block skip).
- Added `resolveBotsByName` tests (unknown-name throw) + a `failureSamples` aggregation test. Doc fix: "four forced-turn-end signals" → "three".

**`56e23a3` — worker-failure cleanup + error surfacing**
- `runPool`: single-settle gate per worker; the `exit` handler now rejects on *any* premature exit (not just non-zero codes), so a worker that dies without posting `done`/`error` is a loud failure rather than a hung `Promise.all`.
- Stacks surfaced — the in-worker stack is carried as `err.workerStack` and printed by the top-level catch (the original failure site, in another thread).
- `aggregateStats` throws on duplicate bot names (ELO/wins are name-keyed, so a duplicate would silently collapse two seats) — safe standalone; the CLI already can't reach it (`matchRunner` rejects dup fields first).
- Tests: worker-failure cleanup e2e (`--out` is a directory → merge fails → **no orphaned `.part` files**) + a direct worker error-plumbing test (message + stack).

✅ Full suite **832 passing** · lint clean · `prettier --check` clean · `npm run build` green.

## Deliberately out of scope

The PLAN task-5 checkbox stays **unchecked**: its gate needs before/after-trims and N-worker scaling numbers in `RESULTS.md`, which depend on **task 3 (per-move allocation trims)**. The harness's `--no-write` mode is the instrument to measure those next.
