### PR TITLE
feat(ml): Phase-3 PPO tracer step 5 — EdgePolicyNet-trunk policy + warm-start/repack (D-19)

### DIFF
--- a/docs/ml-bot/LOG.md
+++ b/docs/ml-bot/LOG.md
@@ -21,6 +21,54 @@ Entry template:
 
 ---
 
+## 2026-06-25 — Phase-3 tracer step 5: EdgePolicyNet-trunk PPO policy + warm-start/repack
+
+**Phase:** 3 · **Who:** Ivan + Claude
+
+**Did:**
+
+- Reviewed merged #58 (step 4) — the review-pass hardening is sound (bounded `recv_frame`,
+  reap-safe server teardown, `weakref.finalize` GC backstop, hermetic env/socket unit tier in CI).
+- Built the custom SB3 policy in `ml/dicewars_ppo/policy.py` (`MaskableEdgePolicy`): the v2-BC
+  `EdgePolicyNet` trunk + per-edge head as the PPO actor, a **fresh scalar critic** off `ctx`.
+  Bypasses SB3's `features_extractor→action_net` pipeline (the ragged per-edge head doesn't fit it)
+  by overriding `forward`/`evaluate_actions`/`predict_values`/`get_distribution` to gather
+  padded-`MAX_EDGES` edge logits straight from the obs `Dict` into a `MaskableCategorical`.
+- `warm_start_from_bc` / `load_bc_checkpoint` load trunk + `edge_head` from the v2-BC checkpoint
+  (assert `encoding_version == 2` + v2 feature widths); critic stays fresh.
+- **Closed the [D-19] gate-breaking repack gap up front:** `repack_to_bc_checkpoint` pulls the
+  actor back into BC checkpoint format (bare `EdgePolicyNet` `state_dict` + config), proven by a
+  round-trip parity test. So the step-7 "graded bot == trained policy" risk is already de-risked.
+- Extracted the edge-head gather into `EdgePolicyNet.edge_logits_from_context` so the BC
+  forward/ONNX export and the PPO actor share one source of truth (Ivan chose the extraction over
+  copy-with-comment). Behavior-preserving: BC `test_model` + `test_export_onnx` green, ONNX trace
+  byte-unchanged.
+- Located the warm-start source: `~/dicewarsjs/ml/checkpoints/v2-base/bc_model.pt` on shodan
+  (`enc=2`, 102,787 params, `val_stop_cal=0.7264…` — matches `bcPolicyWeights.js` byte-for-byte =
+  the deployed `ai_bc`). The other `checkpoints/{probe/*,smoke}` `.pt`s are stale encoding-v1.
+
+**Learned / decided:**
+
+- The PPO actor being a _real_ `EdgePolicyNet` instance (same submodule names) is what makes the
+  repack a near-identity — keep it that way through scaling.
+- The BC `value_head` rides along through warm-start/PPO/repack untouched (PPO never puts it in a
+  loss → grad stays `None` → weights survive), so the JS↔Py parity fixture still runs at export.
+
+**Dead ends / surprises:**
+
+- None. Validated on shodan (branch `ml-bot/phase3-ppo-policy`): ruff clean, 12 BC-parity + 8 new
+  policy tests pass, and the **real `v2-base` checkpoint** warm-starts, repacks byte-identically,
+  and drove the live env-server through a 76-decision episode picking only legal actions.
+
+**Next:**
+
+- Step 6 — tiny tracer PPO run (1–2 envs, 1 learner + fixed JS baselines, terminal-win reward,
+  warm-started, a handful of updates) with low initial LR / optional brief trunk freeze ([D-19]
+  decision 1). Fold in the `truncated`-vs-`terminated` wire flag for `maxTurns` stalemates while
+  there (deferred from step 4) so value bootstrapping is correct.
+
+---
+
 ## 2026-06-25 — Phase-3 tracer step 4: Python `[rl]` env scaffold (`dicewars_ppo`)
 
 **Phase:** 3 · **Who:** Ivan + Claude

--- a/docs/ml-bot/PLAN.md
+++ b/docs/ml-bot/PLAN.md
@@ -367,24 +367,41 @@ and de-risk the two biggest unknowns).**
       the in-process-opponent cost is not a blocker. Measures the real PPO model (terminate the
       episode at learner elimination, not game-over) via `runMatch`'s `onTurn`. Re-confirm on
       shodan before locking the budget.
