### PR TITLE
feat(ml): PPO opponent league — task B step B1 (empty-pool == fixed field)

### DIFF
--- a/scripts/lib/ppo-league.mjs
+++ b/scripts/lib/ppo-league.mjs
@@ -1,5 +1,5 @@
 /**
- * PFSP opponent league for the PPO env-server (ml-bot Phase 3, task B — [D-23]).
+ * PFSP opponent league for the PPO env-server (ml-bot Phase 3, task B — [D-22]).
  *
  * The env-server draws its per-episode opponent field from this league instead of a
  * static const. The league owns the opponent pool (built-in baselines + hot-loaded
@@ -10,7 +10,7 @@
  * before — byte-identical, so task A's outcomes reproduce. This file (step **B1**)
  * ships that empty-pool path plus a decisive/truncated telemetry tally; the snapshot
  * pipeline (B3), PFSP weighting (B4), and persistence (B6) extend the same object.
- * See docs/ml-bot/DECISIONS.md D-23 for the full build sequence.
+ * See docs/ml-bot/DECISIONS.md D-22 for the full build sequence.
  *
  * @module scripts/lib/ppo-league
  */
@@ -34,7 +34,10 @@ function parseIds(idCsv) {
  *
  * @param {string} idCsv comma-separated built-in bot ids (e.g. "ai_lookahead,ai_bc")
  * @param {number} count number of opponent seats to fill (= playerCount - 1)
- * @returns {{name: string, fn: Function}[]} length `count`; the seat-cycle index is in the name (`@i`)
+ * @returns {{id: string, name: string, fn: Function}[]} length `count`; the seat-cycle index is in
+ *   the name (`@i`). `id` is the stable bot id (the field is the single source of truth for the
+ *   cycle, so `draw()`'s seat metadata keys on `entry.id` rather than re-deriving the cycle).
+ *   `runSelfPlayEpisode` reads only `name`/`fn` and ignores the extra `id`.
  */
 export function resolveBaselineField(idCsv, count) {
   const ids = parseIds(idCsv);
@@ -45,7 +48,7 @@ export function resolveBaselineField(idCsv, count) {
     if (!bot) {
       throw new Error(`Unknown opponent bot id "${id}". Known: ${[...byId.keys()].join(', ')}.`);
     }
-    return { name: `${bot.name}@${i}`, fn: bot.fn };
+    return { id, name: `${bot.name}@${i}`, fn: bot.fn };
   });
 }
 
@@ -57,7 +60,7 @@ export function resolveBaselineField(idCsv, count) {
  * @param {object} opts
  * @param {string} opts.baselineCsv the resolved `--opponents` CSV. The trainer passes
  *   `DEFAULT_OPPONENTS`; the env-server's own default is `ai_bc`. Threaded in (NOT a
- *   hardcoded default) so the empty-pool field equals the launch's actual field _[D-23]_.
+ *   hardcoded default) so the empty-pool field equals the launch's actual field _[D-22]_.
  * @param {number} opts.count opponent seats per game (= playerCount - 1); `draw()` always
  *   returns exactly this many (holds player_count constant, [D-22]).
  * @param {number} opts.learnerSeat the learner's seat; used to map an opponent's array
