### PR TITLE
feat(ml): zero-retrain BC STOP-bias inference sweep + green-light diagnostic

### DIFF
--- a/docs/ml-bot/LOG.md
+++ b/docs/ml-bot/LOG.md
@@ -21,6 +21,71 @@ Entry template:
 
 ---
 
+## 2026-06-24 — STOP-de-bias Step 0: fixed an invalid parity row + ran the inference STOP-bias sweep → GREEN-LIGHT
+
+**Phase:** 2 · **Who:** Ivan + Claude
+
+**Did:**
+
+- **Found + fixed a critical latent bug from PR #50.** BC was registered in
+  `src/arena/builtInBots.js` as `adaptModernBot(ai_bc)` — but `adaptModernBot` produces a
+  `(GameState)→move` wrapper for the in-game `runAI` loop, while every `BUILT_IN_BOTS`
+  consumer (CLI scripts, **ArenaScreen, TournamentScreen**) calls bots via
+  `runMatch → runBotDirect` with a **`BotState`**. So BC **threw on every arena turn (0
+  attacks, all errors) and never ran its policy.** The merged "BC 0.0% win / rank-3 ELO 1275"
+  parity row in RESULTS measured a do-nothing seat that force-ends every turn, **not the
+  clone.** No test exercised BC through its registered arena fn, so it slipped through #50.
+  **Fix:** register BC **raw** (`fn: ai_bc`), drop the unused `adaptModernBot` import.
+- **Built the STOP-de-bias Step 0 tooling.** `makeBC({ stopBias, onDecision })` in
+  `src/ai/ai_bc.js` (subtracts a constant from the trailing STOP logit before argmax — an
+  additive logit penalty, **not** a softmax temperature, which is argmax-invariant);
+  `ai_bc = makeBC()` so there's one code path. New `scripts/bc-stopbias-sweep.mjs` +
+  `npm run arena:bc-stopbias`. Tests: an arena-registration regression (BC plays via its
+  built-in fn, 0 errors / >0 attacks — pins the bug fixed above) + `makeBC` hook tests. All
+  235 arena + 15 BC tests green; lint clean.
+- **Ran the full sweep** (6 biases × 20 runs × 150 games = 18,000 games, ~22 min single-core).
+  Numbers in RESULTS ("BC STOP-bias inference sweep" section); also flagged the now-invalid
+  parity row there with a correction banner.
+
+**Learned / decided:**
+
+- **GREEN-LIGHT the de-bias retrain — calibration hypothesis confirmed with tight CIs.**
+  Win% is a clean inverted-U **peaking exactly where STOP% hits the teacher's rate**:
+  `stopBias 1` → STOP 46.7% (teacher ~45%) → **win 5.9 ± 0.8**, statistically clear of the
+  3.6 ± 0.6 control (no CI overlap). Past the peak it goes suicidal as predicted (STOP keeps
+  dropping, attack-win% collapses 85→78, placement/ELO degrade). **Retrain target: STOP ~45%.**
+- **ELO is a trap for this bot — judge on win%.** ELO _decreases_ monotonically with bias
+  (1260→1105) even as win% _peaks_ at bias 1, because ELO rewards survival/placement and the
+  passive clone turtles to middling placement without winning. This is precisely the illusion
+  that made the broken-registration "rank-3 ELO 1275" row look like a near-miss.
+- **Inference biasing alone does NOT reach parity** (best BC 5.9% vs Lookahead 21.2%, ~¼).
+  The retrain is still worth it (cheap, loss-only, bakes calibration in honestly, right PPO
+  warm-start) but the residual ~15-pt gap is the encoding/architecture ceiling (GNN/PPO),
+  not STOP calibration.
+- **First valid arena read of the real policy:** `stopBias 0` (the true control) is **3.6%
+  win / STOP 70.8%**, not 0% — the clone does win occasionally; it just turtles. STOP 70.8%
+  matches the ~68% Python validation number, cross-confirming the encoder/forward path.
+
+**Dead ends / surprises:**
+
+- The 4×40 smoke read oversold bias-1 (~10%); the real 20×150 number is 5.9%. STOP rates
+  matched closely (calibration is stable) — win lift was small-sample noise. Lesson reinforced:
+  tight CIs before trusting a win% delta.
+- The teacher's own win% _rises_ with BC's bias (17.9→23.2) — a suicidal BC feeds territory to
+  the survivors (Lookahead chief among them), a seat-interaction effect, not BC strength.
+
+**Next:**
+
+- The bugfix likely deserves its own small PR — it fixes BC in the live Arena/Tournament
+  **screens** too, independent of the ml-bot retrain work.
+- **The retrain itself (on `shodan`):** weighted/focal segmented CE in `ml/dicewars_bc/losses.py`
+  (teacher-STOP = `label == counts-1`), reuse the fixed 100k corpus, re-export unchanged ([D-16]).
+  **`train.py` MUST switch checkpoint selection off val move-match** (rewards the STOP bias) onto
+  STOP-rate calibration (~45%) or an arena-win probe. Then re-run `arena:bc-stopbias` at bias 0 to
+  confirm the retrained clone sits near the teacher STOP rate without the inference hack.
+
+---
+
 ## 2026-06-23 — Phase-2 parity run: 100k corpus + MLP clone → passive (STOP-biased), no win parity
 
 **Phase:** 2 · **Who:** Ivan + Claude

