### PR TITLE
fix(ml): skip zero-decision episodes in PPO env-server (reset() desync)

### DIFF
--- a/ml/dicewars_ppo/env.py
+++ b/ml/dicewars_ppo/env.py
@@ -69,6 +69,7 @@ class DiceWarsEnv(gym.Env):
         port: int | None = None,
         server_kwargs: dict[str, Any] | None = None,
         connect_timeout_s: float = 30.0,
+        read_timeout_s: float = 180.0,
     ) -> None:
         super().__init__()
         self.max_areas = max_areas
@@ -79,6 +80,7 @@ class DiceWarsEnv(gym.Env):
         self._port = port
         self._server_kwargs = dict(server_kwargs or {})
         self._connect_timeout_s = connect_timeout_s
+        self._read_timeout_s = read_timeout_s
 
         if not managed and (host is None or port is None):
             raise ValueError("managed=False requires explicit host and port.")
@@ -122,7 +124,13 @@ class DiceWarsEnv(gym.Env):
             host, port = self._host, self._port
         try:
             sock = socket.create_connection((host, port), timeout=self._connect_timeout_s)
-            sock.settimeout(None)  # blocking reads for the rest of the episode
+            # A finite per-recv read deadline (not None) so a wedged env-server surfaces as a loud
+            # socket.timeout instead of an infinite client hang. The server's OWN decision watchdog
+            # only covers a hung learner (it parks in Atomics.wait inside chooseAction); it cannot
+            # catch an opponent bot stuck in a synchronous compute loop, because then the server's
+            # main thread never reaches chooseAction. This client deadline is the backstop for that
+            # case. Generous: >> any legal inter-frame gap (a full opponent round is sub-second).
+            sock.settimeout(self._read_timeout_s)
             sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         except OSError as exc:
             # Reap the just-launched managed server so a failed connect can't orphan it,

--- a/ml/dicewars_ppo/train_tracer.py
+++ b/ml/dicewars_ppo/train_tracer.py
@@ -30,6 +30,7 @@ byte-identical to the warm-start, a useful sanity floor.
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 
 import torch
@@ -237,6 +238,12 @@ def _validate_args(args: argparse.Namespace) -> None:
 
 
 def main() -> None:
+    # Line-buffer stdout/stderr so progress AND a fatal traceback flush immediately even when
+    # redirected to a file. Block buffering (the default for a non-tty) otherwise swallows the
+    # final traceback on a crash — which masked a fatal env desync as a silent "process gone" for
+    # several runs before this was added.
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
     args = build_parser().parse_args()
     _validate_args(args)
     train(args)

--- a/ml/tests/test_ppo_env.py
+++ b/ml/tests/test_ppo_env.py
@@ -74,6 +74,47 @@ def test_stop_only_episodes_run_end_to_end() -> None:
     assert decisions > 0, "a STOP-only learner should still make at least one decision"
 
 
+def test_zero_decision_episode_does_not_desync() -> None:
+    """A zero-decision episode must not desync reset() (the bug that killed every tracer run).
+
+    On some seeds the learner seat is conquered before its turn ever comes up, so it takes NO action
+    and the episode emits no obs frame. The env-server streams ``(obs*, terminal)`` per episode, so
+    such an episode would otherwise put a BARE terminal where the client's ``reset()`` expects the
+    next episode's first obs → the desync ``RuntimeError`` in :meth:`DiceWarsEnv.reset`. The
+    server-side fix skips zero-decision episodes. With the full 7-player training field, seed 35 is
+    a zero-decision episode (anchored by the JS test ``tests/ml/ppo-env.test.js``); seeding at
+    ``seed_base=35`` puts it first, so the very first ``reset()`` would crash on the old server.
+    ``episodes=0`` (run-until-disconnect) is required: a skipped episode still advances the seed
+    counter, so a fixed quota could surface fewer episodes than requested.
+    """
+    env = DiceWarsEnv(
+        player_count=7,
+        server_kwargs={
+            "opponents": "ai_lookahead,ai_strategist,ai_expectimax,ai_bc,ai_defensive",
+            "seed_base": 35,  # episode 0 (seed 35) is zero-decision — the server must skip it
+            "episodes": 0,
+        },
+    )
+    completed = 0
+    try:
+        for _ in range(3):
+            obs, info = env.reset()
+            _assert_obs(obs)
+            # The crux: a real first decision, never a leaked bare terminal from a skipped episode.
+            assert info["terminal"] == 0
+            terminated = truncated = False
+            while not (terminated or truncated):
+                obs, reward, terminated, truncated, info = env.step(_stop_index(env.action_masks()))
+                _assert_obs(obs)
+            assert info["terminal"] == 1
+            assert info["won"] in (0, 1)
+            completed += 1
+    finally:
+        env.close()
+
+    assert completed == 3, "every surfaced episode should complete cleanly past the skipped one"
+
+
 def _assert_obs(obs: dict) -> None:
     assert obs["nodes"].shape == (DEFAULT_MAX_AREAS, NODE_W)
     assert obs["edge_feat"].shape == (MAX_EDGES, EDGE_W)