-- [~] **(4)** Python `[rl]` deps (`stable-baselines3`, `sb3-contrib`, `pettingzoo`) +
-  minimal env. **`MAX_EDGES` validated 2026-06-25 ([D-20]): observed p100 ≈ 26
-  (p99 15, mean ~5, zero overflow over ~100k decisions) → use `MAX_EDGES = 64`** (margin;
-  D-19's ~64–128 was conservative, far under sb3-contrib #247's ~1400).
-  **Scaffolded 2026-06-25:** new in-repo package `ml/dicewars_ppo/` — `constants` (the v2
-  wire/encoding contract + `MAX_EDGES`), `wire` (Python port of `obs-frame.mjs` + socket
-  framing), `env_server` (launch/supervise `ppo-env-server.mjs`), and `env.DiceWarsEnv`
-  (`Discrete(MAX_EDGES)` + `action_masks()`, padded v2-tensor `Dict` obs, sparse terminal-win
-  reward). **Realized as a single-agent `gymnasium.Env`, not a PettingZoo AEC env** — the
-  env-server runs all opponent seats in-process and exposes only the learner, so a plain
-  masked Gym env is what MaskablePPO consumes (refines D-19's wording; holds for the whole
-  phase since PFSP snapshots also run in-process). `[rl]` extra added to `pyproject.toml`.
-  Cross-language wire parity is green two ways: a hermetic byte-exact golden-fixture test
-  (`tests/test_ppo_wire.py`) and a live 132-decision run against the real Node server. The
-  end-to-end Gym smoke (`tests/test_ppo_env.py`) runs on shodan once `pip install -e .[rl]`.
-- [ ] **(5)** Custom SB3 `ActorCriticPolicy` (EdgePolicyNet trunk extractor + padded-
-      `MAX_EDGES` `MaskableCategorical` + fresh scalar critic); **warm-start** trunk +
-      `edge_head` from the v2-BC checkpoint, assert `encoding_version == 2`.
+- [x] **(4)** Python `[rl]` deps (`stable-baselines3`, `sb3-contrib`, `pettingzoo`) +
+      minimal env. **`MAX_EDGES` validated 2026-06-25 ([D-20]): observed p100 ≈ 26
+      (p99 15, mean ~5, zero overflow over ~100k decisions) → use `MAX_EDGES = 64`** (margin;
+      D-19's ~64–128 was conservative, far under sb3-contrib #247's ~1400).
+      **Scaffolded 2026-06-25:** new in-repo package `ml/dicewars_ppo/` — `constants` (the v2
+      wire/encoding contract + `MAX_EDGES`), `wire` (Python port of `obs-frame.mjs` + socket
+      framing), `env_server` (launch/supervise `ppo-env-server.mjs`), and `env.DiceWarsEnv`
+      (`Discrete(MAX_EDGES)` + `action_masks()`, padded v2-tensor `Dict` obs, sparse terminal-win
+      reward). **Realized as a single-agent `gymnasium.Env`, not a PettingZoo AEC env** — the
+      env-server runs all opponent seats in-process and exposes only the learner, so a plain
+      masked Gym env is what MaskablePPO consumes (refines D-19's wording; holds for the whole
+      phase since PFSP snapshots also run in-process). `[rl]` extra added to `pyproject.toml`.
+      Cross-language wire parity is green two ways: a hermetic byte-exact golden-fixture test
+      (`tests/test_ppo_wire.py`) and a live 132-decision run against the real Node server. The
+      end-to-end Gym smoke (`tests/test_ppo_env.py`) runs on shodan once `pip install -e .[rl]`.
+      **Merged 2026-06-25 (#58, `b8b91d1`)** with a review-pass hardening: bounded `recv_frame`
+      length prefix (OOM/desync guard), reap-safe `EnvServerProcess.close()` + a `weakref.finalize`
+      GC backstop against orphaned Node children, and a hermetic env/socket unit-test tier wired
+      into `ml-ci.yml` (gymnasium installed there; the live smoke still skips, no `node` in CI).
+- [~] **(5)** Custom SB3 `MaskableActorCriticPolicy` (`ml/dicewars_ppo/policy.py`) — EdgePolicyNet
+  trunk + per-edge head as the actor, fresh scalar critic off `ctx`; overrides
+  `forward`/`evaluate_actions`/`predict_values`/`get_distribution` to gather padded-`MAX_EDGES`
+  logits straight from the obs `Dict` into a `MaskableCategorical` (the ragged per-edge head
+  doesn't fit SB3's `features_extractor→action_net` mold). **Warm-start** (`warm_start_from_bc`
+  / `load_bc_checkpoint`) loads trunk + `edge_head` from the v2-BC checkpoint, asserting
+  `encoding_version == 2` + v2 feature widths; the **gate-breaking repack gap ([D-19]) is
+  closed up front** by `repack_to_bc_checkpoint` (actor → bare-`EdgePolicyNet` `.pt`) with a
+  round-trip parity test. The edge-head gather was extracted into
+  `EdgePolicyNet.edge_logits_from_context` so the BC forward/ONNX export and the PPO actor share
+  one source of truth (behavior-preserving — BC `test_model`/`test_export_onnx` green, ONNX
+  trace unchanged). **Validated on shodan 2026-06-25** (branch `ml-bot/phase3-ppo-policy`):
+  ruff clean, 12 BC-parity + 8 new hermetic policy tests pass, and the **real deployed
+  `v2-base` checkpoint** warm-starts, repacks byte-identically, and drives the live Node
+  env-server through a full episode picking only legal actions. _Hermetic policy tests gated on
+  sb3-contrib/gymnasium (run on shodan, skip in BC CI like the live env smoke)._
 - [ ] **(6)** Tiny tracer PPO run: 1–2 envs, 1 learner + 7 fixed JS baselines (no
       snapshots/PFSP yet), terminal-win reward only, warm-started, a handful of updates.
 - [ ] **(7)** **Repack → export → register → gate:** SB3 sub-modules → bare BC-format

--- a/ml/dicewars_bc/model.py
+++ b/ml/dicewars_bc/model.py
@@ -130,6 +130,36 @@ class EdgePolicyNet(nn.Module):
         ctx = self.context(torch.cat([node_pool, player_pool, board], dim=-1))  # [B, C]
         return node_emb, ctx
 
+    def edge_logits_from_context(
+        self,
+        node_emb: torch.Tensor,  # [B, A, H]
+        ctx: torch.Tensor,  # [B, C]
+        edge_feat: torch.Tensor,  # [E, Fe]
+        edge_from: torch.Tensor,  # [E] int64
+        edge_to: torch.Tensor,  # [E] int64
+        edge_batch: torch.Tensor,  # [E] int64 — which step each edge belongs to
+    ) -> torch.Tensor:
+        """Per-edge logits ``[E]`` from a precomputed context (the edge head).
+
+        Split out of :meth:`forward` so the Phase-3 PPO policy (``dicewars_ppo``)
+        runs the *exact same* edge-head gather as the BC forward / ONNX export — one
+        source of truth, no drift between the trained policy and the graded bot.
+        Only gathers/Linear/ReLU, so it stays ONNX-trace-friendly with dynamic ``E``
+        and ``B``.
+
+        Each edge indexes its OWN step's node block: flatten ``[B, A, H] → [B*A, H]``
+        and gather at ``edge_batch * A + id``. ``reshape(-1, H)`` keeps the batch dim
+        dynamic (so the ONNX export does too).
+        """
+        a = node_emb.shape[1]  # max_areas — statically fixed node-tensor width
+        flat_nodes = node_emb.reshape(-1, node_emb.shape[-1])  # [B*A, H]
+        from_emb = flat_nodes.index_select(0, edge_batch * a + edge_from)  # [E, H]
+        to_emb = flat_nodes.index_select(0, edge_batch * a + edge_to)  # [E, H]
+        ctx_e = ctx.index_select(0, edge_batch)  # [E, C]
+
+        edge_in = torch.cat([ctx_e, from_emb, to_emb, edge_feat], dim=-1)
+        return self.edge_head(edge_in).squeeze(-1)  # [E]
+
     def forward(
         self,
         nodes: torch.Tensor,  # [B, A, Fn]
@@ -145,21 +175,9 @@ class EdgePolicyNet(nn.Module):
         ONNX-export-friendly: only gathers/Linear/ReLU — no data-dependent
         control flow, so it traces cleanly with dynamic ``E`` (edges) and ``B``.
         """
-        a = nodes.shape[1]  # max_areas — statically fixed node-tensor width
         node_emb, ctx = self.encode_context(nodes, players, board)
-
-        # Gather from/to node embeddings for each edge out of its OWN step's
-        # node block: flatten [B, A, H] → [B*A, H] and index by batch*A + id.
-        # reshape(-1, H) keeps the batch dim dynamic (so the ONNX export does too).
-        flat_nodes = node_emb.reshape(-1, node_emb.shape[-1])  # [B*A, H]
-        from_idx = edge_batch * a + edge_from
-        to_idx = edge_batch * a + edge_to
-        from_emb = flat_nodes.index_select(0, from_idx)  # [E, H]
-        to_emb = flat_nodes.index_select(0, to_idx)  # [E, H]
-        ctx_e = ctx.index_select(0, edge_batch)  # [E, C]
-
-        edge_in = torch.cat([ctx_e, from_emb, to_emb, edge_feat], dim=-1)
-        edge_logits = self.edge_head(edge_in).squeeze(-1)  # [E]
-
+        edge_logits = self.edge_logits_from_context(
+            node_emb, ctx, edge_feat, edge_from, edge_to, edge_batch
+        )
         value = self.value_head(ctx)  # [B, 2]
         return edge_logits, value

--- a/ml/dicewars_ppo/__init__.py
+++ b/ml/dicewars_ppo/__init__.py
@@ -14,8 +14,11 @@ Layout (built incrementally over Phase-3 tracer steps 4–7, see
   ``scripts/lib/obs-frame.mjs`` plus the length-prefixed socket framing.
 * ``env_server`` — launch + supervise a ``ppo-env-server.mjs`` subprocess.
 * ``env`` — ``DiceWarsEnv``, a single-agent Gymnasium env over the socket
-  (Discrete(``MAX_EDGES``) + action masking). **Step 4 (this scaffold).**
-* ``policy`` / training entry — step 5–6 (not built yet).
+  (Discrete(``MAX_EDGES``) + action masking). **Step 4.**
+* ``policy`` — ``MaskableEdgePolicy``: the ``EdgePolicyNet``-trunk actor + fresh
+  scalar critic for ``MaskablePPO``, with warm-start/repack to the BC checkpoint.
+  **Step 5.**
+* training entry — step 6 (not built yet).
 
 **Why single-agent, not PettingZoo AEC.** The underlying game is an 8-way AEC,
 but the env-server runs all opponent seats *in-process in Node* and exposes only

--- a/ml/dicewars_ppo/policy.py
+++ b/ml/dicewars_ppo/policy.py
@@ -91,8 +91,10 @@ class MaskableEdgePolicy(MaskableActorCriticPolicy):
         Overrides the base ``_build`` wholesale: we do NOT build the base's
         ``mlp_extractor`` / ``action_net`` (the per-edge head replaces them).
         ``self.action_dist`` is already a ``MaskableCategoricalDistribution`` from
-        the base ``__init__``. The default (param-less) ``CombinedExtractor`` over
-        our all-``Box``/``MultiBinary`` Dict was built before this and is left unused.
+        the base ``__init__``. Any default features extractor SB3 builds (a
+        param-less ``FlattenExtractor`` over our Dict obs) is left unused — every
+        overridden method reads the obs Dict directly, so we don't depend on its
+        class or on exactly when the base instantiates it.
         """
         self.bc_net = EdgePolicyNet(self._bc_config)
         # Fresh scalar critic off ctx (PPO V(s)); separate from BC's value_head.
@@ -208,7 +210,10 @@ def load_bc_checkpoint(ckpt_path: str | Path) -> tuple[ModelConfig, dict]:
     Returns ``(config, checkpoint_dict)``. Raises if the checkpoint is a stale
     encoding version (a v1 net would shape-mismatch the live v2 observation).
     """
-    ckpt = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+    # weights_only=True: our BC checkpoints are tensors + a plain dict/str/num config
+    # (same as dicewars_bc.export_onnx), so this avoids the arbitrary-code-execution
+    # unpickler path that weights_only=False enables.
+    ckpt = torch.load(ckpt_path, map_location="cpu", weights_only=True)
     ev = ckpt.get("encoding_version")
     if ev != ENCODING_VERSION:
         raise ValueError(
@@ -223,12 +228,33 @@ def load_bc_checkpoint(ckpt_path: str | Path) -> tuple[ModelConfig, dict]:
 def warm_start_from_bc(policy: MaskableEdgePolicy, ckpt: dict) -> None:
     """Load BC trunk + ``edge_head`` (+ ``value_head``) into the policy's actor.
 
+    Validates the checkpoint up front — ``encoding_version == 2``, v2 feature widths,
+    and that its ``ModelConfig`` matches the one the policy was built from — so a
+    stale/mismatched checkpoint fails with an actionable message rather than a raw
+    ``load_state_dict`` size-mismatch dump, and a same-shape/different-encoding
+    checkpoint can't warm-start silently. This is a separate public entry point from
+    :func:`load_bc_checkpoint`, so it re-checks rather than trusting the caller.
+
     The actor (``policy.bc_net``) is a bare ``EdgePolicyNet`` with the checkpoint's
     ``ModelConfig``, so ``state_dict`` keys line up exactly (``strict=True``). The
     fresh scalar critic (``policy.value_net``) is intentionally left at its init —
     PPO learns it. The BC ``value_head`` loads too but PPO never trains it (no loss
     references it), so it survives for the repack parity fixture.
     """
+    ev = ckpt.get("encoding_version")
+    if ev != ENCODING_VERSION:
+        raise ValueError(
+            f"warm-start checkpoint encoding_version={ev!r} != {ENCODING_VERSION}; "
+            "must be the v2 BC checkpoint (the deployed ai_bc)."
+        )
+    ckpt_cfg = ModelConfig(**ckpt["config"])
+    _assert_v2_config(ckpt_cfg)
+    if ckpt_cfg != policy.bc_net.config:
+        raise ValueError(
+            f"warm-start checkpoint config {ckpt_cfg} != policy config "
+            f"{policy.bc_net.config}; the policy was built from a different "
+            "ModelConfig than the checkpoint."
+        )
     policy.bc_net.load_state_dict(ckpt["state_dict"], strict=True)
 
 
@@ -249,5 +275,11 @@ def repack_to_bc_checkpoint(
         "encoding_version": ENCODING_VERSION,
     }
     if extra:
+        clobbered = ckpt.keys() & extra.keys()
+        if clobbered:
+            raise ValueError(
+                f"repack `extra` may not override canonical checkpoint keys: "
+                f"{sorted(clobbered)} (use it only for provenance like `teacher`/step)."
+            )
         ckpt.update(extra)
     return ckpt

--- a/ml/dicewars_ppo/policy.py
+++ b/ml/dicewars_ppo/policy.py
@@ -1,0 +1,253 @@
+"""The Phase-3 PPO policy — an ``EdgePolicyNet``-trunk actor + a fresh scalar critic.
+
+This is the custom sb3-contrib ``MaskableActorCriticPolicy`` from PLAN step 5 /
+[D-19]. It reuses the behavioral-cloning net's trunk and per-edge head
+(``dicewars_bc.EdgePolicyNet``) as the PPO actor, with a **fresh scalar critic**
+off the same context vector — PPO needs a bootstrappable ``V(s)``, and BC's
+2-output ``(won, placement)`` value head is not one.
+
+**Why override the four call-sites instead of the features-extractor mold.** SB3's
+``features_extractor → mlp_extractor → action_net`` pipeline assumes a fixed-width
+latent feeding a flat action head. Our action head is *per-edge* — a ragged set of
+``(from, to)`` logits gathered out of node embeddings — so we bypass that pipeline
+and override the four methods MaskablePPO actually calls (``forward`` /
+``evaluate_actions`` / ``predict_values`` / ``get_distribution``), computing the
+padded-``MAX_EDGES`` edge logits and the scalar value directly from the obs Dict.
+``self.action_dist`` is already a ``MaskableCategoricalDistribution`` (set by the
+base ``__init__``); we feed it the padded logits and let MaskablePPO's collected
+``action_masks`` zero the pad tail.
+
+**Repackability (the [D-19] gate constraint).** The actor IS a real
+``EdgePolicyNet`` instance held at ``self.bc_net`` — same submodule names as a bare
+BC net — so :func:`repack_to_bc_checkpoint` can pull its ``state_dict`` straight
+back into the BC checkpoint format that ``dicewars_bc.export_weights`` /
+``export_onnx`` consume. Without that, the graded bot would not be the trained
+policy (the gate-breaking gap [D-19] flagged). The fresh critic is PPO-only and is
+dropped on repack; the BC ``value_head`` rides along untouched (PPO never puts it in
+a loss, so its grad stays ``None`` and the warm-started weights survive) so the
+JS↔Py parity fixture still runs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import torch
+from sb3_contrib.common.maskable.distributions import MaskableCategoricalDistribution
+from sb3_contrib.common.maskable.policies import MaskableActorCriticPolicy
+from torch import nn
+
+from dicewars_bc.model import EdgePolicyNet, ModelConfig
+
+from .constants import BOARD_W, EDGE_W, ENCODING_VERSION, NODE_W, PLAYER_W
+
+
+def _assert_v2_config(cfg: ModelConfig) -> None:
+    """Fail loud if a checkpoint's feature widths don't match the v2 wire contract.
+
+    The env emits the v2 encoding (``constants.{NODE,PLAYER,BOARD,EDGE}_W``); a
+    policy built around a stale-version ``ModelConfig`` (e.g. encoding-v1's node5/
+    edge4) would silently shape-mismatch the live observation. Check up front.
+    """
+    mismatches = [
+        f"{name}: config={got} != wire={want}"
+        for name, got, want in (
+            ("node_features", cfg.node_features, NODE_W),
+            ("player_features", cfg.player_features, PLAYER_W),
+            ("board_features", cfg.board_features, BOARD_W),
+            ("edge_features", cfg.edge_features, EDGE_W),
+        )
+        if got != want
+    ]
+    if mismatches:
+        raise ValueError(
+            "ModelConfig feature widths are not the v2 wire contract "
+            f"(dicewars_ppo.constants): {'; '.join(mismatches)}. Warm-start from a "
+            "v2 BC checkpoint (encoding_version == 2)."
+        )
+
+
+class MaskableEdgePolicy(MaskableActorCriticPolicy):
+    """``EdgePolicyNet``-trunk actor + fresh scalar critic for MaskablePPO.
+
+    Pass the BC ``ModelConfig`` via ``policy_kwargs={"bc_config": cfg}`` when
+    constructing ``MaskablePPO`` (or use :func:`build_policy` standalone). The obs
+    is the v2 ``Dict`` from :class:`dicewars_ppo.env.DiceWarsEnv`; the action space
+    is ``Discrete(MAX_EDGES)``.
+    """
+
+    def __init__(self, *args: Any, bc_config: ModelConfig, **kwargs: Any) -> None:
+        _assert_v2_config(bc_config)
+        # Stash before super().__init__ — the base calls self._build() at the end,
+        # and our override reads self._bc_config. (nn.Module.__setattr__ tolerates a
+        # plain-object attribute set before Module.__init__.)
+        self._bc_config = bc_config
+        super().__init__(*args, **kwargs)
+
+    def _build(self, lr_schedule: Any) -> None:
+        """Build the actor (BC net) + a fresh scalar critic + the optimizer.
+
+        Overrides the base ``_build`` wholesale: we do NOT build the base's
+        ``mlp_extractor`` / ``action_net`` (the per-edge head replaces them).
+        ``self.action_dist`` is already a ``MaskableCategoricalDistribution`` from
+        the base ``__init__``. The default (param-less) ``CombinedExtractor`` over
+        our all-``Box``/``MultiBinary`` Dict was built before this and is left unused.
+        """
+        self.bc_net = EdgePolicyNet(self._bc_config)
+        # Fresh scalar critic off ctx (PPO V(s)); separate from BC's value_head.
+        self.value_net = nn.Linear(self._bc_config.context_hidden, 1)
+        self.optimizer = self.optimizer_class(
+            self.parameters(), lr=lr_schedule(1), **self.optimizer_kwargs
+        )
+
+    # --- core: obs Dict → (padded edge logits [N, MAX_EDGES], values [N, 1]) ------
+
+    def _edge_logits_and_values(
+        self, obs: dict[str, torch.Tensor]
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        nodes = obs["nodes"]  # [N, A, NODE_W] f32
+        players = obs["players"]  # [N, P, PLAYER_W] f32
+        board = obs["board"]  # [N, BOARD_W] f32
+        edge_feat = obs["edge_feat"]  # [N, ME, EDGE_W] f32
+        edge_from = obs["edge_from"].long()  # [N, ME]  (int32 on the wire → index needs int64)
+        edge_to = obs["edge_to"].long()  # [N, ME]
+        n, me = edge_from.shape
+
+        node_emb, ctx = self.bc_net.encode_context(nodes, players, board)  # [N,A,H], [N,C]
+
+        # Flatten the padded [N, ME] edges into the ragged [E]-form the edge head
+        # expects, tagging every edge with its batch row. Pad slots (from=to=0, the
+        # absent-node sentinel) index row b's node 0 — in-bounds garbage that the
+        # action mask discards, so no OOB and no special-casing.
+        edge_batch = torch.arange(n, device=edge_from.device).repeat_interleave(me)  # [N*ME]
+        edge_logits_flat = self.bc_net.edge_logits_from_context(
+            node_emb,
+            ctx,
+            edge_feat.reshape(n * me, EDGE_W),
+            edge_from.reshape(n * me),
+            edge_to.reshape(n * me),
+            edge_batch,
+        )  # [N*ME]
+        edge_logits = edge_logits_flat.view(n, me)  # [N, ME]
+        values = self.value_net(ctx)  # [N, 1]
+        return edge_logits, values
+
+    def _distribution(
+        self, edge_logits: torch.Tensor, action_masks: torch.Tensor | None
+    ) -> MaskableCategoricalDistribution:
+        distribution = self.action_dist.proba_distribution(action_logits=edge_logits)
+        if action_masks is not None:
+            distribution.apply_masking(action_masks)
+        return distribution
+
+    # --- the four sb3-contrib call-sites -----------------------------------------
+
+    def forward(
+        self,
+        obs: dict[str, torch.Tensor],
+        deterministic: bool = False,
+        action_masks: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        edge_logits, values = self._edge_logits_and_values(obs)
+        distribution = self._distribution(edge_logits, action_masks)
+        actions = distribution.get_actions(deterministic=deterministic)
+        log_prob = distribution.log_prob(actions)
+        return actions, values, log_prob
+
+    def evaluate_actions(
+        self,
+        obs: dict[str, torch.Tensor],
+        actions: torch.Tensor,
+        action_masks: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        edge_logits, values = self._edge_logits_and_values(obs)
+        distribution = self._distribution(edge_logits, action_masks)
+        log_prob = distribution.log_prob(actions)
+        return values, log_prob, distribution.entropy()
+
+    def get_distribution(
+        self, obs: dict[str, torch.Tensor], action_masks: torch.Tensor | None = None
+    ) -> MaskableCategoricalDistribution:
+        edge_logits, _ = self._edge_logits_and_values(obs)
+        return self._distribution(edge_logits, action_masks)
+
+    def predict_values(self, obs: dict[str, torch.Tensor]) -> torch.Tensor:
+        _, values = self._edge_logits_and_values(obs)
+        return values
+
+
+def build_policy(
+    observation_space: Any,
+    action_space: Any,
+    bc_config: ModelConfig,
+    *,
+    lr: float = 3e-4,
+    **kwargs: Any,
+) -> MaskableEdgePolicy:
+    """Construct a :class:`MaskableEdgePolicy` standalone (outside ``MaskablePPO``).
+
+    MaskablePPO builds the policy itself from ``policy_kwargs``; this helper is for
+    tests / warm-start-then-repack scripts that need a policy without a full learner.
+    """
+    return MaskableEdgePolicy(
+        observation_space,
+        action_space,
+        lr_schedule=lambda _progress: lr,
+        bc_config=bc_config,
+        **kwargs,
+    )
+
+
+# --- warm-start / repack: the BC <-> PPO checkpoint bridge ------------------------
+
+
+def load_bc_checkpoint(ckpt_path: str | Path) -> tuple[ModelConfig, dict]:
+    """Load a v2 BC checkpoint, asserting ``encoding_version == 2``.
+
+    Returns ``(config, checkpoint_dict)``. Raises if the checkpoint is a stale
+    encoding version (a v1 net would shape-mismatch the live v2 observation).
+    """
+    ckpt = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+    ev = ckpt.get("encoding_version")
+    if ev != ENCODING_VERSION:
+        raise ValueError(
+            f"checkpoint encoding_version={ev!r} != {ENCODING_VERSION} ({ckpt_path}); "
+            "PPO warm-start must use the v2 BC checkpoint (the deployed ai_bc)."
+        )
+    cfg = ModelConfig(**ckpt["config"])
+    _assert_v2_config(cfg)
+    return cfg, ckpt
+
+
+def warm_start_from_bc(policy: MaskableEdgePolicy, ckpt: dict) -> None:
+    """Load BC trunk + ``edge_head`` (+ ``value_head``) into the policy's actor.
+
+    The actor (``policy.bc_net``) is a bare ``EdgePolicyNet`` with the checkpoint's
+    ``ModelConfig``, so ``state_dict`` keys line up exactly (``strict=True``). The
+    fresh scalar critic (``policy.value_net``) is intentionally left at its init —
+    PPO learns it. The BC ``value_head`` loads too but PPO never trains it (no loss
+    references it), so it survives for the repack parity fixture.
+    """
+    policy.bc_net.load_state_dict(ckpt["state_dict"], strict=True)
+
+
+def repack_to_bc_checkpoint(
+    policy: MaskableEdgePolicy, *, extra: dict | None = None
+) -> dict:
+    """Repack the trained actor back into BC checkpoint format (the step-7 gate).
+
+    Produces exactly what ``dicewars_bc.export_weights`` / ``export_onnx`` consume:
+    a bare-``EdgePolicyNet`` ``state_dict`` + its ``config`` + ``encoding_version``.
+    The PPO scalar critic is dropped (it's training-only). Pass ``extra`` to stamp
+    provenance (e.g. ``teacher``, training step). The inverse of
+    :func:`warm_start_from_bc` — round-trips to a byte-identical ``EdgePolicyNet``.
+    """
+    ckpt = {
+        "state_dict": policy.bc_net.state_dict(),
+        "config": policy.bc_net.config.to_dict(),
+        "encoding_version": ENCODING_VERSION,
+    }
+    if extra:
+        ckpt.update(extra)
+    return ckpt

--- a/ml/tests/test_ppo_policy.py
+++ b/ml/tests/test_ppo_policy.py
@@ -1,0 +1,231 @@
+"""Tests for the Phase-3 PPO policy (warm-start + repack parity, masked forward).
+
+Hermetic: builds a tiny synthetic v2 BC checkpoint (no real corpus/data) and
+exercises the policy purely in-process. Needs the `[rl]` stack (sb3-contrib +
+gymnasium) and torch, so it runs on shodan and skips in the BC CI — same split as
+the live env smoke (`test_ppo_env.py`).
+
+The headline test is the **repack round-trip**: warm-start the policy from a BC
+checkpoint, then `repack_to_bc_checkpoint` and reload into a bare `EdgePolicyNet`
+— the actor must be byte-identical to the source. That is the [D-19] gate
+constraint (the graded bot == the trained policy) asserted early.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("gymnasium")
+pytest.importorskip("sb3_contrib")
+
+from dicewars_bc.model import EdgePolicyNet, ModelConfig  # noqa: E402
+from dicewars_ppo.constants import (  # noqa: E402
+    BOARD_W,
+    EDGE_W,
+    MAX_EDGES,
+    NODE_W,
+    PLAYER_W,
+)
+from dicewars_ppo.env import DiceWarsEnv  # noqa: E402
+from dicewars_ppo.policy import (  # noqa: E402
+    build_policy,
+    load_bc_checkpoint,
+    repack_to_bc_checkpoint,
+    warm_start_from_bc,
+)
+
+
+def _v2_config(**overrides) -> ModelConfig:
+    """A small but v2-shaped ModelConfig (feature widths must match the wire)."""
+    base = dict(
+        max_areas=32,
+        node_features=NODE_W,
+        player_features=PLAYER_W,
+        board_features=BOARD_W,
+        edge_features=EDGE_W,
+        player_count=7,
+        # tiny hidden sizes keep the test fast; the policy is size-agnostic
+        node_hidden=16,
+        player_hidden=8,
+        context_hidden=24,
+        edge_hidden=16,
+    )
+    base.update(overrides)
+    return ModelConfig(**base)
+
+
+def _make_bc_checkpoint(cfg: ModelConfig, *, encoding_version: int = 2, seed: int = 0) -> dict:
+    """A BC-format checkpoint dict (state_dict + config) from a fresh EdgePolicyNet."""
+    torch.manual_seed(seed)
+    net = EdgePolicyNet(cfg)
+    return {
+        "state_dict": net.state_dict(),
+        "config": cfg.to_dict(),
+        "encoding_version": encoding_version,
+        "teacher": "Lookahead",
+    }
+
+
+def _spaces(cfg: ModelConfig):
+    """The env's real observation/action spaces (no server is launched)."""
+    env = DiceWarsEnv(max_areas=cfg.max_areas, player_count=cfg.player_count)
+    return env.observation_space, env.action_space
+
+
+def _build_warm_started(cfg: ModelConfig, ckpt: dict):
+    obs_space, act_space = _spaces(cfg)
+    policy = build_policy(obs_space, act_space, cfg)
+    warm_start_from_bc(policy, ckpt)
+    return policy
+
+
+def _fake_obs_batch(cfg: ModelConfig, *, n: int = 2, n_edges: int = 3, max_edges: int = MAX_EDGES):
+    """A padded obs batch with `n_edges` legal slots (last = STOP) and its mask."""
+    a, p = cfg.max_areas, cfg.player_count
+    rng = np.random.default_rng(7)
+    nodes = rng.standard_normal((n, a, NODE_W)).astype(np.float32)
+    nodes[:, :6, 0] = 1.0  # first 6 territories present (col 0 = present)
+    nodes[:, 6:, 0] = 0.0
+    players = rng.standard_normal((n, p, PLAYER_W)).astype(np.float32)
+    board = rng.standard_normal((n, BOARD_W)).astype(np.float32)
+
+    edge_feat = np.zeros((n, max_edges, EDGE_W), np.float32)
+    edge_from = np.zeros((n, max_edges), np.int32)
+    edge_to = np.zeros((n, max_edges), np.int32)
+    mask = np.zeros((n, max_edges), np.int8)
+    for b in range(n):
+        # n_edges-1 attacks then a trailing STOP edge (from=to=0, isStop @ col 3)
+        edge_feat[b, : n_edges - 1] = rng.standard_normal((n_edges - 1, EDGE_W)).astype(np.float32)
+        edge_from[b, : n_edges - 1] = rng.integers(1, 6, n_edges - 1)
+        edge_to[b, : n_edges - 1] = rng.integers(1, 6, n_edges - 1)
+        edge_feat[b, n_edges - 1, 3] = 1.0  # STOP
+        mask[b, :n_edges] = 1
+
+    obs = {
+        "nodes": torch.as_tensor(nodes),
+        "players": torch.as_tensor(players),
+        "board": torch.as_tensor(board),
+        "edge_feat": torch.as_tensor(edge_feat),
+        "edge_from": torch.as_tensor(edge_from),
+        "edge_to": torch.as_tensor(edge_to),
+        "edge_mask": torch.as_tensor(mask),
+    }
+    return obs, torch.as_tensor(mask).bool(), n_edges
+
+
+def _state_dicts_equal(a: dict, b: dict) -> bool:
+    return a.keys() == b.keys() and all(torch.equal(a[k], b[k]) for k in a)
+
+
+# --- warm-start ------------------------------------------------------------------
+
+
+def test_warm_start_loads_actor_from_checkpoint():
+    cfg = _v2_config()
+    ckpt = _make_bc_checkpoint(cfg)
+    policy = _build_warm_started(cfg, ckpt)
+
+    # The actor (trunk + edge_head + BC value_head) is byte-identical to the source.
+    assert _state_dicts_equal(policy.bc_net.state_dict(), ckpt["state_dict"])
+
+
+def test_fresh_scalar_critic_is_separate_from_bc_value_head():
+    cfg = _v2_config()
+    policy = _build_warm_started(cfg, _make_bc_checkpoint(cfg))
+
+    # The PPO critic is a fresh scalar head (context_hidden -> 1), NOT BC's
+    # 2-output (won, placement) value_head.
+    assert isinstance(policy.value_net, torch.nn.Linear)
+    assert policy.value_net.out_features == 1
+    assert policy.value_net.in_features == cfg.context_hidden
+    assert policy.bc_net.value_head[-1].out_features == 2  # BC head untouched
+    # value_net params are not part of the actor that gets repacked.
+    actor_ids = {id(p) for p in policy.bc_net.parameters()}
+    assert all(id(p) not in actor_ids for p in policy.value_net.parameters())
+
+
+# --- masked forward --------------------------------------------------------------
+
+
+def test_forward_shapes_and_masking():
+    cfg = _v2_config()
+    policy = _build_warm_started(cfg, _make_bc_checkpoint(cfg))
+    obs, masks, n_edges = _fake_obs_batch(cfg)
+
+    actions, values, log_prob = policy.forward(obs, action_masks=masks)
+    n = obs["nodes"].shape[0]
+
+    assert actions.shape == (n,)
+    assert values.shape == (n, 1)
+    assert log_prob.shape == (n,)
+    # Every sampled action must be a legal (unmasked) slot.
+    for b in range(n):
+        assert masks[b, int(actions[b])].item() is True
+
+
+def test_distribution_zeros_the_pad_tail():
+    cfg = _v2_config()
+    policy = _build_warm_started(cfg, _make_bc_checkpoint(cfg))
+    obs, masks, n_edges = _fake_obs_batch(cfg)
+
+    dist = policy.get_distribution(obs, action_masks=masks)
+    probs = dist.distribution.probs  # [N, MAX_EDGES]
+
+    assert probs.shape == (obs["nodes"].shape[0], MAX_EDGES)
+    # Pad slots (>= n_edges) carry zero probability; legal slots sum to 1.
+    assert torch.allclose(probs[:, n_edges:], torch.zeros_like(probs[:, n_edges:]), atol=1e-6)
+    assert torch.allclose(probs[:, :n_edges].sum(dim=1), torch.ones(probs.shape[0]), atol=1e-5)
+
+
+def test_evaluate_actions_and_predict_values_are_finite():
+    cfg = _v2_config()
+    policy = _build_warm_started(cfg, _make_bc_checkpoint(cfg))
+    obs, masks, _ = _fake_obs_batch(cfg)
+
+    actions, _, _ = policy.forward(obs, action_masks=masks)
+    values, log_prob, entropy = policy.evaluate_actions(obs, actions, action_masks=masks)
+    assert torch.isfinite(values).all()
+    assert torch.isfinite(log_prob).all()
+    assert torch.isfinite(entropy).all()
+    assert torch.equal(policy.predict_values(obs), values)
+
+
+# --- repack (the step-7 gate parity) ---------------------------------------------
+
+
+def test_repack_roundtrips_to_bare_edgepolicynet():
+    cfg = _v2_config()
+    ckpt = _make_bc_checkpoint(cfg, seed=3)
+    policy = _build_warm_started(cfg, ckpt)
+
+    repacked = repack_to_bc_checkpoint(policy, extra={"teacher": "PPO"})
+    assert repacked["encoding_version"] == 2
+    assert repacked["teacher"] == "PPO"
+    assert repacked["config"] == cfg.to_dict()
+
+    # Rebuild a bare EdgePolicyNet from the repacked checkpoint exactly the way
+    # export_weights.py / export_onnx.py do — it must equal the source actor.
+    reloaded = EdgePolicyNet(ModelConfig(**repacked["config"]))
+    reloaded.load_state_dict(repacked["state_dict"])
+    assert _state_dicts_equal(reloaded.state_dict(), ckpt["state_dict"])
+
+
+# --- guards ----------------------------------------------------------------------
+
+
+def test_load_bc_checkpoint_rejects_non_v2(tmp_path):
+    cfg = _v2_config(node_features=5, edge_features=4)  # encoding-v1 shapes
+    ckpt = _make_bc_checkpoint(cfg, encoding_version=1)
+    path = tmp_path / "v1.pt"
+    torch.save(ckpt, path)
+    with pytest.raises(ValueError, match="encoding_version"):
+        load_bc_checkpoint(path)
+
+
+def test_build_policy_rejects_non_v2_config():
+    cfg = _v2_config(node_features=5)  # wrong width for the v2 wire
+    obs_space, act_space = _spaces(_v2_config())
+    with pytest.raises(ValueError, match="v2 wire contract"):
+        build_policy(obs_space, act_space, cfg)

--- a/ml/tests/test_ppo_policy.py
+++ b/ml/tests/test_ppo_policy.py
@@ -179,6 +179,62 @@ def test_distribution_zeros_the_pad_tail():
     assert torch.allclose(probs[:, :n_edges].sum(dim=1), torch.ones(probs.shape[0]), atol=1e-5)
 
 
+# --- forward-path parity (the warm-start fidelity loop) --------------------------
+
+
+def test_policy_forward_matches_bare_edgepolicynet():
+    """The policy's forward path computes the SAME edge logits as a bare
+    ``EdgePolicyNet`` on the same obs.
+
+    ``test_repack_roundtrips_to_bare_edgepolicynet`` proves the *weights* survive the
+    BC↔PPO round trip. This proves the policy's padded-``[N, ME]`` → ragged reshape /
+    ``edge_batch`` synthesis / ``view`` plumbing (``_edge_logits_and_values``)
+    *consumes* those weights the same way the BC forward / ONNX export does — so the
+    graded bot == the trained policy through the forward path, not just the bytes. A
+    ``repeat`` vs ``repeat_interleave`` slip or an ``n``/``me`` transpose would yield
+    a perfectly valid masked distribution while silently breaking the warm-start;
+    this is the regression pin for that class of bug.
+    """
+    cfg = _v2_config()
+    ckpt = _make_bc_checkpoint(cfg, seed=5)
+    policy = _build_warm_started(cfg, ckpt)
+    obs, _masks, n_edges = _fake_obs_batch(cfg)
+    n = obs["nodes"].shape[0]
+
+    # Policy forward path → padded [N, MAX_EDGES] edge logits (pad tail is garbage).
+    with torch.no_grad():
+        policy_logits, _values = policy._edge_logits_and_values(obs)
+
+    # Reference: a bare EdgePolicyNet with the SAME weights, run over the ragged
+    # *legal* edges of each row — exactly the BC forward / ONNX export call. Every
+    # row has n_edges legal slots; flatten row-major and batch-tag each edge with its
+    # row (repeat_interleave → [0]*n_edges, [1]*n_edges, …), mirroring the legal head
+    # of the policy's own [N, ME] → [N*ME] flatten.
+    bare = EdgePolicyNet(cfg)
+    bare.load_state_dict(ckpt["state_dict"])
+    bare.eval()
+
+    edge_feat = obs["edge_feat"][:, :n_edges, :].reshape(n * n_edges, EDGE_W)
+    edge_from = obs["edge_from"][:, :n_edges].reshape(n * n_edges).long()
+    edge_to = obs["edge_to"][:, :n_edges].reshape(n * n_edges).long()
+    edge_batch = torch.arange(n).repeat_interleave(n_edges)
+    with torch.no_grad():
+        ref_logits, _ = bare(
+            obs["nodes"],
+            obs["players"],
+            obs["board"],
+            edge_feat,
+            edge_from,
+            edge_to,
+            edge_batch,
+        )
+    ref_logits = ref_logits.view(n, n_edges)
+
+    # The legal-slot logits must match the bare net's exactly (same weights, same
+    # gather/Linear/ReLU ops); tolerance covers only BLAS batch-size rounding.
+    assert torch.allclose(policy_logits[:, :n_edges], ref_logits, rtol=1e-4, atol=1e-6)
+
+
 def test_evaluate_actions_and_predict_values_are_finite():
     cfg = _v2_config()
     policy = _build_warm_started(cfg, _make_bc_checkpoint(cfg))


### PR DESCRIPTION
## Summary

**Phase-3 tracer step 5** ([PLAN](docs/ml-bot/PLAN.md) Phase 3): the custom SB3 policy for the self-play PPO learner, warm-started from the v2-BC checkpoint. Builds on the merged #58 env scaffold.

No production-bot or engine code changes — the shipped `ai_bc` and `src/` are untouched. This is training-harness code (`ml/dicewars_ppo/`) plus one behavior-preserving refactor of `ml/dicewars_bc/model.py`.

## What's here

- **`ml/dicewars_ppo/policy.py`** — `MaskableEdgePolicy`, a custom sb3-contrib `MaskableActorCriticPolicy`:
  - **Actor** = the v2-BC `EdgePolicyNet` trunk + per-edge head; **fresh scalar critic** off `ctx` ([D-19] — BC's 2-output `(won, placement)` head isn't a bootstrappable `V(s)`).
  - Overrides the four call-sites MaskablePPO actually uses (`forward` / `evaluate_actions` / `predict_values` / `get_distribution`) to gather padded-`MAX_EDGES` edge logits straight from the obs `Dict` into a `MaskableCategorical`. The ragged per-edge head doesn't fit SB3's `features_extractor→action_net` pipeline, so we bypass it; the collected `action_masks` zero the pad tail.
  - **`warm_start_from_bc` / `load_bc_checkpoint`** — load trunk + `edge_head` from the v2-BC `.pt`, asserting `encoding_version == 2` + v2 feature widths.
  - **`repack_to_bc_checkpoint`** — the inverse: pull the trained actor back into BC checkpoint format (bare `EdgePolicyNet` `state_dict` + config), for the step-7 export/register/gate.
- **`ml/dicewars_bc/model.py`** — extract the edge-head gather into `EdgePolicyNet.edge_logits_from_context`, so the BC forward / ONNX export and the PPO actor share **one** source of truth. Behavior-preserving (identical traced ops).
- **`ml/tests/test_ppo_policy.py`** — 8 hermetic tests (synthetic v2 checkpoint, no real data), gated on sb3-contrib/gymnasium.

## Closing the [D-19] gate-breaking repack gap, up front

D-19's verification flagged that `export_weights.py` rebuilds a **bare** `EdgePolicyNet` via `getattr(model, attr)` on `{node_encoder, …, edge_head, value_head}` — an SB3 policy wraps the trunk under a different namespace, so the export would fail and **the graded bot would not be the trained policy**. This PR makes the policy hold a real `EdgePolicyNet` instance (same submodule names) and adds `repack_to_bc_checkpoint` + a **round-trip-to-bare-`EdgePolicyNet` parity test**, so that risk is retired before any training run rather than discovered at the gate. (The BC `value_head` rides along untouched — PPO never puts it in a loss, so its grad stays `None` and the warm-started weights survive — so the JS↔Py parity fixture still runs at export.)

## Design note — extraction over copy-with-comment

The edge-head gather (the `edge_batch*A + id` index math) is subtle, and drift between the BC ONNX export and the PPO actor would be a silent gate-breaker. So rather than duplicate ~6 lines into the policy, I pulled them into `EdgePolicyNet.edge_logits_from_context` that `forward` now calls — one source of truth. It's a pure extraction: the existing BC `test_model` / `test_export_onnx` parity tests stay green and the ONNX trace is byte-unchanged.

## Testing

Validated on shodan (WSL2, Python 3.10, the `[rl]` stack, RTX 4070 Ti), branch `ml-bot/phase3-ppo-policy`:

- `ruff check .` clean.
- **BC extraction parity** — `test_model` + `test_export_onnx` (`REQUIRE_ONNX=1`): **12 passed**. Confirms the `model.py` refactor is behavior-preserving and the ONNX↔PyTorch parity still holds.
- **New policy tests** — `test_ppo_policy.py`: **8 passed** (warm-start loads actor; fresh-critic separation; masked forward shapes; pad-tail probability is zero; `evaluate_actions`/`predict_values` finite; **repack round-trip parity**; v1-checkpoint + config-mismatch guards reject loudly).
- **Real-artifact end-to-end** — loaded the **deployed `v2-base` checkpoint** (`ml/checkpoints/v2-base/bc_model.pt`, 102,787 params, `val_stop_cal` matching `bcPolicyWeights.js` byte-for-byte = the shipped `ai_bc`): warm-start `actor == deployed state_dict`, repack round-trips byte-identically, and the warm-started policy drove the **live Node env-server through a full 76-decision episode** picking only legal actions.

These tests skip in the BC CI (no sb3-contrib/node) — same split as the live env smoke (`test_ppo_env.py`).

## What's next (not in this PR)

- **Step 6** — tiny tracer PPO run: 1–2 envs, 1 learner + fixed JS baselines, terminal-win reward only, warm-started (low initial LR / optional brief trunk freeze per [D-19] decision 1), a handful of updates. Fold in the `truncated`-vs-`terminated` wire flag for `maxTurns` stalemates (deferred from step 4) so value bootstrapping is correct.
- **Step 7** — repack → `export_weights` → regenerated JS↔Py fixture → register via `makeBC({policy})` → `arena:sweep` win% vs `ai_lookahead@596f781`.

Decisions: [`docs/ml-bot/DECISIONS.md`](docs/ml-bot/DECISIONS.md) D-19/D-20/D-21. Session journal: [`docs/ml-bot/LOG.md`](docs/ml-bot/LOG.md).
