### PR TITLE
chore(ml): harden BC trainer + add Python CI

### DIFF
--- a/.github/workflows/ml-ci.yml
+++ b/.github/workflows/ml-ci.yml
@@ -1,0 +1,52 @@
+name: ML CI
+
+# Python CI for the behavioral-cloning trainer (ml/). Separate from the JS `CI`
+# workflow and scoped to ml/** so it only runs when the Python package changes.
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'ml/**'
+      - '.github/workflows/ml-ci.yml'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'ml/**'
+      - '.github/workflows/ml-ci.yml'
+
+jobs:
+  ml-test:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ml
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: 'ml/pyproject.toml'
+
+      # Install the CPU torch wheel explicitly first: the default PyPI linux wheel
+      # is the multi-GB CUDA build we don't need on a CPU runner. The editable
+      # install below then sees torch>=2.1 already satisfied and only adds the rest.
+      - name: Install CPU PyTorch
+        run: pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+      - name: Install package + ONNX + dev extras
+        run: pip install -e '.[onnx,dev]'
+
+      - name: Lint (ruff)
+        run: ruff check .
+
+      # REQUIRE_ONNX=1 turns a missing onnx/onnxruntime into a hard failure rather
+      # than a silent skip, so the ONNX↔PyTorch parity tests can't quietly go green.
+      - name: Test (with ONNX parity gate)
+        run: pytest
+        env:
+          REQUIRE_ONNX: '1'

--- a/ml/README.md
+++ b/ml/README.md
@@ -72,10 +72,12 @@ Pass `--require-parity` to make a missing onnxruntime a hard failure instead —
 use it for the acceptance-gate run so an unverified model can't slip through.
 
 The export pins the **legacy TorchScript exporter** (`dynamo=False`, feature-detected
-so the floor stays torch 2.1) so the `dynamic_axes` graph is byte-for-byte the same
+so the floor stays torch 2.1) so it keeps the stable `dynamic_axes` graph contract
 across torch versions — torch ≥ 2.9 otherwise defaults to the dynamo exporter, which
-needs `onnxscript` and a different dynamic-shape API. Expect a deprecation warning;
-migrating to the dynamo exporter is future work.
+needs `onnxscript` and a different dynamic-shape API. (Exports stay numerically
+identical to the parity tolerance, asserted by the ONNX↔PyTorch check; the raw protobuf
+may still differ across torch versions.) Expect a deprecation warning; migrating to the
+dynamo exporter is future work.
 
 ## The architecture (per D-Encoding)
 

--- a/ml/README.md
+++ b/ml/README.md
@@ -71,6 +71,12 @@ succeeds but warns and stamps `parityChecked: false` (the model is UNVERIFIED).
 Pass `--require-parity` to make a missing onnxruntime a hard failure instead —
 use it for the acceptance-gate run so an unverified model can't slip through.
 
+The export pins the **legacy TorchScript exporter** (`dynamo=False`, feature-detected
+so the floor stays torch 2.1) so the `dynamic_axes` graph is byte-for-byte the same
+across torch versions — torch ≥ 2.9 otherwise defaults to the dynamo exporter, which
+needs `onnxscript` and a different dynamic-shape API. Expect a deprecation warning;
+migrating to the dynamo exporter is future work.
+
 ## The architecture (per D-Encoding)
 
 A **masked per-edge MLP** — the simplest learner that can clone; escalate to a
@@ -118,9 +124,14 @@ run the session, and `argmax`. The sidecar `bc_policy.onnx.json` carries
 
 ```bash
 cd ml && pytest          # hermetic — builds a tiny synthetic corpus, no real data needed
+cd ml && ruff check .    # lint (ruff is pinned in the dev extra for a reproducible gate)
 ```
 
 Tests that need `torch` / `onnxruntime` skip automatically if those aren't installed.
 Set `REQUIRE_ONNX=1` to turn a missing `onnx`/`onnxruntime` into a hard failure
 instead of a skip — use it in CI so the ONNX↔PyTorch parity gate can't silently
 pass by being skipped.
+
+CI runs both on every PR that touches `ml/**`: [`.github/workflows/ml-ci.yml`](../.github/workflows/ml-ci.yml)
+installs CPU torch + `.[onnx,dev]` on Python 3.11 and runs `ruff check` then
+`REQUIRE_ONNX=1 pytest`. (Requires Python ≥ 3.10 — the code uses `zip(strict=…)`.)

--- a/ml/dicewars_bc/dataset.py
+++ b/ml/dicewars_bc/dataset.py
@@ -18,7 +18,7 @@ highly correlated (same board, adjacent turns), so a per-step split would leak.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 
 import numpy as np
 import torch
@@ -64,12 +64,15 @@ class CorpusDataset(Dataset):
         self._validate_integrity()
 
     def _validate_integrity(self) -> None:
-        """One-time corpus sanity checks at load — cheap (only the small i32 index
-        arrays are read fully). Turns a contract break (a dropped STOP edge, an
-        out-of-range label, a truncated/non-CSR offset array) into a loud error at
-        the seam, rather than an ``-inf`` loss or a silent neighbor-row read deep in
-        training (the segmented loss assumes every step has >=1 edge and a
-        per-slice-local label)."""
+        """One-time corpus sanity checks at load. The CSR/label checks read only the
+        small per-step i32 arrays; the edge_index range check streams a single
+        min/max over the larger edge_index blob (one O(edges) pass, negligible next
+        to a multi-hour training run). Turns a contract break (a dropped STOP edge,
+        an out-of-range label, an out-of-range territory id, a truncated/non-CSR
+        offset array) into a loud error at the seam, rather than an ``-inf`` loss or
+        a silent neighbor-row read deep in training (the segmented loss assumes every
+        step has >=1 edge and a per-slice-local label; the model gathers node
+        embeddings by ``edge_batch * max_areas + id``)."""
         offsets = np.asarray(self.edge_offsets, dtype=np.int64)
         labels = np.asarray(self.labels, dtype=np.int64)
         total_edges = self.edges.shape[0]
@@ -78,7 +81,8 @@ class CorpusDataset(Dataset):
             raise ValueError(f"edge_offsets[0] must be 0, got {offsets[0]}.")
         if offsets[-1] != total_edges:
             raise ValueError(
-                f"edge_offsets[-1]={offsets[-1]} != edges row count {total_edges} — truncated/corrupt corpus."
+                f"edge_offsets[-1]={offsets[-1]} != edges row count {total_edges} — "
+                f"truncated/corrupt corpus."
             )
         counts = np.diff(offsets)
         if counts.size and counts.min() < 1:
@@ -93,6 +97,21 @@ class CorpusDataset(Dataset):
             raise ValueError(
                 f"label {int(labels[bad])} at step {bad} is out of range [0, {int(counts[bad])}) "
                 f"for its edge slice — labels must be LOCAL chosen-edge indices."
+            )
+
+        # edge_index ids must address a real node row [0, max_areas). The model
+        # gathers from/to node embeddings by `edge_batch * max_areas + id`, so an
+        # out-of-range id would silently index a neighbouring step's node block (or
+        # run off the end on the last step) instead of erroring. The JS encoder
+        # guarantees in-range ids; this catches a corrupt/hand-built corpus. STOP
+        # edges use sentinel id 0, which is in range.
+        max_areas = self.manifest.max_areas
+        ei_min = int(self.edge_index.min())
+        ei_max = int(self.edge_index.max())
+        if ei_min < 0 or ei_max >= max_areas:
+            raise ValueError(
+                f"edge_index id out of range [0, {max_areas}): min={ei_min}, max={ei_max}. "
+                f"Ids must address a territory node row (STOP uses sentinel 0)."
             )
 
     def __len__(self) -> int:
@@ -144,19 +163,11 @@ class Batch:
     def batch_size(self) -> int:
         return self.nodes.shape[0]
 
-    def to(self, device) -> "Batch":
-        return Batch(
-            nodes=self.nodes.to(device),
-            players=self.players.to(device),
-            board=self.board.to(device),
-            edge_feat=self.edge_feat.to(device),
-            edge_from=self.edge_from.to(device),
-            edge_to=self.edge_to.to(device),
-            edge_batch=self.edge_batch.to(device),
-            edge_offsets=self.edge_offsets.to(device),
-            labels=self.labels.to(device),
-            value=self.value.to(device),
-        )
+    def to(self, device) -> Batch:
+        # Every field is a tensor; move them generically so adding a field can't
+        # silently leave it on the wrong device (the hand-written version had to be
+        # kept in sync by hand).
+        return Batch(**{f.name: getattr(self, f.name).to(device) for f in fields(self)})
 
 
 def collate(items: list[dict[str, torch.Tensor]]) -> Batch:
@@ -206,6 +217,8 @@ def split_by_game(
         n_val = min(n_val, len(games) - 1)
     val_games = set(games[:n_val].tolist())
 
-    is_val = np.fromiter((g in val_games for g in game_of_step), dtype=bool, count=len(game_of_step))
+    is_val = np.fromiter(
+        (g in val_games for g in game_of_step), dtype=bool, count=len(game_of_step)
+    )
     all_steps = np.arange(len(game_of_step))
     return all_steps[~is_val], all_steps[is_val]

--- a/ml/dicewars_bc/dataset.py
+++ b/ml/dicewars_bc/dataset.py
@@ -31,6 +31,19 @@ def _memmap(m: CorpusManifest, name: str) -> np.memmap:
     return np.memmap(m.file_path(name), dtype=m.dtype(name), mode="r", shape=m.shape(name))
 
 
+def _all_finite(arr, chunk: int = 1 << 24) -> bool:
+    """True iff every element is finite (no NaN/inf), checked in fixed-size chunks.
+
+    A flat ``np.isfinite(arr).all()`` would materialize a bool array the size of the
+    whole blob — defeating the point of memmapping a tens-of-GB corpus. Chunking keeps
+    peak memory flat (~16M elems/chunk) and short-circuits on the first bad chunk."""
+    flat = np.asarray(arr).reshape(-1)
+    for i in range(0, flat.size, chunk):
+        if not np.isfinite(flat[i : i + chunk]).all():
+            return False
+    return True
+
+
 class CorpusDataset(Dataset):
     """One item per teacher decision step.
 
@@ -65,14 +78,14 @@ class CorpusDataset(Dataset):
 
     def _validate_integrity(self) -> None:
         """One-time corpus sanity checks at load. The CSR/label checks read only the
-        small per-step i32 arrays; the edge_index range check streams a single
-        min/max over the larger edge_index blob (one O(edges) pass, negligible next
-        to a multi-hour training run). Turns a contract break (a dropped STOP edge,
-        an out-of-range label, an out-of-range territory id, a truncated/non-CSR
-        offset array) into a loud error at the seam, rather than an ``-inf`` loss or
-        a silent neighbor-row read deep in training (the segmented loss assumes every
-        step has >=1 edge and a per-slice-local label; the model gathers node
-        embeddings by ``edge_batch * max_areas + id``)."""
+        small per-step i32 arrays; the edge_index range check and the float-finiteness
+        check each make a single O(N) pass over the larger blobs (negligible next to a
+        multi-hour training run). Turns a contract break (a dropped STOP edge, an
+        out-of-range label, an out-of-range territory id, a non-finite float feature,
+        a truncated/non-CSR offset array) into a loud error at the seam, rather than an
+        ``-inf``/``nan`` loss or a silent neighbor-row read deep in training (the
+        segmented loss assumes every step has >=1 edge and a per-slice-local label; the
+        model gathers node embeddings by ``edge_batch * max_areas + id``)."""
         offsets = np.asarray(self.edge_offsets, dtype=np.int64)
         labels = np.asarray(self.labels, dtype=np.int64)
         total_edges = self.edges.shape[0]
@@ -101,10 +114,11 @@ class CorpusDataset(Dataset):
 
         # edge_index ids must address a real node row [0, max_areas). The model
         # gathers from/to node embeddings by `edge_batch * max_areas + id`, so an
-        # out-of-range id would silently index a neighbouring step's node block (or
-        # run off the end on the last step) instead of erroring. The JS encoder
-        # guarantees in-range ids; this catches a corrupt/hand-built corpus. STOP
-        # edges use sentinel id 0, which is in range.
+        # out-of-range id would silently index a neighbouring step's node block
+        # instead of erroring (an id past the very last block would instead trip
+        # torch's own index bounds-check — caught, but far from this seam). The JS
+        # encoder guarantees in-range ids; this catches a corrupt/hand-built corpus.
+        # STOP edges use sentinel id 0, which is in range.
         max_areas = self.manifest.max_areas
         ei_min = int(self.edge_index.min())
         ei_max = int(self.edge_index.max())
@@ -113,6 +127,23 @@ class CorpusDataset(Dataset):
                 f"edge_index id out of range [0, {max_areas}): min={ei_min}, max={ei_max}. "
                 f"Ids must address a territory node row (STOP uses sentinel 0)."
             )
+
+        # Float feature blobs must be finite. A NaN/inf would sail through the integer
+        # checks above and surface as a silent `nan` loss deep in training (the same
+        # fail-at-the-seam rationale, for the f32 inputs). Chunked so a tens-of-GB blob
+        # never lands fully in RAM (see _all_finite).
+        for blob_name, arr in (
+            ("nodes", self.nodes),
+            ("players", self.players),
+            ("board", self.board),
+            ("edges", self.edges),
+            ("value", self.value),
+        ):
+            if not _all_finite(arr):
+                raise ValueError(
+                    f"{blob_name}.f32 contains NaN/inf — corrupt corpus; "
+                    f"float features must be finite."
+                )
 
     def __len__(self) -> int:
         return self.manifest.steps

--- a/ml/dicewars_bc/export_onnx.py
+++ b/ml/dicewars_bc/export_onnx.py
@@ -22,6 +22,7 @@ status so the JS wrapper can refuse — or at least warn on — an unverified mo
 from __future__ import annotations
 
 import argparse
+import inspect
 import json
 from pathlib import Path
 
@@ -72,7 +73,10 @@ def _make_example(config: ModelConfig, edge_counts, n_seats=None, seed: int = 0)
 def export(
     ckpt_path: str | Path, out_path: str | Path, opset: int = 17, require_parity: bool = False
 ) -> Path:
-    ckpt = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+    # weights_only=True: our checkpoints are tensors + plain dict/list/str/num/None
+    # (state_dict, config, feature_names, metadata) — no pickled classes — so the
+    # restricted unpickler loads them and we never execute arbitrary pickle payloads.
+    ckpt = torch.load(ckpt_path, map_location="cpu", weights_only=True)
     config = ModelConfig(**ckpt["config"])
     model = EdgePolicyNet(config)
     model.load_state_dict(ckpt["state_dict"])
@@ -97,16 +101,22 @@ def export(
         "value": {0: "batch"},
     }
 