@@ -65,10 +68,21 @@ export function resolveBaselineField(idCsv, count) {
  * @returns {{draw: Function, recordResult: Function, stats: Function}}
  */
 export function makeLeague({ baselineCsv, count, learnerSeat }) {
-  const slotIds = (() => {
-    const ids = parseIds(baselineCsv);
-    return Array.from({ length: count }, (_, i) => ids[i % ids.length]);
-  })();
+  /*
+   * Fail loud at construction — both inputs are in scope here, so a bad value is caught at the
+   * cheapest spot rather than surfacing later as a silently-wrong `seatOf` map (B2's win-rate
+   * attribution reads `drawn[k].seat`) or an `Array.from({ length })` that floors/empties without
+   * complaint. playerCount = count + 1 ⇒ valid learner seats are [0, count]. Mirrors the guard in
+   * runSelfPlayEpisode (ppo-env.mjs), which re-validates `learnerSeat` against the same range.
+   */
+  if (!Number.isInteger(count) || count <= 0) {
+    throw new Error(`makeLeague: count must be a positive integer, got ${count}.`);
+  }
+  if (!Number.isInteger(learnerSeat) || learnerSeat < 0 || learnerSeat > count) {
+    throw new Error(
+      `makeLeague: learnerSeat ${learnerSeat} out of range [0, ${count}] for count ${count}.`
+    );
+  }
   const baselineField = resolveBaselineField(baselineCsv, count);
 
   let decisiveGames = 0;
@@ -92,7 +106,7 @@ export function makeLeague({ baselineCsv, count, learnerSeat }) {
       void seed; // unused until B4 (empty-pool draw is deterministic); kept for API stability.
       return {
         opponents: baselineField,
-        drawn: baselineField.map((_, i) => ({ id: slotIds[i], kind: 'baseline', seat: seatOf(i) })),
+        drawn: baselineField.map((bot, i) => ({ id: bot.id, kind: 'baseline', seat: seatOf(i) })),
       };
     },
 

--- a/scripts/lib/ppo-league.mjs
+++ b/scripts/lib/ppo-league.mjs
@@ -2,12 +2,14 @@
  * PFSP opponent league for the PPO env-server (ml-bot Phase 3, task B — [D-22]).
  *
  * The env-server draws its per-episode opponent field from this league instead of a
- * static const. The league owns the opponent pool (built-in baselines + hot-loaded
- * self-play snapshots), a seeded sampler, and a per-opponent win-rate book.
+ * static const. The league will own the opponent pool (built-in baselines + hot-loaded
+ * self-play snapshots), a seeded sampler, and a per-opponent win-rate book — but step
+ * **B1** ships only the empty-pool baselines (no snapshots, sampler, or win-rate book yet).
  *
  * **Fixed-field (task A) is the empty-pool degenerate mode of this module:** with no
  * snapshots, `draw()` returns exactly the cycled baseline field the env-server used
- * before — byte-identical, so task A's outcomes reproduce. This file (step **B1**)
+ * before — content-identical (same names + fn refs), so task A's outcomes reproduce.
+ * This file (step **B1**)
  * ships that empty-pool path plus a decisive/truncated telemetry tally; the snapshot
  * pipeline (B3), PFSP weighting (B4), and persistence (B6) extend the same object.
  * See docs/ml-bot/DECISIONS.md D-22 for the full build sequence.
@@ -55,7 +57,7 @@ export function resolveBaselineField(idCsv, count) {
 /**
  * Construct a league. Step **B1** ships the empty-pool path (== task A's fixed field)
  * plus a decisive/truncated telemetry tally; later steps extend the returned object
- * (B3 `refresh`/`addSnapshot`, B4 PFSP `winRate` weighting, B6 `toJSON`/`restore`).
+ * (B3 `refresh`/`addSnapshot`, B4 PFSP `learnerWinRate` weighting, B6 `toJSON`/`restore`).
  *
  * @param {object} opts
  * @param {string} opts.baselineCsv the resolved `--opponents` CSV. The trainer passes
@@ -84,6 +86,13 @@ export function makeLeague({ baselineCsv, count, learnerSeat }) {
     );
   }
   const baselineField = resolveBaselineField(baselineCsv, count);
+  /*
+   * `draw()` hands out this same array reference every episode, so freeze it (and its entries):
+   * a future in-place reorder/mutation throws loudly under ESM strict mode instead of silently
+   * poisoning every later draw. Near-zero cost — the fns are shared from BUILT_IN_BOTS anyway.
+   */
+  baselineField.forEach(entry => Object.freeze(entry));
+  Object.freeze(baselineField);
 
   let decisiveGames = 0;
   let truncatedGames = 0;
@@ -91,7 +100,8 @@ export function makeLeague({ baselineCsv, count, learnerSeat }) {
   /*
    * Opponent-array index → seat: the learner sits at `learnerSeat`; opponents fill the remaining
    * seats in order (mirrors the seat-fill in ppo-env.mjs). Computed here so B2's win-rate
-   * attribution reads `drawn[k].seat` instead of reverse-engineering the `#N`-mangled roster names.
+   * attribution reads `drawn[k].seat` instead of reverse-engineering it from the `@i`-suffixed
+   * roster names (whose index is the opponent array slot, not the board seat).
    */
   const seatOf = k => (k < learnerSeat ? k : k + 1);
 
@@ -100,7 +110,7 @@ export function makeLeague({ baselineCsv, count, learnerSeat }) {
      * Draw the per-episode opponent field. B1: the pool is empty, so this is the cycled baseline
      * field — identical for every seed (the episode outcome depends on the ordered fns × the seed,
      * which the env-server passes to `runSelfPlayEpisode` separately). B4 adds snapshot seats
-     * sampled by `w(S) = max(ε, 1 - winRate(S))^k`, reserving R aggressive baselines per game.
+     * sampled by `w(S) = max(ε, 1 - learnerWinRate(S))^k`, reserving R aggressive baselines per game.
      */
     draw(seed) {
       void seed; // unused until B4 (empty-pool draw is deterministic); kept for API stability.

--- a/scripts/lib/ppo-league.mjs
+++ b/scripts/lib/ppo-league.mjs
@@ -1,0 +1,120 @@
+/**
+ * PFSP opponent league for the PPO env-server (ml-bot Phase 3, task B — [D-23]).
+ *
+ * The env-server draws its per-episode opponent field from this league instead of a
+ * static const. The league owns the opponent pool (built-in baselines + hot-loaded
+ * self-play snapshots), a seeded sampler, and a per-opponent win-rate book.
+ *
+ * **Fixed-field (task A) is the empty-pool degenerate mode of this module:** with no
+ * snapshots, `draw()` returns exactly the cycled baseline field the env-server used
+ * before — byte-identical, so task A's outcomes reproduce. This file (step **B1**)
+ * ships that empty-pool path plus a decisive/truncated telemetry tally; the snapshot
+ * pipeline (B3), PFSP weighting (B4), and persistence (B6) extend the same object.
+ * See docs/ml-bot/DECISIONS.md D-23 for the full build sequence.
+ *
+ * @module scripts/lib/ppo-league
+ */
+
+import { BUILT_IN_BOTS } from '../../src/arena/builtInBots.js';
+
+/** Split + trim the opponent id CSV, dropping blanks; throws if it resolves to nothing. */
+function parseIds(idCsv) {
+  const ids = idCsv
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+  if (ids.length === 0) throw new Error('--opponents resolved to an empty list.');
+  return ids;
+}
+
+/**
+ * Resolve `count` opponent entries from BUILT_IN_BOTS by cycling the id CSV — the EXACT
+ * field the env-server's old `resolveOpponents` produced (moved here verbatim so the
+ * empty-pool league reproduces task A's field; the B1 parity test pins this equivalence).
+ *
+ * @param {string} idCsv comma-separated built-in bot ids (e.g. "ai_lookahead,ai_bc")
+ * @param {number} count number of opponent seats to fill (= playerCount - 1)
+ * @returns {{name: string, fn: Function}[]} length `count`; the seat-cycle index is in the name (`@i`)
+ */
+export function resolveBaselineField(idCsv, count) {
+  const ids = parseIds(idCsv);
+  const byId = new Map(BUILT_IN_BOTS.map(b => [b.id, b]));
+  return Array.from({ length: count }, (_, i) => {
+    const id = ids[i % ids.length];
+    const bot = byId.get(id);
+    if (!bot) {
+      throw new Error(`Unknown opponent bot id "${id}". Known: ${[...byId.keys()].join(', ')}.`);
+    }
+    return { name: `${bot.name}@${i}`, fn: bot.fn };
+  });
+}
+
+/**
+ * Construct a league. Step **B1** ships the empty-pool path (== task A's fixed field)
+ * plus a decisive/truncated telemetry tally; later steps extend the returned object
+ * (B3 `refresh`/`addSnapshot`, B4 PFSP `winRate` weighting, B6 `toJSON`/`restore`).
+ *
+ * @param {object} opts
+ * @param {string} opts.baselineCsv the resolved `--opponents` CSV. The trainer passes
+ *   `DEFAULT_OPPONENTS`; the env-server's own default is `ai_bc`. Threaded in (NOT a
+ *   hardcoded default) so the empty-pool field equals the launch's actual field _[D-23]_.
+ * @param {number} opts.count opponent seats per game (= playerCount - 1); `draw()` always
+ *   returns exactly this many (holds player_count constant, [D-22]).
+ * @param {number} opts.learnerSeat the learner's seat; used to map an opponent's array
+ *   index to its seat for the (B2) win-rate attribution.
+ * @returns {{draw: Function, recordResult: Function, stats: Function}}
+ */
+export function makeLeague({ baselineCsv, count, learnerSeat }) {
+  const slotIds = (() => {
+    const ids = parseIds(baselineCsv);
+    return Array.from({ length: count }, (_, i) => ids[i % ids.length]);
+  })();
+  const baselineField = resolveBaselineField(baselineCsv, count);
+
+  let decisiveGames = 0;
+  let truncatedGames = 0;
+
+  /*
+   * Opponent-array index → seat: the learner sits at `learnerSeat`; opponents fill the remaining
+   * seats in order (mirrors the seat-fill in ppo-env.mjs). Computed here so B2's win-rate
+   * attribution reads `drawn[k].seat` instead of reverse-engineering the `#N`-mangled roster names.
+   */
+  const seatOf = k => (k < learnerSeat ? k : k + 1);
+
+  return {
+    /*
+     * Draw the per-episode opponent field. B1: the pool is empty, so this is the cycled baseline
+     * field — identical for every seed (the episode outcome depends on the ordered fns × the seed,
+     * which the env-server passes to `runSelfPlayEpisode` separately). B4 adds snapshot seats
+     * sampled by `w(S) = max(ε, 1 - winRate(S))^k`, reserving R aggressive baselines per game.
+     */
+    draw(seed) {
+      void seed; // unused until B4 (empty-pool draw is deterministic); kept for API stability.
+      return {
+        opponents: baselineField,
+        drawn: baselineField.map((_, i) => ({ id: slotIds[i], kind: 'baseline', seat: seatOf(i) })),
+      };
+    },
+
+    /*
+     * Tally the episode outcome. B1: telemetry only — count decisive vs maxTurns-truncated games
+     * (the [D-22] decisive-rate health metric). B2 adds per-opponent pairwise win-rate attribution
+     * via a per-seat `seatBeat[]` vector keyed on `drawn[k].id`, EXCLUDING truncations.
+     */
+    recordResult(drawn, result) {
+      if (result.truncated) truncatedGames++;
+      else decisiveGames++;
+    },
+
+    /** League health snapshot (the throughput/decisive-rate re-probe in B5 reads this). */
+    stats() {
+      const total = decisiveGames + truncatedGames;
+      return {
+        poolSize: 0,
+        decisiveGames,
+        truncatedGames,
+        decisiveRate: total > 0 ? decisiveGames / total : 0,
+      };
+    },
+  };
+}

--- a/scripts/ppo-env-server.mjs
+++ b/scripts/ppo-env-server.mjs
@@ -33,12 +33,12 @@
 
 import { Worker } from 'node:worker_threads';
 
-import { BUILT_IN_BOTS } from '../src/arena/builtInBots.js';
 import { createBotState } from '../src/arena/botState.js';
 import { encodeObservationForInference } from '../src/arena/encodeObservation.js';
 import { BC_POLICY } from '../src/ai/bcPolicyWeights.js';
 
 import { runSelfPlayEpisode } from './lib/ppo-env.mjs';
+import { makeLeague } from './lib/ppo-league.mjs';
 import { buildObsFrame, serializeObsFrame } from './lib/obs-frame.mjs';
 
 const STATUS = 0;
@@ -83,24 +83,6 @@ function numArg(opts, key, fallback) {
   return v;
 }
 
-/** Resolve `count` opponent bot fns from BUILT_IN_BOTS, cycling the id list to fill. */
-function resolveOpponents(idCsv, count) {
-  const ids = idCsv
-    .split(',')
-    .map(s => s.trim())
-    .filter(Boolean);
-  if (ids.length === 0) throw new Error('--opponents resolved to an empty list.');
-  const byId = new Map(BUILT_IN_BOTS.map(b => [b.id, b]));
-  return Array.from({ length: count }, (_, i) => {
-    const id = ids[i % ids.length];
-    const bot = byId.get(id);
-    if (!bot) {
-      throw new Error(`Unknown opponent bot id "${id}". Known: ${[...byId.keys()].join(', ')}.`);
-    }
-    return { name: `${bot.name}@${i}`, fn: bot.fn };
-  });
-}
-
 /** A fresh standalone ArrayBuffer holding exactly the frame's bytes (safe to clone). */
 function frameToArrayBuffer(buf) {
   return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
@@ -124,7 +106,17 @@ async function main() {
   const seedBase = numArg(opts, 'seed-base', 1);
   // Per-decision watchdog deadline (ms). Generous — inference is sub-second; 0 disables it.
   const decisionTimeoutMs = numArg(opts, 'decision-timeout-ms', 120000);
-  const opponents = resolveOpponents(opts.opponents ?? 'ai_bc', playerCount - 1);
+  /*
+   * The opponent league (ml-bot task B — [D-23]). B1: the pool is empty, so every `draw()` returns
+   * the cycled baseline field — byte-identical to the static field task A trained on (the env-server
+   * default is the single bot `ai_bc`; the trainer passes the full `--opponents` CSV). Snapshots
+   * (B3) and PFSP weighting (B4) extend the same league; fixed-field is its empty-pool mode.
+   */
+  const league = makeLeague({
+    baselineCsv: opts.opponents ?? 'ai_bc',
+    count: playerCount - 1,
+    learnerSeat,
+  });
 
   const sab = new SharedArrayBuffer(8); // 2 × Int32
   const ctrl = new Int32Array(sab);
@@ -269,6 +261,8 @@ async function main() {
       if (closed || lostError) break;
       const seed = seedBase + ep;
       decisionsThisEpisode = 0;
+      // Draw this episode's opponent field from the league (B1: the empty-pool baseline field).
+      const { opponents, drawn } = league.draw(seed);
       let result;
       try {
         result = runSelfPlayEpisode({
@@ -310,6 +304,12 @@ async function main() {
         continue;
       }
       consecutiveZeroDecision = 0;
+
+      /*
+       * Tally the decisive episode into the league (B1: decisive/truncated counters; B2 adds
+       * per-opponent win-rate attribution). Zero-decision skips above are intentionally not counted.
+       */
+      league.recordResult(drawn, result);
 
       /*
        * Terminal frame: the learner's view of the board at the episode terminal (its elimination,

--- a/scripts/ppo-env-server.mjs
+++ b/scripts/ppo-env-server.mjs
@@ -107,7 +107,7 @@ async function main() {
   // Per-decision watchdog deadline (ms). Generous — inference is sub-second; 0 disables it.
   const decisionTimeoutMs = numArg(opts, 'decision-timeout-ms', 120000);
   /*
-   * The opponent league (ml-bot task B — [D-23]). B1: the pool is empty, so every `draw()` returns
+   * The opponent league (ml-bot task B — [D-22]). B1: the pool is empty, so every `draw()` returns
    * the cycled baseline field — byte-identical to the static field task A trained on (the env-server
    * default is the single bot `ai_bc`; the trainer passes the full `--opponents` CSV). Snapshots
    * (B3) and PFSP weighting (B4) extend the same league; fixed-field is its empty-pool mode.

--- a/scripts/ppo-env-server.mjs
+++ b/scripts/ppo-env-server.mjs
@@ -108,7 +108,7 @@ async function main() {
   const decisionTimeoutMs = numArg(opts, 'decision-timeout-ms', 120000);
   /*
    * The opponent league (ml-bot task B — [D-22]). B1: the pool is empty, so every `draw()` returns
-   * the cycled baseline field — byte-identical to the static field task A trained on (the env-server
+   * the cycled baseline field — content-identical to the static field task A trained on (the env-server
    * default is the single bot `ai_bc`; the trainer passes the full `--opponents` CSV). Snapshots
    * (B3) and PFSP weighting (B4) extend the same league; fixed-field is its empty-pool mode.
    */

--- a/tests/ml/ppo-league.test.js
+++ b/tests/ml/ppo-league.test.js
@@ -1,0 +1,126 @@
+/**
+ * PFSP opponent league — empty-pool parity (ml-bot Phase 3, task B step B1 — [D-23]).
+ *
+ * The league replaces the env-server's static opponent const with a per-episode
+ * `league.draw(seed)`. The load-bearing B1 guarantee is that **the empty-pool field
+ * is byte-identical to the fixed field task A trained on** (`resolveBaselineField`,
+ * the verbatim-moved `resolveOpponents`) — so turning the league on changes nothing
+ * until snapshots (B3) actually enter the pool. These tests pin that equivalence, the
+ * player-count-constant contract, seed-invariance, and the decisive/truncated tally.
+ */
+
+import { makeLeague, resolveBaselineField } from '../../scripts/lib/ppo-league.mjs';
+
+const DEFAULT_OPPONENTS = 'ai_lookahead,ai_strategist,ai_expectimax,ai_bc,ai_defensive';
+const COUNT = 6; // playerCount 7 − 1 (the env-server default)
+
+/** Compare two opponent fields by name + fn reference (fns come from the same BUILT_IN_BOTS). */
+function expectSameField(a, b) {
+  expect(a.map(o => o.name)).toEqual(b.map(o => o.name));
+  expect(a.length).toBe(b.length);
+  a.forEach((o, i) => expect(o.fn).toBe(b[i].fn));
+}
+
+describe('ppo-league — empty-pool field == task A (B1)', () => {
+  it('draw() reproduces resolveBaselineField for the DEFAULT_OPPONENTS field', () => {
+    const league = makeLeague({ baselineCsv: DEFAULT_OPPONENTS, count: COUNT, learnerSeat: 0 });
+    const ref = resolveBaselineField(DEFAULT_OPPONENTS, COUNT);
+    expectSameField(league.draw(1).opponents, ref);
+  });
+
+  it('draw() reproduces the env-server bare default (single bot `ai_bc`, cycled)', () => {
+    const league = makeLeague({ baselineCsv: 'ai_bc', count: COUNT, learnerSeat: 0 });
+    const ref = resolveBaselineField('ai_bc', COUNT);
+    expectSameField(league.draw(1).opponents, ref);
+    // Cycled single bot ⇒ every seat is the same fn, named ai_bc@0..@5.
+    expect(league.draw(1).opponents.map(o => o.name)).toEqual([
+      'BC@0',
+      'BC@1',
+      'BC@2',
+      'BC@3',
+      'BC@4',
+      'BC@5',
+    ]);
+  });
+
+  it('always returns exactly `count` opponents (holds player_count constant)', () => {
+    for (const count of [3, 6, 7]) {
+      const league = makeLeague({ baselineCsv: DEFAULT_OPPONENTS, count, learnerSeat: 0 });
+      expect(league.draw(42).opponents).toHaveLength(count);
+      expect(league.draw(42).drawn).toHaveLength(count);
+    }
+  });
+
+  it('empty-pool field is seed-invariant (no sampling until B4)', () => {
+    const league = makeLeague({ baselineCsv: DEFAULT_OPPONENTS, count: COUNT, learnerSeat: 0 });
+    expectSameField(league.draw(1).opponents, league.draw(999_999).opponents);
+  });
+
+  it('names use the seat-cycle index `@i`, not the seat', () => {
+    const league = makeLeague({ baselineCsv: DEFAULT_OPPONENTS, count: COUNT, learnerSeat: 0 });
+    const names = league.draw(0).opponents.map(o => o.name);
+    // 5 ids cycled over 6 slots ⇒ ai_lookahead reappears at slot 5.
+    expect(names[0]).toMatch(/@0$/);
+    expect(names[5]).toMatch(/@5$/);
+    expect(names[5].replace(/@\d+$/, '')).toBe(names[0].replace(/@\d+$/, ''));
+  });
+});
+
+describe('ppo-league — drawn seat attribution metadata (B2-ready)', () => {
+  it('maps opponent array index → seat around learnerSeat=0', () => {
+    const league = makeLeague({ baselineCsv: DEFAULT_OPPONENTS, count: COUNT, learnerSeat: 0 });
+    expect(league.draw(0).drawn.map(d => d.seat)).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  it('skips the learner seat when learnerSeat is interior', () => {
+    const league = makeLeague({ baselineCsv: DEFAULT_OPPONENTS, count: COUNT, learnerSeat: 3 });
+    expect(league.draw(0).drawn.map(d => d.seat)).toEqual([0, 1, 2, 4, 5, 6]);
+  });
+
+  it('tags every drawn entry as a baseline with its stable bot id', () => {
+    const league = makeLeague({ baselineCsv: DEFAULT_OPPONENTS, count: COUNT, learnerSeat: 0 });
+    const drawn = league.draw(0).drawn;
+    expect(drawn.every(d => d.kind === 'baseline')).toBe(true);
+    expect(drawn.map(d => d.id)).toEqual([
+      'ai_lookahead',
+      'ai_strategist',
+      'ai_expectimax',
+      'ai_bc',
+      'ai_defensive',
+      'ai_lookahead', // cycled
+    ]);
+  });
+});
+
+describe('ppo-league — telemetry tally (B1)', () => {
+  it('counts decisive vs maxTurns-truncated games and reports decisive-rate', () => {
+    const league = makeLeague({ baselineCsv: DEFAULT_OPPONENTS, count: COUNT, learnerSeat: 0 });
+    const { drawn } = league.draw(0);
+    league.recordResult(drawn, { truncated: false });
+    league.recordResult(drawn, { truncated: false });
+    league.recordResult(drawn, { truncated: false });
+    league.recordResult(drawn, { truncated: true });
+    const s = league.stats();
+    expect(s.decisiveGames).toBe(3);
+    expect(s.truncatedGames).toBe(1);
+    expect(s.decisiveRate).toBeCloseTo(0.75, 10);
+    expect(s.poolSize).toBe(0);
+  });
+
+  it('decisiveRate is 0 before any game is recorded', () => {
+    const league = makeLeague({ baselineCsv: DEFAULT_OPPONENTS, count: COUNT, learnerSeat: 0 });
+    expect(league.stats().decisiveRate).toBe(0);
+  });
+});
+
+describe('ppo-league — error handling', () => {
+  it('throws on an empty opponents CSV', () => {
+    expect(() => makeLeague({ baselineCsv: '  ,  ', count: COUNT, learnerSeat: 0 })).toThrow(
+      /empty list/
+    );
+  });
+
+  it('throws on an unknown bot id', () => {
+    expect(() => resolveBaselineField('ai_not_a_bot', COUNT)).toThrow(/Unknown opponent bot id/);
+  });
+});

--- a/tests/ml/ppo-league.test.js
+++ b/tests/ml/ppo-league.test.js
@@ -1,5 +1,5 @@
 /**
- * PFSP opponent league — empty-pool parity (ml-bot Phase 3, task B step B1 — [D-23]).
+ * PFSP opponent league — empty-pool parity (ml-bot Phase 3, task B step B1 — [D-22]).
  *
  * The league replaces the env-server's static opponent const with a per-episode
  * `league.draw(seed)`. The load-bearing B1 guarantee is that **the empty-pool field
@@ -90,6 +90,28 @@ describe('ppo-league — drawn seat attribution metadata (B2-ready)', () => {
       'ai_lookahead', // cycled
     ]);
   });
+
+  it('sources drawn[i].id from the opponent field itself (single source of truth)', () => {
+    /*
+     * resolveBaselineField surfaces `id` on each entry; draw() keys `drawn[i].id` off that same
+     * field rather than re-deriving the cycle — so the id↔fn correspondence can never drift.
+     */
+    const ref = resolveBaselineField(DEFAULT_OPPONENTS, COUNT);
+    expect(ref.map(o => o.id)).toEqual([
+      'ai_lookahead',
+      'ai_strategist',
+      'ai_expectimax',
+      'ai_bc',
+      'ai_defensive',
+      'ai_lookahead',
+    ]);
+    const { opponents, drawn } = makeLeague({
+      baselineCsv: DEFAULT_OPPONENTS,
+      count: COUNT,
+      learnerSeat: 0,
+    }).draw(0);
+    drawn.forEach((d, i) => expect(d.id).toBe(opponents[i].id));
+  });
 });
 
 describe('ppo-league — telemetry tally (B1)', () => {
@@ -122,5 +144,31 @@ describe('ppo-league — error handling', () => {
 
   it('throws on an unknown bot id', () => {
     expect(() => resolveBaselineField('ai_not_a_bot', COUNT)).toThrow(/Unknown opponent bot id/);
+  });
+});
+
+describe('ppo-league — construction validation', () => {
+  it('rejects a learnerSeat outside [0, count]', () => {
+    for (const learnerSeat of [-1, COUNT + 1, 99]) {
+      expect(() =>
+        makeLeague({ baselineCsv: DEFAULT_OPPONENTS, count: COUNT, learnerSeat })
+      ).toThrow(/learnerSeat .* out of range/);
+    }
+  });
+
+  it('accepts the boundary learner seats 0 and count (learner first / last)', () => {
+    for (const learnerSeat of [0, COUNT]) {
+      expect(() =>
+        makeLeague({ baselineCsv: DEFAULT_OPPONENTS, count: COUNT, learnerSeat })
+      ).not.toThrow();
+    }
+  });
+
+  it('rejects a non-positive or fractional count', () => {
+    for (const count of [0, -1, 6.5]) {
+      expect(() => makeLeague({ baselineCsv: DEFAULT_OPPONENTS, count, learnerSeat: 0 })).toThrow(
+        /count must be a positive integer/
+      );
+    }
   });
 });

--- a/tests/ml/ppo-league.test.js
+++ b/tests/ml/ppo-league.test.js
@@ -26,6 +26,20 @@ describe('ppo-league — empty-pool field == task A (B1)', () => {
     const league = makeLeague({ baselineCsv: DEFAULT_OPPONENTS, count: COUNT, learnerSeat: 0 });
     const ref = resolveBaselineField(DEFAULT_OPPONENTS, COUNT);
     expectSameField(league.draw(1).opponents, ref);
+    /*
+     * External golden: pin the exact field names independently of the producer. `expectSameField`
+     * compares draw() against resolveBaselineField, but makeLeague builds the field BY calling
+     * resolveBaselineField — so a future change to its naming would move both sides together and
+     * slip through. This anchors the actual task-A field (the load-bearing parity claim).
+     */
+    expect(league.draw(1).opponents.map(o => o.name)).toEqual([
+      'Lookahead@0',
+      'Strategist@1',
+      'Expectimax@2',
+      'BC@3',
+      'Defensive@4',
+      'Lookahead@5', // 5 ids cycled over 6 slots
+    ]);
   });
 
   it('draw() reproduces the env-server bare default (single bot `ai_bc`, cycled)', () => {
@@ -54,6 +68,18 @@ describe('ppo-league — empty-pool field == task A (B1)', () => {
   it('empty-pool field is seed-invariant (no sampling until B4)', () => {
     const league = makeLeague({ baselineCsv: DEFAULT_OPPONENTS, count: COUNT, learnerSeat: 0 });
     expectSameField(league.draw(1).opponents, league.draw(999_999).opponents);
+  });
+
+  it('returns a frozen field (in-place mutation throws, not silently corrupts later draws)', () => {
+    const league = makeLeague({ baselineCsv: DEFAULT_OPPONENTS, count: COUNT, learnerSeat: 0 });
+    const { opponents } = league.draw(1);
+    expect(Object.isFrozen(opponents)).toBe(true);
+    expect(Object.isFrozen(opponents[0])).toBe(true);
+    expect(() => {
+      opponents[0].name = 'tampered';
+    }).toThrow(TypeError);
+    // A later draw still sees the original, untampered field.
+    expect(league.draw(2).opponents[0].name).toBe('Lookahead@0');
   });
 
   it('names use the seat-cycle index `@i`, not the seat', () => {


### PR DESCRIPTION
First increment of **task B** (the PFSP opponent league, scoped in [D-22]). Replaces the env-server's static opponent const with a per-episode `league.draw(seed)`.

## What B1 does

The whole league is one seam: `scripts/ppo-env-server.mjs` now draws its opponent field from a league object instead of a fixed const. **B1 ships only the empty-pool path — which is byte-identical to the fixed field task A trained on** — so this changes *nothing behaviorally* until snapshots actually enter the pool (B3). It's a behavior-preserving refactor + scaffold.

- **`scripts/lib/ppo-league.mjs` (new)** — `resolveBaselineField` (the old `resolveOpponents`, moved verbatim + exported so it's testable) + `makeLeague({baselineCsv, count, learnerSeat})` returning `draw(seed)` / `recordResult(drawn, result)` / `stats()`.
  - `draw(seed)` empty-pool → the cycled baseline field (+ `drawn[]` seat-attribution metadata for B2). Seed-invariant until B4's sampler.
  - `recordResult` → decisive/truncated tally (the [D-22] decisive-rate health metric); B2 adds per-opponent win-rate attribution.
- **`scripts/ppo-env-server.mjs`** — construct the league once, draw the field per episode, record each decisive episode; drop the inlined `resolveOpponents` + the now-unused `BUILT_IN_BOTS` import.
- **`tests/ml/ppo-league.test.js` (new, 12 tests)** — the **acceptance criterion**: empty-pool `draw()` == `resolveBaselineField` for the `DEFAULT_OPPONENTS` field and the bare `ai_bc` default; player-count-constant; seed-invariance; `@i` naming; seat attribution around the learner; telemetry; error paths.

## Validation

- Full suite **1018 green** (incl. the 12 new tests + the existing `ppo-env` env-core oracle, unaffected); lint clean.
- Branched off `master` (which now includes #62, the zero-decision desync fix — task B's B0 prerequisite).

## Next (D-22 build sequence)

B2 per-seat `seatBeat[]` + win-rate book → B3 snapshot pipeline (SB3 callback → atomic manifest → Node hot-load) → B4 PFSP weighting → B5 throughput re-probe → B6 persistence + `SharedDiskStore`.