--- a/docs/ml-bot/RESULTS.md
+++ b/docs/ml-bot/RESULTS.md
@@ -370,6 +370,18 @@ density.
 
 ## Phase 2 — imitation parity run (100k corpus, MLP clone) · 2026-06-23
 
+> **⚠️ THE `BC` ROW IN THIS SECTION IS INVALID — it measured a broken registration,
+> not the clone (discovered 2026-06-24).** BC was registered in `builtInBots.js` as
+> `adaptModernBot(ai_bc)`, whose wrapper expects a `GameState`, but every
+> `BUILT_IN_BOTS` consumer (CLI scripts, ArenaScreen, TournamentScreen) calls bots via
+> `runMatch → runBotDirect` with a **`BotState`**. So BC **threw on every turn (0 attacks,
+> all errors) and never ran its policy** — a do-nothing bot that force-ends every turn.
+> Its "0.0% win / rank-3 ELO 1275" is the signature of a passive seat surviving to
+> middling placement, _not_ the trained net. The "STOP ~68%" figure was a separate
+> Python-validation number, not the arena. **For the real BC arena numbers, see the
+> STOP-bias sweep section below (`stopBias 0` is the corrected control: 3.6% win).**
+> The corpus / training / val-move-match numbers in this section are unaffected and stand.
+
 **Corpus.** Full 7-bot arena field, `Lookahead` teacher, seeds 1–100,000 (generated on
 `shodan`, foreground-sharded 4×25k). **100,000 games · 8,591,769 teacher steps · 59.4M
 edges · 8.2 GB packed.** 100% clean (no forced-end quarantine).
@@ -398,3 +410,65 @@ plays passively → survives for middling placement (ELO) but can't conquer a bo
 "STOP instead of attack," which is competitively fatal. Per [D-Encoding] the simple MLP
 plateaus; the objective/encoding (not RL) is the gap. **Next levers:** STOP-class de-bias
 (class-weighted / focal CE) on the same corpus → if it plateaus, a 1–2 layer GNN.
+
+---
+
+## Phase 2 — BC STOP-bias inference sweep (zero-retrain diagnostic) · 2026-06-24
+
+**What & why.** Before paying for a class-weighted/focal-CE retrain on the GPU box, a
+free oracle over the already-exported weights: sweep an **inference-time STOP-logit bias**
+(`makeBC({stopBias})`, subtract a constant from the trailing STOP logit before argmax) and
+watch BC's win% and realized STOP rate. If a bias lifts win% off the control while pushing
+STOP from ~71% toward the teacher's ~45% → the failure is STOP-threshold miscalibration
+(green-light the retrain, target that STOP rate). If win% stays flat while attacks climb
+and attack-win% collapses → passivity just becomes suicide (skip the retrain, escalate).
+**This run also produced the first VALID arena measurement of the trained policy** (the
+parity section above measured a broken registration — see its banner).
+
+**`npm run arena:bc-stopbias` — 6 biases × 20 runs × 150 games (18,000 games, seat-fair,
+same 7-bot field as the parity run, Lookahead as yardstick; 95% Student-t CIs):**
+
+| stopBias | BC win% (95% CI) | BC STOP% | BC ELO | BC place | BC atk/g | BC atk-win% | Lookahead win% (CI) |
+| -------: | ---------------- | -------: | -----: | -------: | -------: | ----------: | ------------------- |
+|        0 | 3.6 ± 0.6        |     70.8 |   1260 |     3.87 |     15.6 |        88.0 | 17.9 ± 1.3          |
+|      0.5 | 4.9 ± 0.8        |     59.3 |   1225 |     4.21 |     21.6 |        86.3 | 18.7 ± 1.3          |
+| **1** ◀ | **5.9 ± 0.8**    | **46.7** |   1184 |     4.68 |     27.4 |        84.8 | 21.2 ± 1.5          |
+|        2 | 5.4 ± 0.9        |     34.5 |   1144 |     5.14 |     30.7 |        83.2 | 22.8 ± 1.6          |
+|        3 | 5.0 ± 1.0        |     28.8 |   1125 |     5.24 |     31.8 |        80.5 | 23.1 ± 1.7          |
+|        4 | 4.2 ± 0.6        |     28.0 |   1105 |     5.46 |     30.5 |        77.9 | 23.2 ± 1.5          |
+
+**Verdict — GREEN-LIGHT the de-bias retrain (with a sharp caveat).**
+
+- **The calibration hypothesis is confirmed with tight, non-overlapping CIs.** Win% is a
+  clean inverted-U that **peaks exactly where STOP% hits the teacher's rate**: `stopBias 1`
+  → STOP 46.7% (teacher ~45%) → win 5.9 ± 0.8, statistically clear of the 3.6 ± 0.6 control
+  ([5.1, 6.7] vs [3.0, 4.2], no overlap). Past the peak it goes suicidal as predicted —
+  STOP keeps falling, attack-win% collapses 85→78, placement/ELO degrade monotonically.
+  **Retrain target STOP rate: ~45–47%.**
+- **ELO is the trap, not the gate.** ELO _decreases_ monotonically with bias (1260→1105)
+  even as win% _peaks_ at bias 1 — because ELO rewards survival/placement, and the passive
+  bias-0 clone turtles to middling placement (3.87) without ever winning. **This is exactly
+  the illusion the invalid parity row fell for** ("rank-3 ELO 1275"). Judge BC on **win%**.
+- **Inference biasing alone does NOT reach parity.** Best BC 5.9% vs Lookahead 21.2% at the
+  same bias (~¼ of the teacher). So the retrain is worth doing (cheap, loss-only, bakes the
+  calibration into the weights honestly, right PPO warm-start) but will **not** close the
+  full parity gap — the residual ~15 pts is the encoding/architecture ceiling ([D-Encoding]):
+  the GNN/PPO escalation, not this retrain. (The teacher's own win% _rises_ with BC's bias,
+  17.9→23.2, because a suicidal BC feeds territory to the survivors, Lookahead chief among
+  them — a seat-interaction effect, not BC strength.)
+- **Note vs. the early smoke read.** A tiny 4×40 pre-run had bias-1 at ~10% win; the real
+  number is **5.9%**. STOP rates matched closely (calibration is stable) — the win lift was
+  a small-sample fluctuation. The true lift is ~+2.3 pts absolute (~64% relative), real but
+  modest.
+
+**Retrain plumbing reminders** (for when it runs on `shodan`): the de-bias is loss-only in
+`ml/dicewars_bc/losses.py` (weighted/focal segmented CE; teacher-STOP = `label == counts-1`),
+reuse the fixed 100k corpus, re-export unchanged ([D-16]). **`train.py` MUST stop selecting
+checkpoints on val move-match** (the misleading proxy that rewards the STOP bias) — select on
+STOP-rate calibration (target ~45%) or an arena-win probe, or the retrain re-introduces the bias.
+
+**Repro.** `npm run arena:bc-stopbias` (defaults: `--runs 20 --games 150 --bias 0,0.5,1,2,3,4`);
+`--seedbase 100` for a disjoint replication. Run `r` for bias `b` uses base seed
+`(seedbase + r) · STRIDE + 1` (STRIDE = max(1e6, games·1000)), independent of `b`, so every
+bias sees identical maps (paired across the column). STOP% is the realized rate aggregated
+over every BC decision in the config via the `onDecision` hook.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "prepare": "husky install",
     "arena": "node scripts/arena.mjs",
     "arena:sweep": "node scripts/arena-sweep.mjs",
