### PR TITLE
fix(arena): register BC bot raw so it runs in the arena and live screens

### DIFF
--- a/src/arena/builtInBots.js
+++ b/src/arena/builtInBots.js
@@ -8,7 +8,6 @@
  */
 
 import { adaptLegacyBot } from './legacyBotAdapter.js';
-import { adaptModernBot } from './modernBotAdapter.js';
 import { ai_example } from '../ai/ai_example.js';
 import { ai_default } from '../ai/ai_default.js';
 import { ai_defensive } from '../ai/ai_defensive.js';
@@ -26,6 +25,12 @@ export const BUILT_IN_BOTS = [
   { id: 'ai_strategist', name: 'Strategist', fn: adaptLegacyBot(ai_strategist, 'Strategist') },
   { id: 'ai_lookahead', name: 'Lookahead', fn: adaptLegacyBot(ai_lookahead, 'Lookahead') },
   { id: 'ai_expectimax', name: 'Expectimax', fn: adaptLegacyBot(ai_expectimax, 'Expectimax') },
-  // BC — the behavioral-cloning net (modern bot), runs a synchronous pure-JS forward.
-  { id: 'ai_bc', name: 'BC', fn: adaptModernBot(ai_bc, 'BC') },
+  /*
+   * BC — the behavioral-cloning net. Already a modern `(BotState) => move` bot, so it
+   * registers RAW: every BUILT_IN_BOTS consumer (the CLI scripts, ArenaScreen,
+   * TournamentScreen) runs bots through runMatch/runBotDirect, which calls `fn(botState)`
+   * — exactly ai_bc's contract. (adaptModernBot is for the in-game `runAI` loop, which
+   * passes a GameState and does NOT use this list; wrapping here made BC throw every turn.)
+   */
+  { id: 'ai_bc', name: 'BC', fn: ai_bc },
 ];

--- a/src/arena/builtInBots.js
+++ b/src/arena/builtInBots.js
@@ -30,7 +30,8 @@ export const BUILT_IN_BOTS = [
    * registers RAW: every BUILT_IN_BOTS consumer (the CLI scripts, ArenaScreen,
    * TournamentScreen) runs bots through runMatch/runBotDirect, which calls `fn(botState)`
    * — exactly ai_bc's contract. (adaptModernBot is for the in-game `runAI` loop, which
-   * passes a GameState and does NOT use this list; wrapping here made BC throw every turn.)
+   * passes a GameState and does NOT use this list; wrapping here made BC throw every turn —
+   * its wrapper dereferences `state.turnOrder`, a field a BotState lacks.)
    */
   { id: 'ai_bc', name: 'BC', fn: ai_bc },
 ];

--- a/tests/ai/ai_bc.test.js
+++ b/tests/ai/ai_bc.test.js
@@ -12,6 +12,8 @@ import { ai_bc } from '../../src/ai/ai_bc.js';
 import { BC_POLICY } from '../../src/ai/bcPolicyWeights.js';
 import { createBotState } from '../../src/arena/botState.js';
 import { encodeObservationForInference } from '../../src/arena/encodeObservation.js';
+import { BUILT_IN_BOTS } from '../../src/arena/builtInBots.js';
+import { runMatch } from '../../src/arena/matchRunner.js';
 
 const moveKey = m => `${m.from}->${m.to}`;
 
@@ -126,5 +128,31 @@ describe('ai_bc bot', () => {
      * A full-game forward-pass drive runs ~10x slower under CI coverage (v8)
      * instrumentation, exceeding vitest's 5s default — hence the explicit timeout.
      */
+  }, 30_000);
+});
+
+describe('BC built-in arena registration', () => {
+  it('actually plays in the arena (called with a BotState, not a GameState)', () => {
+    /*
+     * Regression: BC was registered as `adaptModernBot(ai_bc)`, whose wrapper expects a
+     * GameState — but every BUILT_IN_BOTS consumer (CLI scripts, ArenaScreen,
+     * TournamentScreen) runs bots via runMatch → runBotDirect, which calls `fn(botState)`.
+     * So BC threw on every turn (0 attacks, all errors) and never ran its policy. It must
+     * register raw, taking a BotState directly.
+     */
+    const bcEntry = BUILT_IN_BOTS.find(b => b.name === 'BC');
+    expect(bcEntry).toBeDefined();
+
+    const field = BUILT_IN_BOTS.map(b => ({ name: b.name, fn: b.fn }));
+    let bcErrors = 0;
+    let bcAttacks = 0;
+    for (let seed = 1; seed <= 6; seed++) {
+      const res = runMatch({ bots: field, seed });
+      const bc = res.botStats.find(s => s.name === 'BC');
+      bcErrors += bc.errors;
+      bcAttacks += bc.attacksMade;
+    }
+    expect(bcErrors).toBe(0); // the adapter-mismatch bug would make this == every BC turn
+    expect(bcAttacks).toBeGreaterThan(0); // BC ran its policy and attacked at least once
   }, 30_000);
 });

--- a/tests/ai/ai_bc.test.js
+++ b/tests/ai/ai_bc.test.js
@@ -143,6 +143,14 @@ describe('BC built-in arena registration', () => {
     const bcEntry = BUILT_IN_BOTS.find(b => b.name === 'BC');
     expect(bcEntry).toBeDefined();
 
+    /*
+     * Sum across seeds on purpose — do NOT tighten this to a per-seed assertion. Three
+     * opponents in the field (ai_default, ai_adaptive, ai_example) pick moves with unseeded
+     * Math.random, so the engine seed fixes only the map/dice, not the board trajectory:
+     * on any single seed BC can legitimately make 0 attacks (it over-predicts STOP). The
+     * cross-seed sum is what keeps `bcAttacks > 0` non-flaky. (`bcErrors === 0` is
+     * seed-independent — errors come only from the adapter mismatch, never legitimate play.)
+     */
     const field = BUILT_IN_BOTS.map(b => ({ name: b.name, fn: b.fn }));
     let bcErrors = 0;
     let bcAttacks = 0;


### PR DESCRIPTION
## Summary

BC (the behavioral-cloning bot) was registered in `BUILT_IN_BOTS` as
`adaptModernBot(ai_bc)`. But `adaptModernBot` produces a `(GameState) => move`
wrapper for the **in-game `runAI` loop** (GameController/AIAdapter). Every
`BUILT_IN_BOTS` *consumer* — the CLI arena/tournament scripts, **ArenaScreen**,
and **TournamentScreen** — instead runs bots via `runMatch → runBotDirect`,
which calls `fn(botState)` with a **BotState**. That's already exactly `ai_bc`'s
own contract, so the extra wrapper made BC throw on **every turn** (0 attacks,
all errors) and never run its policy.

This is why the merged "BC 0.0% win parity" row was measuring a do-nothing bot
rather than the clone.

## Fix

- Register BC **raw** (`fn: ai_bc`) and drop the now-unused `adaptModernBot`
  import. This fixes BC everywhere the built-in list is consumed, including the
  **live Arena and Tournament screens**, not just the ml-bot benchmark.

## Test

- New regression test (`tests/ai/ai_bc.test.js`) drives BC through its
  *registered arena fn* across 6 seeds and asserts **0 errors** and **>0
  attacks** — i.e. the policy actually runs. The adapter-mismatch bug would make
  `bcErrors` equal every BC turn.

`npx vitest run tests/ai/ai_bc.test.js` → 6/6 pass; eslint + prettier clean.

## Scope

Intentionally small and independent of the ongoing ml-bot STOP-de-bias work
(the `makeBC({stopBias})` factory, sweep script, and docs land separately). This
PR is purely the correctness fix for the broken registration.