--- a/scripts/ppo-env-server.mjs
+++ b/scripts/ppo-env-server.mjs
@@ -182,10 +182,20 @@ async function main() {
   let lostError = null;
 
   /*
+   * Learner decisions emitted in the CURRENT episode (reset per episode below). Lets the loop
+   * detect a "zero-decision" episode — the learner eliminated before it ever took a turn, so
+   * chooseAction never fired and no obs frame was sent. Surfacing a terminal for such an episode
+   * would desync the client's reset() (which expects the next episode's first obs, not a bare
+   * terminal); see the skip in the episode loop.
+   */
+  let decisionsThisEpisode = 0;
+
+  /*
    * The learner's synchronous action selector: emit a frame, park (with a watchdog deadline), and
    * either return the validated index or record why the learner was lost and throw.
    */
   const chooseAction = (encoded, botState) => {
+    decisionsThisEpisode++;
     const buf = serializeObsFrame(buildObsFrame({ encoded, botState, maxAreas }));
     Atomics.store(ctrl, STATUS, ST_WAITING);
     worker.postMessage({ type: 'obs', frame: frameToArrayBuffer(buf) });
@@ -243,6 +253,12 @@ async function main() {
   };
 
   let played = 0;
+  /*
+   * Consecutive zero-decision episodes skipped without surfacing a frame; a long run of these means
+   * the learner can never act (degenerate field/seat) — abort loud rather than spin silently.
+   */
+  let consecutiveZeroDecision = 0;
+  const MAX_CONSECUTIVE_ZERO_DECISION = 1000;
   try {
     /*
      * Block until the worker's server is listening and a client has connected (or it failed/closed,
@@ -252,6 +268,7 @@ async function main() {
     for (let ep = 0; episodes === 0 || ep < episodes; ep++) {
       if (closed || lostError) break;
       const seed = seedBase + ep;
+      decisionsThisEpisode = 0;
       let result;
       try {
         result = runSelfPlayEpisode({
@@ -273,6 +290,26 @@ async function main() {
         if (err instanceof EnvClosed) break;
         throw err;
       }
+
+      /*
+       * Zero-decision episode: the learner was eliminated before it ever took a turn, so NO obs
+       * frame was emitted (chooseAction never fired). The wire contract is a run of obs frames then
+       * ONE terminal; a bare terminal with no preceding obs would land in the client's reset() —
+       * which expects the next episode's first decision — and desync it (env.py's reset guard). Such
+       * an episode carries no learner transition for PPO, so surface nothing and roll to the next
+       * seed. Guard against an unbounded silent skip in a degenerate field where the learner can
+       * never move.
+       */
+      if (decisionsThisEpisode === 0) {
+        if (++consecutiveZeroDecision > MAX_CONSECUTIVE_ZERO_DECISION) {
+          throw new Error(
+            `PPO env-server: ${consecutiveZeroDecision} consecutive zero-decision episodes ` +
+              `(learner eliminated before acting every time) — check the opponents/learner-seat config.`
+          );
+        }
+        continue;
+      }
+      consecutiveZeroDecision = 0;
 
       /*
        * Terminal frame: the learner's view of the board at the episode terminal (its elimination,

--- a/tests/ml/ppo-env.test.js
+++ b/tests/ml/ppo-env.test.js
@@ -21,6 +21,7 @@ import { runMatch } from '../../src/arena/matchRunner.js';
 import { ai_bc } from '../../src/ai/ai_bc.js';
 import { forward, argmax } from '../../src/ai/bcForward.js';
 import { BC_POLICY } from '../../src/ai/bcPolicyWeights.js';
+import { BUILT_IN_BOTS } from '../../src/arena/builtInBots.js';
 
 import {
   runSelfPlayEpisode,
@@ -56,6 +57,16 @@ const mimicAiBc = encoded => argmax(forward(BC_POLICY, encoded).logits);
 
 /** A learner that always ends its turn immediately (STOP slot is last). */
 const alwaysStop = encoded => encoded.moves.length - 1;
+
+/** The training opponent field ([D-15]); the env-server cycles it to fill the non-learner seats. */
+const FULL_FIELD = ['ai_lookahead', 'ai_strategist', 'ai_expectimax', 'ai_bc', 'ai_defensive'];
+const fieldOpponents = count => {
+  const byId = new Map(BUILT_IN_BOTS.map(b => [b.id, b]));
+  return Array.from({ length: count }, (_, i) => {
+    const bot = byId.get(FULL_FIELD[i % FULL_FIELD.length]);
+    return { name: `${bot.name}@${i}`, fn: bot.fn };
+  });
+};
 
 /** Compare the salient, data-only parts of two final states. */
 function projectState(s) {
@@ -171,6 +182,40 @@ describe('runSelfPlayEpisode — STOP and reward semantics', () => {
     // Winner ⇒ best placement (1.0); a present seat is always ranked.
     if (ep.winner === ep.learnerSeat) expect(ep.placement).toBe(1);
     expect(ep.playerCount).toBe(PLAYER_COUNT);
+  });
+});
+
+describe('runSelfPlayEpisode — zero-decision episodes (the env-server desync hazard)', () => {
+  it('a learner eliminated before its first turn makes zero decisions (server must skip it)', () => {
+    /*
+     * On some seeds the learner seat is conquered before its turn ever comes up in the order, so the
+     * episode ends with the learner having taken NO action — chooseAction never fires (here the seat
+     * even starts with 5 areas; it is wiped by turn 6, all before its first turn). The env-server
+     * streams a run of obs frames then ONE terminal per episode, so a zero-decision episode would put
+     * a BARE terminal where the client's reset() expects the next episode's first obs → the desync
+     * RuntimeError in env.py's reset guard. The server-side fix (ppo-env-server.mjs) skips such
+     * episodes. seed 35 / 7-player full field is the canonical anchor — also the seed_base the Python
+     * e2e regression (ml/tests/test_ppo_env.py) spawns a real server on. If the engine RNG changes and
+     * this assertion fails, re-find a zero-decision seed and update both tests in lockstep.
+     */
+    let decisions = 0;
+    const ep = runSelfPlayEpisode({
+      seed: 35,
+      opponents: fieldOpponents(PLAYER_COUNT - 1),
+      learnerSeat: 0,
+      maxAreas: MAX_AREAS,
+      maxTurns: MAX_TURNS,
+      chooseAction: encoded => {
+        decisions++;
+        return alwaysStop(encoded);
+      },
+      terminateOnElimination: true,
+    });
+
+    expect(decisions).toBe(0); // the learner never got to act → no obs frame would be emitted
+    expect(ep.eliminated).toBe(true); // ended by elimination, not a win or stalemate cap
+    expect(ep.won).toBe(0);
+    expect(ep.truncated).toBe(false); // a genuine terminal (elimination), not a maxTurns truncation
   });
 });
 


### PR DESCRIPTION
## Summary

Every Phase-3 PPO tracer run died within the first few iterations. Root cause: an **episode-protocol desync**, not the OOM/memory/hang it masqueraded as.

The env-server streams `(obs×N, terminal)` per episode back-to-back; the client's `reset()` (DummyVecEnv auto-reset) assumes the next frame is a non-terminal observation. But a **zero-decision episode** — the learner eliminated before its first turn ever comes up in the order — emits a **bare terminal with no preceding obs**, which lands in `reset()` and raises:

```
RuntimeError: env-server sent a terminal frame at reset() — episode desync
```

It's probabilistic (depends which seeds the parallel envs hit), which is why it killed runs at iterations 1, 3, 4, etc. It stayed invisible because `train_tracer` ran **block-buffered**, so the fatal traceback never flushed — it read as a silent "process gone" and was misdiagnosed as OOM. A live memory monitor later showed memory dead-flat with 62 GB free, and forcing unbuffered output finally captured the real traceback.

## Changes

- **`scripts/ppo-env-server.mjs`** — the fix: count learner decisions per episode and **skip** (surface nothing for) a zero-decision episode, with a guard against an unbounded silent skip in a degenerate field/seat. A zero-decision episode carries no learner transition, so dropping it is correct for PPO.
- **`ml/dicewars_ppo/env.py`** — hardening: a finite **180 s client read-timeout** (was `None`). The server's decision watchdog only covers a hung *learner*; a synchronous opponent stall would otherwise hang the client forever. Now it surfaces a loud `socket.timeout`.
- **`ml/dicewars_ppo/train_tracer.py`** — force **line-buffered** stdout/stderr so a crash traceback always flushes (the thing that hid this bug).
- **Tests** — a JS test (`tests/ml/ppo-env.test.js`) locking the zero-decision anchor (seed 35, 7-player field), and a Python e2e regression (`ml/tests/test_ppo_env.py`) that spawns a real server seeded at the zero-decision episode and asserts `reset()` no longer desyncs.

## Validation

- Full JS suite green (1006 tests). Python `test_ppo_env.py` green on shodan (2 passed).
- **Regression test proven to catch the bug**: with the skip neutralized it fails in 0.4 s with the exact desync `RuntimeError`; with the fix it passes.
- **Behavioral**: with the fix deployed, training runs cleanly past the iteration zone where every prior run died (memory flat, healthy PPO stats), provably skipping zero-decision episodes that used to crash it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)