+    "arena:bc-stopbias": "node scripts/bc-stopbias-sweep.mjs",
     "new-bot": "node scripts/new-bot.mjs",
     "validate-bot": "node scripts/validate-bot.mjs",
     "benchmark-bot": "node scripts/benchmark-bot.mjs",

--- a/scripts/bc-stopbias-sweep.mjs
+++ b/scripts/bc-stopbias-sweep.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+
+/**
+ * BC STOP-bias sweep (ml-bot Phase 2 — STOP-de-bias diagnostic, Step 0).
+ *
+ * The trained BC clone over-predicts STOP (~68% of decisions vs ~45% for the teacher)
+ * and so turtles to a 0% win rate (docs/ml-bot/RESULTS.md). Before paying for a
+ * class-weighted/focal-CE retrain on the GPU box, this script answers — for free, with
+ * NO retraining, over the already-exported weights — whether that failure is just a
+ * miscalibrated STOP threshold.
+ *
+ * It sweeps an inference-time STOP-logit bias (`makeBC({stopBias})`, src/ai/ai_bc.js):
+ * for each bias it runs the SAME field as the parity run (the 7 heuristic built-ins +
+ * one BC variant) over identical seed blocks, and reports BC's win% (with 95% CI) and
+ * its realized STOP rate, with Lookahead's win% as a stable yardstick. `stopBias = 0`
+ * reproduces the 0%-win control.
+ *
+ * How to read it:
+ *   - If some bias lifts BC's win% materially off 0 AND pushes its STOP rate from ~68%
+ *     toward the teacher's ~45% → the failure is STOP-threshold miscalibration; GREEN-LIGHT
+ *     the retrain and target that STOP rate.
+ *   - If no bias moves win% off ~0 (attacks/game climbs but attack-win-rate collapses, i.e.
+ *     passivity just becomes suicide) → per-step debias won't help; skip the retrain and
+ *     escalate (GNN / PPO warm-start).
+ *
+ * Usage:
+ *   npm run arena:bc-stopbias                                  # 20 runs x 150 games, bias 0,0.5,1,2,3,4
+ *   npm run arena:bc-stopbias -- --runs 12 --games 150         # fewer runs (quicker)
+ *   npm run arena:bc-stopbias -- --bias 0,1,2,4,6              # custom bias grid
+ *   npm run arena:bc-stopbias -- --seedbase 100               # a disjoint seed replication
+ */
+
+import { runArena } from '../src/arena/arenaRunner.js';
+import { BUILT_IN_BOTS } from '../src/arena/builtInBots.js';
+import { makeBC } from '../src/ai/ai_bc.js';
+import { getArg } from './lib/cli-utils.mjs';
+
+// --- Parse CLI args ---
+
+const args = process.argv.slice(2);
+
+const runCount = parseInt(getArg(args, 'runs', '20'), 10);
+if (!Number.isFinite(runCount) || runCount < 2) {
+  console.error('Invalid --runs value. Must be an integer >= 2 (need >= 2 runs for a CI).');
+  process.exit(1);
+}
+
+const gamesPerRun = parseInt(getArg(args, 'games', '150'), 10);
+if (!Number.isFinite(gamesPerRun) || gamesPerRun < 1) {
+  console.error('Invalid --games value. Must be a positive integer.');
+  process.exit(1);
+}
+
+const seedBase = parseInt(getArg(args, 'seedbase', '0'), 10);
+if (!Number.isFinite(seedBase) || seedBase < 0) {
+  console.error('Invalid --seedbase value. Must be a non-negative integer.');
+  process.exit(1);
+}
+
+const biases = getArg(args, 'bias', '0,0.5,1,2,3,4')
+  .split(',')
+  .map(s => Number(s.trim()));
+if (biases.length === 0 || biases.some(b => !Number.isFinite(b))) {
+  console.error('Invalid --bias value. Comma-separated finite numbers, e.g. --bias 0,0.5,1,2,3,4');
+  process.exit(1);
+}
+
+/*
+ * The reference field is the parity-run field with the built-in BC removed; each bias
+ * config re-adds its own BC variant. Every config sees identical seed blocks (baseSeed
+ * is independent of bias), so the comparison across biases is paired on the same maps.
+ */
+const baseField = BUILT_IN_BOTS.filter(b => b.name !== 'BC').map(b => ({ name: b.name, fn: b.fn }));
+const YARDSTICK = 'Lookahead';
+if (!baseField.some(b => b.name === YARDSTICK)) {
+  console.error(`Reference bot "${YARDSTICK}" is not in BUILT_IN_BOTS — cannot anchor the sweep.`);
+  process.exit(1);
+}
+
+const STRIDE = Math.max(1_000_000, gamesPerRun * 1000);
+
+// --- Statistics helpers (95% Student-t CI; mirrors scripts/arena-sweep.mjs) ---
+
+// 95% two-sided Student's t critical values by degrees of freedom (df = runs - 1).
+const T95 = {
+  1: 12.706,
+  2: 4.303,
+  3: 3.182,
+  4: 2.776,
+  5: 2.571,
+  6: 2.447,
+  7: 2.365,
+  8: 2.306,
+  9: 2.262,
+  10: 2.228,
+  11: 2.201,
+  12: 2.179,
+  13: 2.16,
+  14: 2.145,
+  15: 2.131,
+  16: 2.12,
+  17: 2.11,
+  18: 2.101,
+  19: 2.093,
+  20: 2.086,
+  21: 2.08,
+  22: 2.074,
+  23: 2.069,
+  24: 2.064,
+  25: 2.06,
+  26: 2.056,
+  27: 2.052,
+  28: 2.048,
+  29: 2.045,
+  30: 2.042,
+};
+// For df > 30 the t distribution is close enough to normal to use 1.96.
+const tCrit = df => T95[df] ?? 1.96;
+
+/** Mean and 95% confidence half-width for a sample array. */
+function meanCi(values) {
+  const n = values.length;
+  const mean = values.reduce((a, b) => a + b, 0) / n;
+  const variance = values.reduce((a, b) => a + (b - mean) ** 2, 0) / (n - 1);
+  const stdErr = Math.sqrt(variance) / Math.sqrt(n);
+  return { mean, ci: tCrit(n - 1) * stdErr };
+}
+
+const mean = values => values.reduce((a, b) => a + b, 0) / values.length;
+
+// --- Run the sweep ---
+
+console.log(
+  `BC STOP-bias sweep: ${biases.length} bias values x ${runCount} runs x ${gamesPerRun} games ` +
+    `(${biases.length * runCount * gamesPerRun} games total)`
+);
+console.log(`Field (${baseField.length + 1}): ${baseField.map(b => b.name).join(', ')}, BC<bias>`);
+console.log(
+  `Yardstick: ${YARDSTICK}.  STOP-rate target ≈ 45% (teacher); the clone sits at ~68%.\n`
+);
+
+const startTime = Date.now();
+const rows = [];
+
+for (const bias of biases) {
+  /*
+   * One BC variant per bias, reused across runs so its STOP counter aggregates the
+   * realized STOP rate over every BC decision in the whole config. The arena calls bots
+   * with a BotState (runBotDirect), so the raw makeBC fn is used directly — no adapter.
+   */
+  const counter = { stops: 0, decisions: 0 };
+  const bcFn = makeBC({
+    stopBias: bias,
+    onDecision: stopped => {
+      counter.decisions++;
+      if (stopped) counter.stops++;
+    },
+  });
+  const field = [...baseField, { name: 'BC', fn: bcFn }];
+
+  const bcWin = [];
+  const lookWin = [];
+  const bcElo = [];
+  const bcPlace = [];
+  const bcAtk = [];
+  const bcAtkWin = [];
+
+  for (let run = 0; run < runCount; run++) {
+    let result;
+    try {
+      result = runArena({
+        bots: field,
+        gameCount: gamesPerRun,
+        baseSeed: (seedBase + run) * STRIDE + 1,
+      });
+    } catch (err) {
+      console.error(`\nSweep failed (bias ${bias}, run ${run + 1}): ${err.message}`);
+      process.exit(1);
+    }
+
+    const bc = result.bots.find(b => b.name === 'BC');
+    const look = result.bots.find(b => b.name === YARDSTICK);
+    bcWin.push(bc.gamesPlayed > 0 ? (bc.wins / bc.gamesPlayed) * 100 : 0);
+    lookWin.push(look.gamesPlayed > 0 ? (look.wins / look.gamesPlayed) * 100 : 0);
+    bcElo.push(bc.elo);
+    bcPlace.push(bc.avgPlacement);
+    bcAtk.push(bc.avgAttacks);
+    bcAtkWin.push(bc.attackWinRate);
+
+    process.stdout.write(`\r[bias ${bias}] run ${run + 1}/${runCount}        `);
+  }
+
+  const w = meanCi(bcWin);
+  const lw = meanCi(lookWin);
+  rows.push({
+    bias,
+    bcWin: `${w.mean.toFixed(1)} ± ${w.ci.toFixed(1)}`,
+    stopPct: counter.decisions > 0 ? ((counter.stops / counter.decisions) * 100).toFixed(1) : '—',
+    bcElo: String(Math.round(mean(bcElo))),
+    bcPlace: mean(bcPlace).toFixed(2),
+    bcAtk: mean(bcAtk).toFixed(1),
+    bcAtkWin: (mean(bcAtkWin) * 100).toFixed(1),
+    lookWin: `${lw.mean.toFixed(1)} ± ${lw.ci.toFixed(1)}`,
+  });
+}
+
+const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+console.log(`\n\nCompleted in ${elapsed}s\n`);
+
+// --- Print results table ---
+
+const header = [
+  'stopBias',
+  'BC win% (CI)',
+  'BC STOP%',
+  'BC ELO',
+  'BC place',
+  'BC atk/g',
+  'BC atk-win%',
+  `${YARDSTICK} win% (CI)`,
+];
+const table = [
+  header,
+  ...rows.map(r => [
+    String(r.bias),
+    r.bcWin,
+    r.stopPct,
+    r.bcElo,
+    r.bcPlace,
+    r.bcAtk,
+    r.bcAtkWin,
+    r.lookWin,
+  ]),
+];
+const widths = header.map((_, col) => Math.max(...table.map(row => row[col].length)));
+const formatRow = row => row.map((cell, i) => cell.padEnd(widths[i])).join('  ');
+
+console.log(formatRow(header));
+console.log(widths.map(w => '-'.repeat(w)).join('  '));
+table.slice(1).forEach(row => console.log(formatRow(row)));
+
+console.log(
+  `\nRead: a bias that lifts BC win% off ~0 while its STOP% falls toward ~45% ⇒ STOP-threshold\n` +
+    `miscalibration (green-light the retrain, target that STOP%). If win% stays ~0 while atk/g\n` +
+    `climbs and atk-win% drops ⇒ aggression just turns suicidal — escalate instead of retraining.`
+);