-    torch.onnx.export(
-        model,
-        example,
-        str(out_path),
+    export_kwargs = dict(
         input_names=INPUT_NAMES,
         output_names=OUTPUT_NAMES,
         dynamic_axes=dynamic_axes,
         opset_version=opset,
         do_constant_folding=True,
     )
+    # torch>=2.9 defaults `torch.onnx.export` to the dynamo exporter, which needs
+    # onnxscript and consumes `dynamic_shapes` rather than the `dynamic_axes`
+    # contract above. Pin the legacy TorchScript exporter so the export is identical
+    # across torch versions (and pulls no onnxscript) — but only pass the flag on
+    # torch>=2.5, which is where the `dynamo` kwarg first exists (the floor is 2.1).
+    # The eventual migration is to the dynamo exporter + dynamic_shapes.
+    if "dynamo" in inspect.signature(torch.onnx.export).parameters:
+        export_kwargs["dynamo"] = False
+    torch.onnx.export(model, example, str(out_path), **export_kwargs)
     print(f"Exported ONNX → {out_path}")
 
     # Check parity at B=1 (the inference shape) AND B=2 — the latter is the only
@@ -153,7 +163,7 @@ def _check_parity(model, out_path: Path, examples, strict: bool = False) -> dict
     for label, example in examples:
         with torch.no_grad():
             torch_logits, torch_value = model(*example)
-        feeds = {name: t.numpy() for name, t in zip(INPUT_NAMES, example)}
+        feeds = {name: t.numpy() for name, t in zip(INPUT_NAMES, example, strict=True)}
         ort_logits, ort_value = sess.run(OUTPUT_NAMES, feeds)
 
         logit_err = float(np.abs(ort_logits - torch_logits.numpy()).max())
@@ -165,7 +175,10 @@ def _check_parity(model, out_path: Path, examples, strict: bool = False) -> dict
                 f"ONNX/PyTorch parity FAILED on {label}: max |Δlogits|={logit_err:.2e}, "
                 f"max |Δvalue|={value_err:.2e} (tol {tol:.0e})."
             )