--- a/scripts/bc-stopbias-sweep.mjs
+++ b/scripts/bc-stopbias-sweep.mjs
@@ -3,8 +3,9 @@
 /**
  * BC STOP-bias sweep (ml-bot Phase 2 — STOP-de-bias diagnostic, Step 0).
  *
- * The trained BC clone over-predicts STOP (~68% of decisions vs ~45% for the teacher)
- * and so turtles to a 0% win rate (docs/ml-bot/RESULTS.md). Before paying for a
+ * The trained BC clone over-predicts STOP (~68% of decisions in Python-val, ~71% realized
+ * in-arena, vs ~45% for the teacher) and so plays too passively to win — the corrected
+ * `stopBias = 0` control wins only ~3.6% (docs/ml-bot/RESULTS.md). Before paying for a
  * class-weighted/focal-CE retrain on the GPU box, this script answers — for free, with
  * NO retraining, over the already-exported weights — whether that failure is just a
  * miscalibrated STOP threshold.
@@ -13,10 +14,10 @@
  * for each bias it runs the SAME field as the parity run (the 7 heuristic built-ins +
  * one BC variant) over identical seed blocks, and reports BC's win% (with 95% CI) and
  * its realized STOP rate, with Lookahead's win% as a stable yardstick. `stopBias = 0`
- * reproduces the 0%-win control.
+ * reproduces the corrected control (~3.6% win).
  *
  * How to read it:
- *   - If some bias lifts BC's win% materially off 0 AND pushes its STOP rate from ~68%
+ *   - If some bias lifts BC's win% materially off 0 AND pushes its STOP rate from ~71%
  *     toward the teacher's ~45% → the failure is STOP-threshold miscalibration; GREEN-LIGHT
  *     the retrain and target that STOP rate.
  *   - If no bias moves win% off ~0 (attacks/game climbs but attack-win-rate collapses, i.e.
@@ -136,7 +137,7 @@ console.log(
 );
 console.log(`Field (${baseField.length + 1}): ${baseField.map(b => b.name).join(', ')}, BC<bias>`);
 console.log(
-  `Yardstick: ${YARDSTICK}.  STOP-rate target ≈ 45% (teacher); the clone sits at ~68%.\n`
+  `Yardstick: ${YARDSTICK}.  STOP-rate target ≈ 45% (teacher); the untuned clone sits at ~71%.\n`
 );
 
 const startTime = Date.now();
@@ -174,14 +175,41 @@ for (const bias of biases) {
         baseSeed: (seedBase + run) * STRIDE + 1,
       });
     } catch (err) {
-      console.error(`\nSweep failed (bias ${bias}, run ${run + 1}): ${err.message}`);
+      console.error(`\nSweep failed (bias ${bias}, run ${run + 1}):`);
+      console.error(err); // full stack + cause, not just .message
+      if (rows.length) {
+        console.error('\nCompleted rows before the failure:');
+        console.table(rows);
+      }
+      process.exit(1);
+    }
+
+    /*
+     * Refuse to fold a degraded run into the averaged diagnostic. runArena does NOT throw
+     * on the abort path — it returns normally with aborted:true (plus any per-match failures
+     * in failedGames), so the try/catch above never sees it. A diagnostic whose entire signal
+     * lives in the 0–6% win band must not silently average a 0% that means "the arena fell
+     * over" together with a 0% that means "the clone turtled" — fail loud instead.
+     */
+    if (result.aborted || result.failedGames > 0) {
+      console.error(
+        `\nSweep run degraded (bias ${bias}, run ${run + 1}): ${result.failedGames} game(s) ` +
+          `failed, aborted=${result.aborted}. Refusing to average a partial run into the diagnostic.`
+      );
       process.exit(1);
     }
 
     const bc = result.bots.find(b => b.name === 'BC');
     const look = result.bots.find(b => b.name === YARDSTICK);
-    bcWin.push(bc.gamesPlayed > 0 ? (bc.wins / bc.gamesPlayed) * 100 : 0);
-    lookWin.push(look.gamesPlayed > 0 ? (look.wins / look.gamesPlayed) * 100 : 0);
+    if (bc.gamesPlayed !== gamesPerRun || look.gamesPlayed !== gamesPerRun) {
+      console.error(
+        `\nUnexpected gamesPlayed (bias ${bias}, run ${run + 1}): BC=${bc.gamesPlayed}, ` +
+          `${YARDSTICK}=${look.gamesPlayed}, expected ${gamesPerRun}.`
+      );
+      process.exit(1);
+    }
+    bcWin.push((bc.wins / bc.gamesPlayed) * 100);
+    lookWin.push((look.wins / look.gamesPlayed) * 100);
     bcElo.push(bc.elo);
     bcPlace.push(bc.avgPlacement);
     bcAtk.push(bc.avgAttacks);

--- a/src/ai/ai_bc.js
+++ b/src/ai/ai_bc.js
@@ -37,18 +37,59 @@ if (BC_POLICY.encodingVersion !== ENCODING_VERSION) {
 const CTX = { maxAreas: BC_POLICY.config.maxAreas };
 
 /**
- * The BC bot move function.
+ * Build a BC bot, optionally with an inference-time STOP-logit bias.
+ *
+ * `stopBias` is subtracted from the trailing STOP edge's logit *before* the argmax,
+ * so a positive value makes the bot less willing to end its turn (more aggressive);
+ * `stopBias = 0` is the plain clone. This is a **no-retrain** calibration knob for the
+ * ml-bot Phase-2 STOP-bias diagnostic: the trained clone over-predicts STOP (~68% of
+ * decisions vs ~45% for the teacher) and so turtles to a 0% win rate. Sweeping this
+ * knob over the *existing* exported weights tells us whether the failure is just a
+ * miscalibrated STOP threshold — and what STOP rate to target — before paying for a
+ * class-weighted/focal-CE retrain on the GPU box. See `scripts/bc-stopbias-sweep.mjs`.
+ *
+ * NB: a constant additive penalty, **not** a softmax temperature — a single global
+ * temperature is argmax-invariant and would have no effect on the deployed argmax.
+ *
+ * @param {Object} [opts]
+ * @param {number} [opts.stopBias=0] - Subtracted from the STOP logit before argmax.
+ * @param {(stopped: boolean) => void} [opts.onDecision] - Called once per decision with
+ *   whether the bot chose STOP — lets a sweep tally the realized STOP rate.
+ * @returns {(botState: import('../arena/types.js').BotState) => ({ from: number, to: number } | null)}
+ */
+export function makeBC({ stopBias = 0, onDecision } = {}) {
+  return function bc(botState) {
+    const encoded = encodeObservationForInference(botState, CTX);
+    const { logits } = forward(BC_POLICY, encoded);
+
+    /*
+     * The encoder appends exactly one trailing STOP edge (moves[last] === null), so the
+     * STOP logit is the last one. Assert that invariant before shifting it, so a future
+     * encoder change biases nothing silently rather than mis-steering a real attack edge.
+     */
+    const stopIdx = logits.length - 1;
+    if (encoded.moves[stopIdx] !== null) {
+      throw new Error(
+        'makeBC: trailing edge is not STOP (moves[last] !== null) — encoder layout changed.'
+      );
+    }
+    logits[stopIdx] -= stopBias;
+
+    /*
+     * moves[i] is {from,to} for an attack, null for the STOP edge — so argmax → STOP
+     * naturally returns null (end turn). No masking needed: every edge is legal.
+     */
+    const choice = argmax(logits);
+    if (onDecision) onDecision(choice === stopIdx);
+    return encoded.moves[choice];
+  };
+}
+
+/**
+ * The BC bot move function — the plain clone (`makeBC()`, i.e. `stopBias = 0`).
  * @param {import('../arena/types.js').BotState} botState
  * @returns {{ from: number, to: number } | null} An attack, or null to end the turn.
  */
-export function ai_bc(botState) {
-  const encoded = encodeObservationForInference(botState, CTX);
-  const { logits } = forward(BC_POLICY, encoded);
-  /*
-   * moves[i] is {from,to} for an attack, null for the STOP edge — so argmax → STOP
-   * naturally returns null (end turn). No masking needed: every edge is legal.
-   */
-  return encoded.moves[argmax(logits)];
-}
+export const ai_bc = makeBC();
 
 export default ai_bc;

--- a/src/ai/ai_bc.js
+++ b/src/ai/ai_bc.js
@@ -43,7 +43,8 @@ const CTX = { maxAreas: BC_POLICY.config.maxAreas };
  * so a positive value makes the bot less willing to end its turn (more aggressive);
  * `stopBias = 0` is the plain clone. This is a **no-retrain** calibration knob for the
  * ml-bot Phase-2 STOP-bias diagnostic: the trained clone over-predicts STOP (~68% of
- * decisions vs ~45% for the teacher) and so turtles to a 0% win rate. Sweeping this
+ * decisions vs ~45% for the teacher) and so plays too passively to win (the corrected
+ * `stopBias = 0` control wins only ~3.6% vs the teacher's ~18%). Sweeping this
  * knob over the *existing* exported weights tells us whether the failure is just a
  * miscalibrated STOP threshold — and what STOP rate to target — before paying for a
  * class-weighted/focal-CE retrain on the GPU box. See `scripts/bc-stopbias-sweep.mjs`.

--- a/tests/ai/ai_bc.test.js
+++ b/tests/ai/ai_bc.test.js
@@ -8,7 +8,7 @@
  */
 import { createGame } from '../../src/engine/GameRunner.js';
 import { applyAction, getValidMoves } from '../../src/engine/StateManager.js';
-import { ai_bc } from '../../src/ai/ai_bc.js';
+import { ai_bc, makeBC } from '../../src/ai/ai_bc.js';
 import { BC_POLICY } from '../../src/ai/bcPolicyWeights.js';
 import { createBotState } from '../../src/arena/botState.js';
 import { encodeObservationForInference } from '../../src/arena/encodeObservation.js';
@@ -163,4 +163,27 @@ describe('BC built-in arena registration', () => {
     expect(bcErrors).toBe(0); // the adapter-mismatch bug would make this == every BC turn
     expect(bcAttacks).toBeGreaterThan(0); // BC ran its policy and attacked at least once
   }, 30_000);
+});
+
+describe('makeBC stopBias hook', () => {
+  it('makeBC() is the plain clone — identical to ai_bc', () => {
+    const state = firstStateWithMoves();
+    const botState = createBotState(state, state.turnOrder[state.currentPlayerIndex]);
+    expect(makeBC()(botState)).toEqual(ai_bc(botState));
+  });
+
+  it('a large stopBias suppresses STOP (always attacks when an attack exists) and reports it', () => {
+    const state = firstStateWithMoves(); // current player has >= 1 legal attack
+    const botState = createBotState(state, state.turnOrder[state.currentPlayerIndex]);
+
+    let lastStopped = null;
+    const move = makeBC({ stopBias: 1e9, onDecision: stopped => (lastStopped = stopped) })(
+      botState
+    );
+
+    expect(move).not.toBeNull(); // never ends the turn while an attack is on the board
+    expect(lastStopped).toBe(false); // onDecision fires, reporting "did not STOP"
+    const legal = new Set(getValidMoves(state).map(moveKey));
+    expect(legal.has(moveKey(move))).toBe(true);
+  });
 });