-        print(f"ORT parity OK ({label}): max |Δlogits|={logit_err:.2e}, max |Δvalue|={value_err:.2e}")
+        print(
+            f"ORT parity OK ({label}): max |Δlogits|={logit_err:.2e}, "
+            f"max |Δvalue|={value_err:.2e}"
+        )
     return {
         "checked": True,
         "tol": tol,
@@ -182,6 +195,10 @@ def _write_sidecar(
     ``parityChecked`` records whether the ONNX↔PyTorch parity gate actually ran
     (it no-ops when onnxruntime is absent), so the JS wrapper can refuse — or at
     least warn on — a model whose numerics were never verified."""
+
+    def spec(name: str, dtype: str, shape: list) -> dict:
+        return {"name": name, "dtype": dtype, "shape": shape}
+
     sidecar = {
         "encodingVersion": ckpt.get("encoding_version"),
         "teacher": ckpt.get("teacher"),
@@ -192,17 +209,17 @@ def _write_sidecar(
         "featureNames": ckpt.get("feature_names"),
         "io": {
             "inputs": [
-                {"name": "nodes", "dtype": "float32", "shape": ["batch", config.max_areas, config.node_features]},
-                {"name": "players", "dtype": "float32", "shape": ["batch", "players", config.player_features]},
-                {"name": "board", "dtype": "float32", "shape": ["batch", config.board_features]},
-                {"name": "edge_feat", "dtype": "float32", "shape": ["edges", config.edge_features]},
-                {"name": "edge_from", "dtype": "int64", "shape": ["edges"]},
-                {"name": "edge_to", "dtype": "int64", "shape": ["edges"]},
-                {"name": "edge_batch", "dtype": "int64", "shape": ["edges"]},
+                spec("nodes", "float32", ["batch", config.max_areas, config.node_features]),
+                spec("players", "float32", ["batch", "players", config.player_features]),
+                spec("board", "float32", ["batch", config.board_features]),
+                spec("edge_feat", "float32", ["edges", config.edge_features]),
+                spec("edge_from", "int64", ["edges"]),
+                spec("edge_to", "int64", ["edges"]),
+                spec("edge_batch", "int64", ["edges"]),
             ],
             "outputs": [
-                {"name": "edge_logits", "dtype": "float32", "shape": ["edges"]},
-                {"name": "value", "dtype": "float32", "shape": ["batch", 2]},
+                spec("edge_logits", "float32", ["edges"]),
+                spec("value", "float32", ["batch", 2]),
             ],
         },
         "notes": [

--- a/ml/dicewars_bc/export_onnx.py
+++ b/ml/dicewars_bc/export_onnx.py
@@ -109,14 +109,23 @@ def export(
         do_constant_folding=True,
     )
     # torch>=2.9 defaults `torch.onnx.export` to the dynamo exporter, which needs
-    # onnxscript and consumes `dynamic_shapes` rather than the `dynamic_axes`
-    # contract above. Pin the legacy TorchScript exporter so the export is identical
-    # across torch versions (and pulls no onnxscript) — but only pass the flag on
-    # torch>=2.5, which is where the `dynamo` kwarg first exists (the floor is 2.1).
-    # The eventual migration is to the dynamo exporter + dynamic_shapes.
+    # onnxscript and consumes `dynamic_shapes` rather than the `dynamic_axes` contract
+    # above. Pin the legacy TorchScript exporter so the export keeps the same
+    # `dynamic_axes` contract across torch versions (and pulls no onnxscript, and stays
+    # numerically identical to the parity tol below — the raw protobuf may still differ).
+    # We FEATURE-DETECT the `dynamo` kwarg from the signature rather than version-gate
+    # (more robust than parsing torch.__version__): the kwarg first appears in torch 2.5,
+    # and our floor is 2.1. The eventual migration is to the dynamo exporter +
+    # dynamic_shapes.
     if "dynamo" in inspect.signature(torch.onnx.export).parameters:
         export_kwargs["dynamo"] = False
     torch.onnx.export(model, example, str(out_path), **export_kwargs)
+    # Positively confirm the legacy exporter was the one that ran: the dynamo exporter
+    # ignores `dynamic_axes` and would freeze the edge/seat dims to constants. Inspect
+    # the written graph and fail loudly if any declared-dynamic input axis came out
+    # static — this also covers the onnxruntime-absent path, where the B=2 parity check
+    # below can't run.
+    _assert_dynamic_axes(out_path, dynamic_axes)
     print(f"Exported ONNX → {out_path}")
 
     # Check parity at B=1 (the inference shape) AND B=2 — the latter is the only
@@ -133,6 +142,45 @@ def export(
     )
     _write_sidecar(out_path, ckpt, config, opset, parity)
     return out_path
+
+
+def _assert_dynamic_axes(out_path: Path, dynamic_axes: dict) -> None:
+    """Confirm the exported graph kept its declared-dynamic INPUT axes as symbolic dims.
+
+    The legacy TorchScript exporter encodes each ``dynamic_axes`` entry as a named dim
+    (a ``dim_param``); the dynamo exporter ignores ``dynamic_axes`` and emits a fixed
+    ``dim_value`` instead — silently freezing the edge/seat axes. Reading the graph back
+    catches that regardless of *why* it happened (a future ``torch.onnx.export`` signature
+    change, a dropped ``dynamo=False``). Best-effort: no-op when the ``onnx`` package isn't
+    importable (it ships only in the ``onnx`` extra), mirroring the parity check's handling
+    of a missing onnxruntime."""
+    try:
+        import onnx
+    except ImportError:
+        return
+    graph = onnx.load(str(out_path)).graph
+    inputs = {vi.name: vi for vi in graph.input}
+    # A renamed/dropped input is itself a red flag: the dynamo/FX exporter can rename or
+    # reorder graph I/O (not just freeze axes), which would otherwise let the per-axis
+    # loop below skip every input and pass vacuously. Require our named inputs to exist.
+    missing = [n for n in INPUT_NAMES if n not in inputs]
+    if missing:
+        raise RuntimeError(
+            f"Exported ONNX is missing expected input(s) {missing} — the legacy "
+            f"TorchScript exporter was not used (did torch.onnx.export change?)."
+        )
+    for name, axes in dynamic_axes.items():
+        vi = inputs.get(name)
+        if vi is None:
+            continue  # output axes (edge_logits/value) aren't graph inputs
+        dims = vi.type.tensor_type.shape.dim
+        for axis in axes:
+            if not dims[axis].dim_param:
+                raise RuntimeError(
+                    f"Exported ONNX froze input '{name}' axis {axis} to a constant "
+                    f"({dims[axis].dim_value}) — expected a dynamic dim. The legacy "
+                    f"TorchScript exporter was not used (did torch.onnx.export change?)."
+                )
 
 
 def _check_parity(model, out_path: Path, examples, strict: bool = False) -> dict:

--- a/ml/dicewars_bc/model.py
+++ b/ml/dicewars_bc/model.py
@@ -30,7 +30,7 @@ belongs to). The same ``forward`` runs at B=1 for the single-step ONNX export.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 
 import torch
 from torch import nn
@@ -57,7 +57,7 @@ class ModelConfig:
     edge_hidden: int = 128
 
     @classmethod
-    def from_manifest(cls, m: CorpusManifest, **overrides) -> "ModelConfig":
+    def from_manifest(cls, m: CorpusManifest, **overrides) -> ModelConfig:
         return cls(
             max_areas=m.max_areas,
             node_features=m.node_features,
@@ -69,7 +69,9 @@ class ModelConfig:
         )
 
     def to_dict(self) -> dict:
-        return self.__dict__.copy()
+        # asdict() is the canonical dataclass→dict (round-trips via ModelConfig(**d))
+        # and, unlike __dict__, won't leak any non-field attribute set on the instance.
+        return asdict(self)
 
 
 def _mlp(sizes: list[int]) -> nn.Sequential:

--- a/ml/dicewars_bc/train.py
+++ b/ml/dicewars_bc/train.py
@@ -183,8 +183,12 @@ def train(args: argparse.Namespace) -> Path:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    p = argparse.ArgumentParser(description="Behavioral-cloning trainer (DiceWarsJS ml-bot Phase 2)")
-    p.add_argument("--corpus", required=True, help="Packed-corpus dir (output of npm run encode-corpus)")
+    p = argparse.ArgumentParser(
+        description="Behavioral-cloning trainer (DiceWarsJS ml-bot Phase 2)"
+    )
+    p.add_argument(
+        "--corpus", required=True, help="Packed-corpus dir (output of npm run encode-corpus)"
+    )
     p.add_argument("--out", default="checkpoints", help="Checkpoint output dir")
     p.add_argument("--epochs", type=int, default=20)
     p.add_argument("--batch-size", type=int, default=512)

--- a/ml/pyproject.toml
+++ b/ml/pyproject.toml
@@ -21,7 +21,9 @@ onnx = [
 ]
 dev = [
   "pytest>=7.4",
-  "ruff>=0.4",
+  # Pinned exact so the lint gate is reproducible: an unpinned ruff adds/retires
+  # rules on new releases and would break CI with no code change. Bump deliberately.
+  "ruff==0.15.18",
 ]
 
 [project.scripts]

--- a/ml/requirements.txt
+++ b/ml/requirements.txt
@@ -18,4 +18,6 @@ onnxruntime>=1.17
 
 # Tests / lint.
 pytest>=7.4
-ruff>=0.4
+# Pinned exact to match pyproject.toml's dev extra so this install path produces the
+# same lint results as CI (an unpinned ruff adds/retires rules across releases).
+ruff==0.15.18

--- a/ml/tests/_fixtures.py
+++ b/ml/tests/_fixtures.py
@@ -16,7 +16,9 @@ import numpy as np
 # Feature widths are part of the v1 encoding contract — keep these at the real
 # widths so the model code paths are identical to production; only A and P shrink.
 NODE_FEATURES = ["present", "diceNorm", "isMine", "isEnemy", "isBorder"]
-PLAYER_FEATURES = ["isMe", "eliminated", "territoriesFrac", "diceFrac", "connectedFrac", "stockNorm"]
+PLAYER_FEATURES = [
+    "isMe", "eliminated", "territoriesFrac", "diceFrac", "connectedFrac", "stockNorm",
+]
 BOARD_FEATURES = ["myDiceShare", "activeFrac", "phaseEarly", "phaseMid", "phaseLate"]
 EDGE_FEATURES = ["winProb", "atkNorm", "defNorm", "isStop"]
 

--- a/ml/tests/test_dataset.py
+++ b/ml/tests/test_dataset.py
@@ -100,6 +100,40 @@ def test_integrity_rejects_out_of_range_edge_index(tmp_path):
         CorpusDataset(corpus)
 
 
+def test_integrity_rejects_negative_edge_index(tmp_path):
+    # The lower half of the `ei_min < 0 or ei_max >= max_areas` guard: a negative id
+    # would index backwards into the previous step's node block (edge_batch * A + id),
+    # a silent mis-gather rather than an error — so it must be rejected at the seam.
+    corpus = default_corpus(tmp_path / "c")  # max_areas == 6
+    ei = np.fromfile(corpus / "edge_index.i32", dtype="<i4")
+    ei[0] = -1
+    ei.tofile(corpus / "edge_index.i32")
+    with pytest.raises(ValueError, match="out of range"):
+        CorpusDataset(corpus)
+
+
+def test_integrity_rejects_edge_index_equal_to_max_areas(tmp_path):
+    # Off-by-one boundary: the range is half-open [0, max_areas), so id == max_areas
+    # is the first INVALID value and must raise. Pins the `>=` (vs `>`) in the guard.
+    corpus = default_corpus(tmp_path / "c")  # max_areas == 6
+    ei = np.fromfile(corpus / "edge_index.i32", dtype="<i4")
+    ei[0] = 6  # == max_areas
+    ei.tofile(corpus / "edge_index.i32")
+    with pytest.raises(ValueError, match="out of range"):
+        CorpusDataset(corpus)
+
+
+def test_integrity_accepts_max_in_range_edge_index(tmp_path):
+    # Positive boundary: max_areas - 1 is the highest valid node row and must NOT be
+    # rejected — guards against an over-eager check that would flag the top of range.
+    corpus = default_corpus(tmp_path / "c")  # max_areas == 6
+    ei = np.fromfile(corpus / "edge_index.i32", dtype="<i4")
+    ei[0] = 5  # max_areas - 1
+    ei.tofile(corpus / "edge_index.i32")
+    ds = CorpusDataset(corpus)  # must construct without raising
+    assert len(ds) == 7
+
+
 def test_split_val_frac_zero(tmp_path):
     corpus = default_corpus(tmp_path / "c")
     ds = CorpusDataset(corpus)

--- a/ml/tests/test_dataset.py
+++ b/ml/tests/test_dataset.py
@@ -1,5 +1,7 @@
 """Dataset memmap reads, CSR slicing, collation, and game-level split."""
 
+from dataclasses import fields
+
 import numpy as np
 import pytest
 from _fixtures import default_corpus
@@ -132,6 +134,30 @@ def test_integrity_accepts_max_in_range_edge_index(tmp_path):
     ei.tofile(corpus / "edge_index.i32")
     ds = CorpusDataset(corpus)  # must construct without raising
     assert len(ds) == 7
+
+
+def test_integrity_rejects_nan_in_float_blob(tmp_path):
+    # A NaN in any f32 feature blob is corruption that would otherwise surface as a
+    # silent `nan` loss deep in training — reject it at load, like the integer checks.
+    corpus = default_corpus(tmp_path / "c")
+    nodes = np.fromfile(corpus / "nodes.f32", dtype="<f4")
+    nodes[0] = np.nan
+    nodes.tofile(corpus / "nodes.f32")
+    with pytest.raises(ValueError, match="NaN/inf"):
+        CorpusDataset(corpus)
+
+
+def test_batch_to_moves_every_field(tmp_path):
+    # Batch.to() rebuilds generically over dataclass fields; the result must be a Batch
+    # whose every field is a tensor on the target device. A non-tensor field added later
+    # would raise here — the regression the generic rewrite is meant to guard against.
+    corpus = default_corpus(tmp_path / "c")
+    ds = CorpusDataset(corpus)
+    batch = collate([ds[i] for i in range(len(ds))]).to("cpu")
+    for f in fields(batch):
+        t = getattr(batch, f.name)
+        assert isinstance(t, torch.Tensor)
+        assert t.device.type == "cpu"
 
 
 def test_split_val_frac_zero(tmp_path):

--- a/ml/tests/test_dataset.py
+++ b/ml/tests/test_dataset.py
@@ -2,7 +2,6 @@
 
 import numpy as np
 import pytest
-
 from _fixtures import default_corpus
 
 torch = pytest.importorskip("torch")
@@ -89,6 +88,15 @@ def test_integrity_rejects_empty_segment(tmp_path):
     offsets[1] = offsets[0]  # step 0 now owns zero edges (no STOP)
     offsets.tofile(corpus / "edge_offsets.i32")
     with pytest.raises(ValueError, match=">=1"):
+        CorpusDataset(corpus)
+
+
+def test_integrity_rejects_out_of_range_edge_index(tmp_path):
+    corpus = default_corpus(tmp_path / "c")  # max_areas == 6
+    ei = np.fromfile(corpus / "edge_index.i32", dtype="<i4")
+    ei[0] = 999  # a territory id far past max_areas
+    ei.tofile(corpus / "edge_index.i32")
+    with pytest.raises(ValueError, match="out of range"):
         CorpusDataset(corpus)
 
 

--- a/ml/tests/test_export_onnx.py
+++ b/ml/tests/test_export_onnx.py
@@ -185,3 +185,54 @@ def test_onnx_matches_torch_on_a_real_step(tmp_path):
     o_logits, o_value = sess.run(OUTPUT_NAMES, feeds)
     np.testing.assert_allclose(o_logits, t_logits.numpy(), atol=1e-4)
     np.testing.assert_allclose(o_value, t_value.numpy(), atol=1e-4)
+
+
+def test_export_graph_has_symbolic_dynamic_axes(tmp_path):
+    """The exported graph keeps its dynamic input axes as symbolic dims rather than
+    freezing them — checked at the graph level (onnx only), so it holds even on the
+    onnxruntime-absent path. This is the regression guard that the legacy TorchScript
+    exporter (not the dynamo exporter, which ignores dynamic_axes) produced the graph."""
+    import onnx
+
+    ckpt_path, _ = _make_checkpoint(tmp_path)
+    onnx_path = tmp_path / "bc_policy.onnx"
+    export(ckpt_path, onnx_path)
+
+    inputs = {vi.name: vi for vi in onnx.load(str(onnx_path)).graph.input}
+    # edge_feat: dynamic edge count on axis 0; players: dynamic seat count on axis 1;
+    # nodes: dynamic batch on axis 0. A frozen axis would carry dim_value, not dim_param.
+    assert inputs["edge_feat"].type.tensor_type.shape.dim[0].dim_param
+    assert inputs["players"].type.tensor_type.shape.dim[1].dim_param
+    assert inputs["nodes"].type.tensor_type.shape.dim[0].dim_param
+
+
+def test_assert_dynamic_axes_rejects_frozen_and_renamed(tmp_path):
+    """The post-export guard must fire on both ways the dynamo/FX exporter would break
+    the dynamic_axes contract: a frozen (static) input axis, and a renamed/dropped input
+    (which would otherwise let the per-axis loop skip everything and pass vacuously)."""
+    import onnx
+
+    from dicewars_bc.export_onnx import _assert_dynamic_axes
+
+    ckpt_path, _ = _make_checkpoint(tmp_path)
+    onnx_path = tmp_path / "bc_policy.onnx"
+    export(ckpt_path, onnx_path)
+    axes = {"nodes": {0: "batch"}, "edge_feat": {0: "edges"}}
+
+    # (a) freeze edge_feat axis 0 to a constant -> rejected.
+    frozen = tmp_path / "frozen.onnx"
+    m = onnx.load(str(onnx_path))
+    dim = next(v for v in m.graph.input if v.name == "edge_feat").type.tensor_type.shape.dim[0]
+    dim.ClearField("dim_param")
+    dim.dim_value = 6
+    onnx.save(m, str(frozen))
+    with pytest.raises(RuntimeError, match="froze input"):
+        _assert_dynamic_axes(frozen, axes)
+
+    # (b) rename an expected input -> rejected (not silently skipped).
+    renamed = tmp_path / "renamed.onnx"
+    m = onnx.load(str(onnx_path))
+    next(v for v in m.graph.input if v.name == "edge_feat").name = "edge_feat_X"
+    onnx.save(m, str(renamed))
+    with pytest.raises(RuntimeError, match="missing expected input"):
+        _assert_dynamic_axes(renamed, axes)

--- a/ml/tests/test_export_onnx.py
+++ b/ml/tests/test_export_onnx.py
@@ -157,7 +157,7 @@ def test_onnx_matches_torch_on_a_real_step(tmp_path):
     export(ckpt_path, onnx_path)
 
     model = EdgePolicyNet(config)
-    model.load_state_dict(torch.load(ckpt_path, weights_only=False)["state_dict"])
+    model.load_state_dict(torch.load(ckpt_path, weights_only=True)["state_dict"])
     model.eval()
 
     a = config.max_areas
@@ -179,6 +179,7 @@ def test_onnx_matches_torch_on_a_real_step(tmp_path):
         zip(
             INPUT_NAMES,
             [t.numpy() for t in (nodes, players, board, edge_feat, edge_from, edge_to, edge_batch)],
+            strict=True,
         )
     )
     o_logits, o_value = sess.run(OUTPUT_NAMES, feeds)

--- a/ml/tests/test_manifest.py
+++ b/ml/tests/test_manifest.py
@@ -3,8 +3,8 @@
 import json
 
 import pytest
-
 from _fixtures import default_corpus
+
 from dicewars_bc.manifest import EXPECTED_ENCODING_VERSION, load_manifest
 
 

--- a/ml/tests/test_train.py
+++ b/ml/tests/test_train.py
@@ -1,7 +1,6 @@
 """End-to-end smoke test: the training loop runs and writes a checkpoint."""
 
 import pytest
-
 from _fixtures import default_corpus
 
 torch = pytest.importorskip("torch")
@@ -29,7 +28,9 @@ def test_train_one_epoch_writes_checkpoint(tmp_path):
     ckpt_path = train(args)
     assert ckpt_path.is_file()
 
-    ckpt = torch.load(ckpt_path, weights_only=False)
+    # weights_only=True doubles as a guard that the checkpoint stays safe-loadable
+    # (only tensors + plain containers/scalars) — see export_onnx.py.
+    ckpt = torch.load(ckpt_path, weights_only=True)
     assert ckpt["encoding_version"] == 1
     assert ckpt["teacher"] == "Lookahead"
     assert ckpt["config"]["max_areas"] == 6
@@ -64,7 +65,7 @@ def test_train_overfits_tiny_corpus(tmp_path):
     # recorded honestly as such (selection_metric="train_acc", val_accuracy=None).
     # Random-guess baseline on ~3.9 edges/step is ≈0.26; clearing 0.7 shows the
     # policy head actually learns.
-    ckpt = torch.load(ckpt_path, weights_only=False)
+    ckpt = torch.load(ckpt_path, weights_only=True)
     assert ckpt["selection_metric"] == "train_acc"
     assert ckpt["val_accuracy"] is None
     assert ckpt["selection_accuracy"] >= 0.7


### PR DESCRIPTION
Follow-up hardening from the PR #48 review, plus the first **Python CI gate** for `ml/`.

## Code hardening (validated across the supported torch range — 2.3.1 *and* 2.12.1)
- **`export_onnx`** — load checkpoints with `weights_only=True` (no arbitrary pickle execution). Pin the **legacy TorchScript ONNX exporter** via `dynamo=False`, *feature-detected* so the `torch>=2.1` floor still holds. torch ≥ 2.9 defaults `torch.onnx.export` to the dynamo exporter, which needs `onnxscript` and a different dynamic-shape API — that silently broke export under modern torch (caught here because CI now installs current torch).
- **`dataset`** — validate `edge_index` ids are in `[0, max_areas)` at load; an out-of-range id would otherwise silently gather a neighbouring step's node block (the model indexes `edge_batch * max_areas + id`). Generic `Batch.to()` over dataclass fields so a newly-added field can't be left on the wrong device.
- **`model`** — `ModelConfig.to_dict()` via `dataclasses.asdict`.
- `zip(..., strict=True)` on the fixed 7-input ONNX contract.

## Lint
- Fixed the pre-existing ruff violations (`E501`/`UP037`/`B905`/`I001`) — the package was only ever `ruff format`-clean, never `ruff check`-clean under its own `select`, because there was no gate. Pinned **`ruff==0.15.18`** in the `dev` extra so the gate is reproducible (an unpinned ruff would break CI on any future rule change).

## CI
- New **`.github/workflows/ml-ci.yml`** — on `ml/**` changes, installs CPU torch + `.[onnx,dev]` on Python 3.11 and runs `ruff check` + `REQUIRE_ONNX=1 pytest`, so the ONNX↔PyTorch parity gate can't quietly skip.

## Tests
- +1 `edge_index` range-check test; checkpoint loads now assert `weights_only`-safe.
- Full suite green on **py3.11 / torch 2.12 / ort 1.27 (33 passed)**, ruff-clean.

Part of ml-bot Phase 2 deferred follow-ups. Next: in-browser ONNX-RT-Web bot slice, then the GPU-box parity run.