--- a/tests/ai/ai_bc.test.js
+++ b/tests/ai/ai_bc.test.js
@@ -186,4 +186,23 @@ describe('makeBC stopBias hook', () => {
     const legal = new Set(getValidMoves(state).map(moveKey));
     expect(legal.has(moveKey(move))).toBe(true);
   });
+
+  it('a large negative stopBias forces STOP even when an attack exists (pins sign + onDecision(true))', () => {
+    const state = firstStateWithMoves(); // current player has >= 1 legal attack
+    const botState = createBotState(state, state.turnOrder[state.currentPlayerIndex]);
+
+    let lastStopped = null;
+    const move = makeBC({ stopBias: -1e9, onDecision: stopped => (lastStopped = stopped) })(
+      botState
+    );
+
+    /*
+     * stopBias is *subtracted*, so a large negative bias adds +1e9 to the STOP logit →
+     * argmax picks STOP despite a legal attack on the board. This is the converse of the
+     * suppression test above: together they pin the subtraction's sign, and this one
+     * exercises the onDecision(true) branch (the +1e9 suppression test only sees `false`).
+     */
+    expect(move).toBeNull();
+    expect(lastStopped).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

The BC clone over-predicts STOP (~68% Python val vs ~45% teacher-true), so it
turtles and never conquers a board. Before paying for a GPU retrain, this PR
tests the calibration hypothesis **cheaply at inference time**: subtract a
constant from the trailing STOP logit before argmax, and sweep that constant.

This is the second half of the BC-registration split — the bugfix landed in #52;
this PR is the diagnostic tooling + the green-light evidence.

## What's here

- **`makeBC({ stopBias, onDecision })`** factory in `ai_bc.js` — single code
  path, `ai_bc = makeBC()`. `stopBias` subtracts from the **provably-trailing**
  STOP logit (asserts `moves[last] === null` as an encoder-layout guard).
  `onDecision(stopped)` reports whether the bot STOPped, for realized-STOP-rate
  measurement. Note: this is an **additive logit/prior correction, not a softmax
  temperature** (temperature is argmax-invariant — it would do nothing here).
- **`scripts/bc-stopbias-sweep.mjs`** + **`npm run arena:bc-stopbias`** — paired
  sweep over bias values on identical seed blocks (baseSeed independent of bias),
  reporting BC win% (95% Student-t CI), realized STOP%, ELO, placement,
  attack-win%, and Lookahead win%.
- **`makeBC` hook tests** — `makeBC() === ai_bc`; a large *positive* `stopBias`
  suppresses STOP (always attacks when an attack exists) and a large *negative*
  `stopBias` forces STOP — together pinning the subtraction's sign and both
  `onDecision` branches.
- **`RESULTS.md` + `LOG.md`** — the 18k-game sweep (6 bias × 20 × 150) and its
  verdict.

## Result — GREEN-LIGHT the de-bias retrain (target STOP ~45–47%)

Win% is a clean inverted-U peaking **exactly where STOP% hits the teacher's rate**:

| stopBias | BC win% (95% CI) | realized STOP% |
|---------:|:-----------------|---------------:|
| 0 (control) | 3.6 ± 0.6% | 70.8% |
| **1** | **5.9 ± 0.8%** (peak, CI clear of control) | **46.7%** |
| 2–4 | 5.4 → 4.2% (declining) | drops further; attack-win% collapses 85→78 (suicidal) |

Three load-bearing reads:
1. **ELO is a trap here** — it falls *monotonically* with bias (1260→1105) even
   as win% peaks at bias 1, because ELO rewards survival/placement, not wins.
   Judge BC on **win%**. (This is the same illusion behind the old "rank-3 ELO
   1275" row.)
2. **Inference biasing alone does not reach parity** — best BC 5.9% vs
   Lookahead 21.2% (~¼). The retrain is still worth it (cheap, loss-only, honest,
   right PPO warm-start), but the residual ~15-pt gap is the **encoding/arch
   ceiling** (GNN/PPO), not STOP calibration.
3. The earlier 4×40 smoke **oversold** bias-1 (~10% vs the real 5.9%) — STOP
   rates were stable, the win lift was small-sample noise.

## Review follow-ups (post-review commits)

A multi-agent PR review (code quality, engine contract, test coverage, silent
failures, comment accuracy) found the deployed bot **provably unchanged**
(`ai_bc = makeBC()` ⇒ `logits[stopIdx] -= 0`, a no-op) and the diagnostic sound.
Two follow-up commits address its findings:

- **`45df0bf`** — pinned the `stopBias` **sign** with a large-negative-bias →
  forced-STOP test (the prior test only exercised the positive /
  `onDecision(false)` side), and fixed a `makeBC` JSDoc line that still claimed a
  "0% win rate" — the artifact of the pre-#52 broken registration; this PR's own
  control measures ~3.6%.
- **`f41a5eb`** — hardened the sweep's error path. `runArena` returns
  `aborted: true` (and counts per-match failures in `failedGames`) rather than
  throwing, so the old `gamesPlayed > 0 ? … : 0` fallback could silently average an
  aborted/under-sampled run as a clean 0% — indistinguishable from a real
  turtle-to-0% in a diagnostic whose signal lives in the 0–6% band. Now it fails
  loud on `aborted`/`failedGames` and asserts `gamesPlayed === gamesPerRun` before
  averaging, prints the full stack + cause (not just `.message`) and dumps
  completed rows on failure, and clarifies ~68% (Python-val) vs ~71% (realized
  in-arena) STOP rate so the header/banner match the table the script prints.

## Test / validation

`npm test` → **906/906** pass (60 files). `npx vitest run tests/ai/ai_bc.test.js`
→ 9/9 (incl. the `makeBC` positive/negative-bias hook tests). eslint + prettier clean.

## Repro

```
npm run arena:bc-stopbias            # 6 bias × 20 runs × 150 games (~22 min)
npm run arena:bc-stopbias -- --runs 4 --games 40   # quick smoke
```

## Follow-up (not in this PR)

The actual retrain on the GPU box: weighted/focal segmented CE in
`ml/dicewars_bc/losses.py` (teacher-STOP = `label == counts-1`), reuse the fixed
100k corpus, re-export unchanged — **and `train.py` MUST switch checkpoint
selection off val-move-match** (the proxy that *rewards* the STOP bias) onto
STOP-rate calibration / an arena-win probe, or the retrain re-introduces the bias.
