### PR TITLE
feat(ml): PPO league task B — B2 win-rate book + B3 snapshot pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,17 @@ jobs:
       - name: Run benchmarks
         run: npm run test:benchmark
 
+      # PPO env-server transport smokes (ml-bot Phase 3). Each forks the Node env-server
+      # + a live socket — pure Node, no Python/torch — so they belong here (the Python
+      # `ML CI` job has no `node`). Fast + deterministic; bash errexit fails the step on
+      # the first non-zero exit. booking-smoke guards the B2 "book before the zero-decision
+      # wire gate" reordering, which no vitest test covers (the book is internal Node state).
+      - name: PPO env-server smoke checks
+        run: |
+          npm run ppo:env-smoke
+          npm run ppo:disconnect-smoke
+          npm run ppo:booking-smoke
+
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:

--- a/docs/ml-bot/DECISIONS.md
+++ b/docs/ml-bot/DECISIONS.md
@@ -1293,7 +1293,16 @@ mode-agnostic; C is where cross-worker aggregation becomes load-bearing (intertw
 backend). Task D (reward shaping) — orthogonal (env-side JS reward). Task E (`SubprocVecEnv` +
 checkpoint/resume) — must persist the league pool + book + counters (B6).
 
-**Status: Proposed.** Implementation pending Ivan's go + the PR #62 merge.
+**Status: In progress (B0–B3 shipped 2026-06-27).** B0 (PR #62 merged) · B1 (PR #64, empty-pool
+parity) · B2 (per-seat `seatBeat[]` + win-rate book) · B3 (snapshot pipeline:
+`ml/dicewars_ppo/snapshot_callback.py` + league `refresh()` + the `--snapshot-*` flags). **B3
+deviations from this scope:** (a) `--snapshot-store` deferred to B6 with `SharedDiskStore` rather than
+shipping a dead flag now; (b) `--snapshot-pool-cap` added and forwarded through `EnvServerProcess`
+(the pool cap is the consumer-side setting that must reach the Node league — D-23's literal list only
+named `snapshot_manifest`/`snapshot_store`); (c) the producer `manifest.json` is append-only (entries
+are tiny; prune in B5/B6 if it matters); (d) `draw()` does NOT sample the pool until B4, so B3 is
+behavior-preserving. The Python producer is validated by `py_compile` + a monkeypatched pytest (no
+local torch/sb3); it gets its first live exercise on shodan at B4. **Next: B4** (PFSP weighting on).
 
 **Grounding.** 9-agent scoping workflow (4 code-readers mapping env-server / training-snapshot /
 match-stats / locked-decisions → 3 design decisions → synthesize + adversarial verify). One design

--- a/docs/ml-bot/DECISIONS.md
+++ b/docs/ml-bot/DECISIONS.md
@@ -1248,8 +1248,9 @@ snapshots _unloadable_, not gracefully degraded). **Stats locality (chosen): shi
 `store` now, default `InMemoryStore` (per-worker); land `SharedDiskStore` with Task E** when
 `SubprocVecEnv` makes per-worker books noisy ([D-22] leans shared-disk-global; the interface makes it
 a one-line swap). **Disk retention: GC the evicted snapshots' `.js` files** — `poolCap` bounds the
-in-memory pool only, and the mandatory fresh-filename guarantees unbounded disk growth otherwise
-_[verifier correction]._
+live (sampleable) pool and, via the GC, disk; it does NOT bound process memory (Node's ESM registry
+retains every dynamic-`import()`ed snapshot module for the run), and the mandatory fresh-filename
+guarantees unbounded disk growth without the GC _[verifier correction; memory caveat added post-review]._
 
 **Sampler params (chosen defaults — all CLI knobs).** `w(S)=max(ε,1−winRate(S))^k`; `ε=0.05`, `k=2`,
 `poolCap=40` (FIFO-by-step eviction — keeps the most recent/hardest snapshots; FIFO avoids the

--- a/docs/ml-bot/LOG.md
+++ b/docs/ml-bot/LOG.md
@@ -33,9 +33,10 @@ unchanged — B3 only _loads_ snapshots; B4 samples them, so episode outcomes ar
   diffs by stable id, dynamic-`import()`s each new snapshot's `.weights.js` (fresh filename → ESM URL
   cache never serves a stale module), wraps it with `makeBC({ policy })`, FIFO-evicts past `poolCap`,
   and GCs the evicted `.js`. An evicted id stays in `loadedIds` so it is never re-imported from its
-  deleted file. `makeBC`/`ENCODING_VERSION` are dynamic-imported in `refresh()` for code locality
-  only — they defer no load cost (the ~2 MB `bcPolicyWeights.js` is already pulled in eagerly via the
-  top-level `BUILT_IN_BOTS` import → `ai_bc.js`; corrected post-review). `stats()` now reports real `poolSize` +
+  deleted file. `makeBC`/`ENCODING_VERSION` are top-level static imports with no extra load cost (the
+  ~2 MB `bcPolicyWeights.js` `makeBC` pulls in is already loaded eagerly via the top-level
+  `BUILT_IN_BOTS` import → `ai_bc.js`; the per-snapshot `.weights.js` load stays a dynamic `import()`
+  since its filename is runtime-generated — both corrected/simplified post-review). `stats()` now reports real `poolSize` +
   `loadedSnapshots`. Env-server: `--snapshot-manifest`/`--snapshot-pool-cap` flags + `await
 league.refresh()` at each episode boundary (a one-`statSync` no-op without a manifest; an
   encoding-version skew throws and stops the run — the frozen-`ENCODING_VERSION` invariant).

--- a/docs/ml-bot/LOG.md
+++ b/docs/ml-bot/LOG.md
@@ -33,8 +33,9 @@ unchanged — B3 only _loads_ snapshots; B4 samples them, so episode outcomes ar
   diffs by stable id, dynamic-`import()`s each new snapshot's `.weights.js` (fresh filename → ESM URL
   cache never serves a stale module), wraps it with `makeBC({ policy })`, FIFO-evicts past `poolCap`,
   and GCs the evicted `.js`. An evicted id stays in `loadedIds` so it is never re-imported from its
-  deleted file. `makeBC`/`ENCODING_VERSION` are lazy-imported (only when a manifest exists) so the
-  B1/B2 fast unit tests never pay the ~2 MB ai_bc load. `stats()` now reports real `poolSize` +
+  deleted file. `makeBC`/`ENCODING_VERSION` are dynamic-imported in `refresh()` for code locality
+  only — they defer no load cost (the ~2 MB `bcPolicyWeights.js` is already pulled in eagerly via the
+  top-level `BUILT_IN_BOTS` import → `ai_bc.js`; corrected post-review). `stats()` now reports real `poolSize` +
   `loadedSnapshots`. Env-server: `--snapshot-manifest`/`--snapshot-pool-cap` flags + `await
 league.refresh()` at each episode boundary (a one-`statSync` no-op without a manifest; an
   encoding-version skew throws and stops the run — the frozen-`ENCODING_VERSION` invariant).

--- a/docs/ml-bot/LOG.md
+++ b/docs/ml-bot/LOG.md
@@ -21,6 +21,113 @@ Entry template:
 
 ---
 
+## 2026-06-27 — Task B step B3: the snapshot pipeline (Python producer → Node hot-load)
+
+**Phase:** 3 · **Who:** Ivan + Claude
+
+**Did:** Built the full PFSP snapshot pipeline end-to-end (producer + consumer), keeping `draw()`
+unchanged — B3 only _loads_ snapshots; B4 samples them, so episode outcomes are still the fixed field.
+
+- **Consumer (Node, fully tested locally).** `scripts/lib/ppo-league.mjs` gained `snapshotManifest` +
+  `poolCap` and an async `refresh()`: an mtime-guarded poll of the producer `manifest.json` that
+  diffs by stable id, dynamic-`import()`s each new snapshot's `.weights.js` (fresh filename → ESM URL
+  cache never serves a stale module), wraps it with `makeBC({ policy })`, FIFO-evicts past `poolCap`,
+  and GCs the evicted `.js`. An evicted id stays in `loadedIds` so it is never re-imported from its
+  deleted file. `makeBC`/`ENCODING_VERSION` are lazy-imported (only when a manifest exists) so the
+  B1/B2 fast unit tests never pay the ~2 MB ai_bc load. `stats()` now reports real `poolSize` +
+  `loadedSnapshots`. Env-server: `--snapshot-manifest`/`--snapshot-pool-cap` flags + `await
+league.refresh()` at each episode boundary (a one-`statSync` no-op without a manifest; an
+  encoding-version skew throws and stops the run — the frozen-`ENCODING_VERSION` invariant).
+- **Producer (Python).** NEW `ml/dicewars_ppo/snapshot_callback.py` — `SnapshotCallback(BaseCallback)`
+  publishes every `--snapshot-every` env steps: `repack_to_bc_checkpoint` → temp `.pt` →
+  `export(…, fixture_path=None)` (the exact gate-proven path, no per-snapshot fixture) → fsync the
+  weights → atomic `manifest.json` via temp + `os.replace`. `train_tracer.py` got
+  `--snapshot-dir`/`-every`/`-pool-cap` (absolutized so producer & consumers agree on the path) and
+  attaches the callback; `EnvServerProcess.__init__` forwards `snapshot_manifest`/`snapshot_pool_cap`
+  into the server argv (`env.py` already splats `server_kwargs`).
+- **Tests.** NEW `tests/ml/ppo-league-snapshots.test.js` (11): no-op/empty-pool, incremental
+  diff-by-id, mtime short-circuit, FIFO eviction + disk GC, the `loadedIds`-vs-deleted-file guard, and
+  the encoding-version fail-loud (manifest-level + per-snapshot). NEW `ml/tests/test_snapshot_callback.py`
+  (5): cadence, atomic manifest schema (mirrors the JS consumer), publish orchestration (monkeypatched
+  repack/export), append order. `tests/ml/` 89 green; JS lint/prettier clean; Python `py_compile` OK.
+
+**Learned / decided:**
+
+- Clean B3↔B4 seam: **load in B3, sample in B4.** Snapshots enter the pool but `draw()` ignores them,
+  so B3 is behavior-preserving and independently testable (pool grows; the drawn field is byte-identical).
+- The snapshot manifest is a NEW file distinct from the BC-corpus `manifest.py` — same name, different
+  dir + schema (`{encodingVersion, snapshots:[{id,step,weights,createdAt}], latestStep}`).
+- **Deviations from [D-23]** (folded into PLAN/D-23): `--snapshot-store` deferred to B6 with
+  `SharedDiskStore` (no dead flag now); `--snapshot-pool-cap` added/forwarded (the cap is a consumer
+  setting that genuinely needs to reach Node); producer manifest is append-only (tiny entries).
+
+**Dead ends / surprises:**
+
+- **No local Python env** (no torch/sb3 on this Mac), so the producer is validated by `py_compile` +
+  its monkeypatched pytest, which must run on **shodan / CI** — not locally. The `repack→export` step
+  it wraps is already gate-proven (PR #61), so the untested-locally surface is only the new
+  orchestration (atomic manifest + cadence), which the pytest covers.
+
+**Next:**
+
+- **B4** — turn PFSP weighting on in `draw()`: sample the pool by `w(S)=max(ε,1−winRate(S))^k`, reserve
+  R=3 aggressive baselines, seeded `mulberry32(seedBase+ep)`, empty-pool fallback. **First step the
+  league must run on shodan with Python** (the producer publishing into a live consumer pool) — the B3
+  Python side gets its first real exercise there.
+
+---
+
+## 2026-06-27 — Task B step B2: per-seat `seatBeat[]` + the id-keyed win-rate book
+
+**Phase:** 3 · **Who:** Ivan + Claude
+
+**Did:**
+
+- **Reviewed the post-review hardening that landed on the merged PRs.** PR #63 (weights + docs) and
+  PR #64 (B1) are both merged. #64 carried two Ivan-authored hardening commits on top of my B1:
+  `1fda04c` (validate `count`/`learnerSeat` at `makeLeague`; fold the stable `id` into the resolved
+  field → single source of truth; correct dangling `[D-23]`→`[D-22]` citations) and `10f2aaa`
+  (`Object.freeze` the empty-pool field + entries; external name golden; comment accuracy). All sound;
+  the `id`-on-field change directly feeds B2's `recordResult` keying.
+- **Implemented B2 — the [D-22] "real work item" (pairwise win-rate attribution).**
+  - `scripts/lib/ppo-env.mjs`: added a per-board-seat `seatBeat[]` vector to **both** outcome shapers.
+    `summarizeOutcome` derives it from the final placement order (`seatBeatFromPlacements`);
+    `eliminationOutcome` synthesizes it at the learner's death from alive / prior-elim / same-turn
+    co-elim, threading a `coElimSeats` **Set** out of `guardedOnTurn` (replacing the old scalar
+    `coElimAbove` count, which is now derived from the set) — so the ~2× early-termination throughput
+    is preserved with no full `placements` build.
+  - `scripts/lib/ppo-league.mjs`: added the id-keyed win-rate book (`Map<id,{wins,games}>`).
+    `recordResult` now credits `book[id].wins += seatBeat[seat]` per drawn opponent (excluding
+    `maxTurns` truncations); new `winRate(id)` returns `wins/games`, **0 on cold-start** (→ max PFSP
+    weight, [D-23]); `stats()` gains `bookSize`. A cycled baseline seated twice yields two independent
+    records — verified.
+  - `scripts/ppo-env-server.mjs`: moved `league.recordResult(drawn, result)` **above** the wire
+    zero-decision gate so a zero-decision episode (a real decisive loss) **is** booked — Ivan's call on
+    [D-23] open-Q2 (the wire-skip is a frame concern; the Node-side league is orthogonal).
+- **Tests.** Threaded a `seatBeat` oracle (independent reimpl) into the existing full-vs-early fixtures
+  in `ppo-env.test.js` — both shapers validated against the engine's placement order across a plain
+  mid-game elimination, the three co-elimination tie-break seeds, a runner-up, a learner win, and the
+  zero-decision seed — **zero extra match runs**. Added 7 win-rate-book tests to `ppo-league.test.js`
+  (pairwise crediting, cycled-baseline double-record, interior-learner board-seat indexing, accrual,
+  truncation exclusion, cold-start, no-seatBeat defensive). `tests/ml/` 78 green; lint clean.
+
+**Learned / decided:**
+
+- `placements` is a **best-first ordered list of seat ids** (rank = `indexOf`), so "learner beat seat
+  s" = `rank[learnerSeat] < rank[s]` — strict, no ties. The early path reproduces this exactly via the
+  `runMatch` ascending-seat-id / `calculatePlacements`-reversal tie-break, which the existing
+  co-elimination fixtures already pin — they doubled as the B2 attribution oracle.
+- Booking zero-decision episodes keeps the win-rate honest about fast-crushing fields (what PFSP wants)
+  without touching the wire contract — the two concerns are cleanly separable.
+
+**Next:**
+
+- **B3** — the snapshot pipeline (Python SB3 `SnapshotCallback` → `repack` → `export(…,
+fixture_path=None)` → atomic manifest → Node `refresh()` hot-load via `makeBC`, fresh filename). B0's
+  deferred `snapshot-manifest`/`-store` CLI flags + the `ENCODING_VERSION=2` freeze doc land here too.
+
+---
+
 ## 2026-06-27 — Task A PASSED: fixed-field 1M PPO BEATS the gate (Δ +33.4)
 
 **Phase:** 3 · **Who:** Ivan + Claude

--- a/docs/ml-bot/PLAN.md
+++ b/docs/ml-bot/PLAN.md
@@ -479,29 +479,39 @@ ppo:gate` over **3040 seat-fair games**: PPO **11.5 ± 1.3%** vs Lookahead **15.
       the 7 gate opponents (incl. all 3 strong ones) were training opponents → partly fixed-field
       _exploitation_ (also beats the 3 held-out bots → partial generalization); this green-lights task
       B. Full record: RESULTS.md + LOG.md + [D-23].
-- [ ] **(B) PFSP opponent league ([D-22]) — Node-resident. 🟢 SCOPED 2026-06-27 → [D-23].** New `scripts/lib/ppo-league.mjs` (pool +
-      seeded `mulberry32` sampler + win-rate book) inside the env-server; the loop draws
-      `league.draw(seed)` per episode (replaces the static `opponents` const at `ppo-env-server.mjs:259`).
-      **Fixed-field is the empty-pool degenerate mode of this same pipeline** — so (A) and (B) share
-      code. Snapshots: Python SB3 callback `repack → export_weights` (weights-only — no per-snapshot
-      fixture needed, [D-22] decision 6) → atomic `manifest.json`; Node hot-loads via `makeBC({policy})`
-      (fresh filename per snapshot — ESM URL cache). Sample `w(S)=max(ε,1−learnerWinRate(S))^k`; reserve
-      **R≈3–4 aggressive baselines every game** ([D-15] turtle defense); hold `player_count` constant.
-      **Win-rate attribution is the real work item** — pairwise/placement-relative, **excluding
-      `maxTurns` truncations**. Honor: freeze `ENCODING_VERSION`; dedup via `uniquifyNames` `#N`;
-      re-probe decisive-rate + throughput on a snapshot-heavy field before locking the budget.
-      _Open: per-worker vs shared-disk-global stats — lean shared-disk-global, pluggable ([D-22])._
-      **Build sequence — scoped in [D-23]** (verifier-corrected: `count = playerCount−1 = 6`, so R=3
-      leaves 3 PFSP seats; baselines threaded from the resolved `opts.opponents`; extend the
-      `EnvServerProcess` signature; GC evicted snapshot `.js` files): **B0** rebase/merge **PR #62
-      (hard prereq)** + `snapshot-manifest`/`-store` flags + freeze `ENCODING_VERSION=2` → **B1**
-      empty-pool league `== task A` (byte-identical parity — the milestone) → **B2** per-seat
-      `seatBeat[]` on both outcome shapers + win-rate book (exclude `truncated`) → **B3** snapshot
-      pipeline (SB3 callback → repack → `export(…, fixture_path=None)` → atomic manifest → Node
-      hot-load via `makeBC`, fresh filename) → **B4** PFSP weighting `w(S)=max(ε,1−winRate)^k` + R
-      reserved baselines (seeded `mulberry32`) → **B5** throughput/decisive-rate re-probe on a
-      snapshot-heavy field → **then** lock the env-step budget → **B6** persistence
-      (`toJSON()/restore()`) + `SharedDiskStore` (with task E).
+- [~] **(B) PFSP opponent league ([D-22]) — Node-resident. 🔵 B1–B3 DONE 2026-06-27 (PRs #62/#64 + win-rate book + snapshot pipeline); B4 next → [D-23].** New `scripts/lib/ppo-league.mjs` (pool +
+  seeded `mulberry32` sampler + win-rate book) inside the env-server; the loop draws
+  `league.draw(seed)` per episode (replaces the static `opponents` const at `ppo-env-server.mjs:259`).
+  **Fixed-field is the empty-pool degenerate mode of this same pipeline** — so (A) and (B) share
+  code. Snapshots: Python SB3 callback `repack → export_weights` (weights-only — no per-snapshot
+  fixture needed, [D-22] decision 6) → atomic `manifest.json`; Node hot-loads via `makeBC({policy})`
+  (fresh filename per snapshot — ESM URL cache). Sample `w(S)=max(ε,1−learnerWinRate(S))^k`; reserve
+  **R≈3–4 aggressive baselines every game** ([D-15] turtle defense); hold `player_count` constant.
+  **Win-rate attribution is the real work item** — pairwise/placement-relative, **excluding
+  `maxTurns` truncations**. Honor: freeze `ENCODING_VERSION`; dedup via `uniquifyNames` `#N`;
+  re-probe decisive-rate + throughput on a snapshot-heavy field before locking the budget.
+  _Open: per-worker vs shared-disk-global stats — lean shared-disk-global, pluggable ([D-22])._
+  **Build sequence — scoped in [D-23]** (verifier-corrected: `count = playerCount−1 = 6`, so R=3
+  leaves 3 PFSP seats; baselines threaded from the resolved `opts.opponents`; extend the
+  `EnvServerProcess` signature; GC evicted snapshot `.js` files): **B0 ✅** **PR #62 (hard prereq)
+  MERGED** (`snapshot-manifest`/`-store` flags + `ENCODING_VERSION=2` freeze deferred to B3, when
+  snapshots first need them) → **B1 ✅** empty-pool league `== task A` (content-identical parity —
+  the milestone; PR #64) → **B2 ✅** per-seat `seatBeat[]` on both outcome shapers
+  (`summarizeOutcome` from placements, `eliminationOutcome` synthesized from `coElimSeats`) +
+  id-keyed win-rate book (`recordResult` credits, `winRate(id)`; truncations excluded;
+  zero-decision episodes booked per [D-23] open-Q2) → **B3 ✅** snapshot
+  pipeline: NEW `ml/dicewars_ppo/snapshot_callback.py` (`SnapshotCallback` → repack →
+  `export(…, fixture_path=None)` → fsync-then-`os.replace` atomic `manifest.json`); league `refresh()`
+  polls the manifest at each episode boundary, `makeBC`-loads new snapshots (fresh filename → ESM URL
+  cache), FIFO-evicts past `poolCap` + GCs the `.js`; env-server `--snapshot-manifest`/`-pool-cap`
+  flags; `train_tracer` `--snapshot-dir`/`-every`/`-pool-cap`; `EnvServerProcess` forwards them. _(B3
+  deviations from [D-23]: `--snapshot-store` deferred to B6 with `SharedDiskStore`, not a dead flag
+  now; `--snapshot-pool-cap` added/forwarded since the pool cap is the consumer setting; the producer
+  manifest is append-only — entries are tiny, prune later if needed. `draw()` does NOT sample the pool
+  yet — that is B4 — so B3 is behavior-preserving for episode outcomes.)_ → **B4** PFSP weighting `w(S)=max(ε,1−winRate)^k` + R
+  reserved baselines (seeded `mulberry32`) → **B5** throughput/decisive-rate re-probe on a
+  snapshot-heavy field → **then** lock the env-step budget → **B6** persistence
+  (`toJSON()/restore()`) + `SharedDiskStore` (with task E).
 - [ ] **(C)** Scale envs across cores; add the short **from-scratch control** run ([D-19] decision 1).
 - [ ] **(D)** Add **annealed potential-based reward shaping** (Δlargest-group/territory/dice/elims,
       `F = γΦ(s′)−Φ(s)`, env-side in JS) only if terminal-only learning is too slow.

--- a/ml/dicewars_ppo/env_server.py
+++ b/ml/dicewars_ppo/env_server.py
@@ -80,6 +80,8 @@ class EnvServerProcess:
         episodes: int = 0,
         seed_base: int = 1,
         decision_timeout_ms: int = 120_000,
+        snapshot_manifest: str | None = None,
+        snapshot_pool_cap: int = 40,
         host: str = "127.0.0.1",
         node_bin: str | None = None,
         start_timeout_s: float = 30.0,
@@ -116,6 +118,11 @@ class EnvServerProcess:
         ]
         if max_areas is not None:
             argv.append(f"--max-areas={max_areas}")
+        # PFSP snapshot pool (B3): point the server's league at the producer manifest and bound its
+        # live pool. Absent ⇒ the server runs in empty-pool fixed-field mode (task A / B1 / B2).
+        if snapshot_manifest is not None:
+            argv.append(f"--snapshot-manifest={snapshot_manifest}")
+            argv.append(f"--snapshot-pool-cap={snapshot_pool_cap}")
         self._argv = argv
 
     def start(self) -> EnvServerProcess:

--- a/ml/dicewars_ppo/snapshot_callback.py
+++ b/ml/dicewars_ppo/snapshot_callback.py
@@ -1,0 +1,147 @@
+"""Periodic self-play snapshot publisher for the PFSP league (Phase 3, task B step B3 — [D-22]/[D-23]).
+
+An SB3 :class:`~stable_baselines3.common.callbacks.BaseCallback` that, every ``snapshot_every`` env
+steps, repacks the live PPO actor back into BC-checkpoint format, exports it to a ``.weights.js``
+module in ``snapshot_dir``, and atomically republishes ``manifest.json`` listing every snapshot. The
+Node env-server's ``league.refresh()`` (``scripts/lib/ppo-league.mjs``) polls that manifest at each
+episode boundary and hot-loads the new snapshots as in-process ``ai_bc`` opponents — the PFSP pool the
+learner trains against.
+
+This is the **producer half** only: the pool, the seeded sampler, the win-rate book, and the
+``poolCap`` FIFO/disk-GC are all Node-resident ([D-22], forced by the bare-i32 learner↔env wire — the
+trainer cannot select opponents per-episode over it). The producer just publishes artifacts.
+
+Reuse, not reinvention: ``repack_to_bc_checkpoint`` + ``export`` are the exact step-7 gate path
+(PR #61), already proven to produce a module ``makeBC`` accepts — so a snapshot needs **no per-snapshot
+parity fixture** ([D-22] decision 6); ``fixture_path=None``.
+
+Atomic publish ordering (so a poller never sees a torn or dangling reference):
+
+1. write the ``.weights.js`` to its final path and ``fsync`` it — durable FIRST;
+2. write ``manifest.json`` to a temp file, ``fsync``, then ``os.replace`` it into place — atomic on
+   POSIX, and the now-referenced weights file is already on disk.
+
+Frozen invariant: the manifest stamps ``encodingVersion = EXPECTED_ENCODING_VERSION`` (2). The whole
+run must hold it — ``makeBC`` hard-throws on skew, so a mid-run bump makes pooled snapshots unloadable
+(the Node ``refresh()`` rejects a skewed manifest loudly rather than training on a broken pool).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import torch
+from stable_baselines3.common.callbacks import BaseCallback
+
+from dicewars_bc.export_weights import export
+from dicewars_bc.manifest import EXPECTED_ENCODING_VERSION
+
+from .policy import repack_to_bc_checkpoint
+
+
+class SnapshotCallback(BaseCallback):
+    """Publish a PFSP self-play snapshot every ``snapshot_every`` env steps.
+
+    :param snapshot_dir: directory to write ``snap-*.weights.js`` + ``manifest.json`` into. The Node
+        env-server is pointed at ``<snapshot_dir>/manifest.json`` via ``--snapshot-manifest``.
+    :param snapshot_every: publish cadence in total env steps (across all vec-envs). Must be > 0.
+    :param teacher: provenance stamped into each exported module's header.
+    """
+
+    def __init__(
+        self,
+        snapshot_dir: str | Path,
+        snapshot_every: int,
+        *,
+        teacher: str = "ppo-snapshot",
+        verbose: int = 0,
+    ) -> None:
+        super().__init__(verbose)
+        if int(snapshot_every) <= 0:
+            raise ValueError(f"snapshot_every must be a positive int, got {snapshot_every!r}")
+        self.snapshot_dir = Path(snapshot_dir)
+        self.snapshot_every = int(snapshot_every)
+        self.teacher = teacher
+        self._last_snapshot_step = 0
+        self._snapshots: list[dict] = []  # manifest entries, ascending step (append-only)
+
+    def _on_training_start(self) -> None:
+        self.snapshot_dir.mkdir(parents=True, exist_ok=True)
+
+    def _on_step(self) -> bool:
+        # ``num_timesteps`` is SB3's total-env-steps counter (summed over vec-envs). Publish the first
+        # time it crosses a multiple of the cadence; never at step 0 (that snapshot is just the
+        # warm-start = the ai_bc baseline, already in the field).
+        if self.num_timesteps - self._last_snapshot_step >= self.snapshot_every:
+            self._last_snapshot_step = self.num_timesteps
+            self._publish(self.num_timesteps)
+        return True
+
+    def _publish(self, step: int) -> None:
+        self.snapshot_dir.mkdir(parents=True, exist_ok=True)
+        snap_id = f"snap-{int(step):09d}"
+        weights_name = f"{snap_id}.weights.js"
+        weights_path = self.snapshot_dir / weights_name
+
+        # 1) repack the LIVE actor → BC-format checkpoint dict → temp .pt (export() reads a path).
+        repacked = repack_to_bc_checkpoint(
+            self.model.policy,
+            extra={"teacher": self.teacher, "ppo_step": int(step)},
+        )
+        tmp_fd, tmp_name = tempfile.mkstemp(suffix=".pt", dir=str(self.snapshot_dir))
+        os.close(tmp_fd)
+        tmp_pt = Path(tmp_name)
+        try:
+            torch.save(repacked, tmp_pt)
+            # 2) export the JS weights module — no parity fixture (makeBC needs only weights, [D-22]).
+            export(tmp_pt, weights_path, fixture_path=None)
+        finally:
+            tmp_pt.unlink(missing_ok=True)
+
+        # Make the weights durable BEFORE the manifest references it (atomic-publish ordering).
+        _fsync_path(weights_path)
+
+        # 3) append + atomically republish the manifest (weights already on disk).
+        self._snapshots.append(
+            {
+                "id": snap_id,
+                "step": int(step),
+                "weights": weights_name,
+                "createdAt": datetime.now(timezone.utc).isoformat(),
+            }
+        )
+        self._write_manifest_atomic()
+        if self.verbose:
+            print(f"[snapshot] published {snap_id} ({len(self._snapshots)} total) → {weights_path}")
+
+    def _write_manifest_atomic(self) -> None:
+        """Rewrite ``manifest.json`` via temp-file + ``os.replace`` (atomic; never torn for a poller).
+
+        Schema (a NEW manifest, distinct from the BC-corpus ``manifest.py`` one) — mirrored by the Node
+        consumer ``ppo-league.refresh()``::
+
+            {"encodingVersion": 2, "snapshots": [{"id","step","weights","createdAt"}], "latestStep": N}
+        """
+        manifest = {
+            "encodingVersion": EXPECTED_ENCODING_VERSION,
+            "snapshots": self._snapshots,
+            "latestStep": self._snapshots[-1]["step"] if self._snapshots else 0,
+        }
+        manifest_path = self.snapshot_dir / "manifest.json"
+        tmp_path = manifest_path.with_name(manifest_path.name + ".tmp")
+        tmp_path.write_text(json.dumps(manifest, indent=2) + "\n")
+        _fsync_path(tmp_path)
+        os.replace(tmp_path, manifest_path)  # atomic rename on POSIX
+
+
+def _fsync_path(path: Path) -> None:
+    """``fsync`` a written file so its bytes are durable before anything references it."""
+    fd = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)

--- a/ml/dicewars_ppo/snapshot_callback.py
+++ b/ml/dicewars_ppo/snapshot_callback.py
@@ -1,29 +1,32 @@
-"""Periodic self-play snapshot publisher for the PFSP league (Phase 3, task B step B3 — [D-22]/[D-23]).
+"""Periodic self-play snapshot publisher for the PFSP league (Phase 3, task B step B3).
 
-An SB3 :class:`~stable_baselines3.common.callbacks.BaseCallback` that, every ``snapshot_every`` env
-steps, repacks the live PPO actor back into BC-checkpoint format, exports it to a ``.weights.js``
-module in ``snapshot_dir``, and atomically republishes ``manifest.json`` listing every snapshot. The
-Node env-server's ``league.refresh()`` (``scripts/lib/ppo-league.mjs``) polls that manifest at each
-episode boundary and hot-loads the new snapshots as in-process ``ai_bc`` opponents — the PFSP pool the
-learner trains against.
+An SB3 :class:`~stable_baselines3.common.callbacks.BaseCallback` that, every
+``snapshot_every`` env steps, repacks the live PPO actor back into BC-checkpoint format,
+exports it to a ``.weights.js`` module in ``snapshot_dir``, and atomically republishes
+``manifest.json`` listing every snapshot. The Node env-server's ``league.refresh()``
+(``scripts/lib/ppo-league.mjs``) polls that manifest at each episode boundary and hot-loads
+the new snapshots as in-process ``ai_bc`` opponents — the PFSP pool the learner trains on.
+See [D-22]/[D-23].
 
-This is the **producer half** only: the pool, the seeded sampler, the win-rate book, and the
-``poolCap`` FIFO/disk-GC are all Node-resident ([D-22], forced by the bare-i32 learner↔env wire — the
-trainer cannot select opponents per-episode over it). The producer just publishes artifacts.
+This is the **producer half** only: the pool, the seeded sampler, the win-rate book, and
+the ``poolCap`` FIFO/disk-GC are all Node-resident ([D-22], forced by the bare-i32
+learner-env wire — the trainer cannot select opponents per-episode over it). The producer
+just publishes artifacts.
 
-Reuse, not reinvention: ``repack_to_bc_checkpoint`` + ``export`` are the exact step-7 gate path
-(PR #61), already proven to produce a module ``makeBC`` accepts — so a snapshot needs **no per-snapshot
-parity fixture** ([D-22] decision 6); ``fixture_path=None``.
+Reuse, not reinvention: ``repack_to_bc_checkpoint`` + ``export`` are the exact step-7 gate
+path (PR #61), already proven to produce a module ``makeBC`` accepts — so a snapshot needs
+**no per-snapshot parity fixture** ([D-22] decision 6); ``fixture_path=None``.
 
 Atomic publish ordering (so a poller never sees a torn or dangling reference):
 
 1. write the ``.weights.js`` to its final path and ``fsync`` it — durable FIRST;
-2. write ``manifest.json`` to a temp file, ``fsync``, then ``os.replace`` it into place — atomic on
-   POSIX, and the now-referenced weights file is already on disk.
+2. write ``manifest.json`` to a temp file, ``fsync``, then ``os.replace`` it into place —
+   atomic on POSIX, and the now-referenced weights file is already on disk.
 
-Frozen invariant: the manifest stamps ``encodingVersion = EXPECTED_ENCODING_VERSION`` (2). The whole
-run must hold it — ``makeBC`` hard-throws on skew, so a mid-run bump makes pooled snapshots unloadable
-(the Node ``refresh()`` rejects a skewed manifest loudly rather than training on a broken pool).
+Frozen invariant: the manifest stamps ``encodingVersion = EXPECTED_ENCODING_VERSION`` (2).
+The whole run must hold it — ``makeBC`` hard-throws on skew, so a mid-run bump makes pooled
+snapshots unloadable (the Node ``refresh()`` rejects a skewed manifest loudly rather than
+training on a broken pool).
 """
 
 from __future__ import annotations
@@ -73,8 +76,8 @@ class SnapshotCallback(BaseCallback):
         self.snapshot_dir.mkdir(parents=True, exist_ok=True)
 
     def _on_step(self) -> bool:
-        # ``num_timesteps`` is SB3's total-env-steps counter (summed over vec-envs). Publish the first
-        # time it crosses a multiple of the cadence; never at step 0 (that snapshot is just the
+        # ``num_timesteps`` is SB3's total env steps (summed over vec-envs). Publish the first
+        # time it crosses a cadence multiple; never at step 0 (that snapshot is just the
         # warm-start = the ai_bc baseline, already in the field).
         if self.num_timesteps - self._last_snapshot_step >= self.snapshot_every:
             self._last_snapshot_step = self.num_timesteps
@@ -97,7 +100,7 @@ class SnapshotCallback(BaseCallback):
         tmp_pt = Path(tmp_name)
         try:
             torch.save(repacked, tmp_pt)
-            # 2) export the JS weights module — no parity fixture (makeBC needs only weights, [D-22]).
+            # 2) export the JS weights module — no parity fixture (makeBC needs weights only).
             export(tmp_pt, weights_path, fixture_path=None)
         finally:
             tmp_pt.unlink(missing_ok=True)
@@ -119,12 +122,12 @@ class SnapshotCallback(BaseCallback):
             print(f"[snapshot] published {snap_id} ({len(self._snapshots)} total) → {weights_path}")
 
     def _write_manifest_atomic(self) -> None:
-        """Rewrite ``manifest.json`` via temp-file + ``os.replace`` (atomic; never torn for a poller).
+        """Rewrite ``manifest.json`` via temp-file + ``os.replace`` (atomic; never torn).
 
-        Schema (a NEW manifest, distinct from the BC-corpus ``manifest.py`` one) — mirrored by the Node
-        consumer ``ppo-league.refresh()``::
+        Schema (a NEW manifest, distinct from the BC-corpus ``manifest.py`` one), mirrored by
+        the Node consumer ``ppo-league.refresh()``::
 
-            {"encodingVersion": 2, "snapshots": [{"id","step","weights","createdAt"}], "latestStep": N}
+            {"encodingVersion":2, "snapshots":[{"id","step","weights","createdAt"}], "latestStep":N}
         """
         manifest = {
             "encodingVersion": EXPECTED_ENCODING_VERSION,

--- a/ml/dicewars_ppo/train_tracer.py
+++ b/ml/dicewars_ppo/train_tracer.py
@@ -245,7 +245,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--snapshot-dir",
         default=None,
-        help="Publish self-play snapshots (weights + manifest.json) here for the league to hot-load; "
+        help="Publish snapshots (weights + manifest.json) here for the league to hot-load; "
         "unset ⇒ fixed-field (no PFSP).",
     )
     p.add_argument(
@@ -258,7 +258,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--snapshot-pool-cap",
         type=int,
         default=40,
-        help="Max snapshots the env-server league holds live (FIFO-by-step; forwarded to the server).",
+        help="Max snapshots the env-server league holds live (FIFO-by-step; forwarded).",
     )
     return p
 
@@ -279,8 +279,8 @@ def _validate_args(args: argparse.Namespace) -> None:
             raise SystemExit("--snapshot-every must be > 0 when --snapshot-dir is set.")
         if args.snapshot_pool_cap <= 0:
             raise SystemExit("--snapshot-pool-cap must be > 0.")
-        # Absolutize so the producer (this process) and the Node consumers (cwd=repo-root) resolve the
-        # same manifest path; create it now so the env-servers can stat() it from episode 0.
+        # Absolutize so the producer (this process) and the Node consumers (cwd=repo-root)
+        # resolve the same manifest path; create it now so env-servers can stat() it from ep 0.
         args.snapshot_dir = str(Path(args.snapshot_dir).resolve())
         Path(args.snapshot_dir).mkdir(parents=True, exist_ok=True)
 

--- a/ml/dicewars_ppo/train_tracer.py
+++ b/ml/dicewars_ppo/train_tracer.py
@@ -46,6 +46,7 @@ from .policy import (
     repack_to_bc_checkpoint,
     warm_start_from_bc,
 )
+from .snapshot_callback import SnapshotCallback
 
 # Fixed, seed-pure, heterogeneous baseline field ([D-15]: strong bots in every game
 # keep it decisive; no Math.random bots so episodes stay reproducible). resolveOpponents
@@ -62,6 +63,13 @@ def _make_env_thunk(cfg: ModelConfig, args: argparse.Namespace, env_index: int):
     replay identical episodes.
     """
 
+    # All vec-env servers poll the SAME producer manifest, so they share one snapshot pool ([D-22]).
+    # `snapshot_dir` is resolved absolute in _validate_args so producer (this process) and consumers
+    # (the Node servers, cwd=repo-root) agree on the path regardless of cwd.
+    snapshot_manifest = (
+        str(Path(args.snapshot_dir) / "manifest.json") if args.snapshot_dir else None
+    )
+
     def _thunk() -> DiceWarsEnv:
         return DiceWarsEnv(
             max_areas=cfg.max_areas,
@@ -71,6 +79,8 @@ def _make_env_thunk(cfg: ModelConfig, args: argparse.Namespace, env_index: int):
                 "max_turns": args.max_turns,
                 "learner_seat": args.learner_seat,
                 "seed_base": args.seed_base + env_index * 1_000_000,
+                "snapshot_manifest": snapshot_manifest,
+                "snapshot_pool_cap": args.snapshot_pool_cap,
             },
         )
 
@@ -146,9 +156,19 @@ def train(args: argparse.Namespace) -> Path:
         f"timesteps={args.timesteps} n_steps={args.n_steps} lr={args.lr} gamma={args.gamma}"
     )
 
+    # PFSP snapshot publisher (B3): periodically repack+export the live actor so the env-servers'
+    # leagues hot-load it as a self-play opponent. Off unless --snapshot-dir is given (fixed-field).
+    callback = None
+    if args.snapshot_dir:
+        callback = SnapshotCallback(args.snapshot_dir, args.snapshot_every, teacher="ppo-snapshot")
+        print(
+            f"snapshot publisher: every {args.snapshot_every} steps → {args.snapshot_dir} "
+            f"(consumer pool_cap={args.snapshot_pool_cap})"
+        )
+
     model, venv = build_model(cfg, ckpt, args)
     try:
-        model.learn(total_timesteps=args.timesteps, progress_bar=False)
+        model.learn(total_timesteps=args.timesteps, progress_bar=False, callback=callback)
     finally:
         # Always reap the env-servers (each DiceWarsEnv owns a Node child) even on error.
         venv.close()
@@ -221,6 +241,25 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--seed", type=int, default=0, help="PPO/torch seed")
     p.add_argument("--seed-base", type=int, default=1, help="Env-server episode seed base")
     p.add_argument("--device", default="cpu", help="torch device (cpu is fine — the net is tiny)")
+    # PFSP snapshots (B3 / [D-22]). --snapshot-dir off ⇒ fixed-field (task A) empty-pool mode.
+    p.add_argument(
+        "--snapshot-dir",
+        default=None,
+        help="Publish self-play snapshots (weights + manifest.json) here for the league to hot-load; "
+        "unset ⇒ fixed-field (no PFSP).",
+    )
+    p.add_argument(
+        "--snapshot-every",
+        type=int,
+        default=50_000,
+        help="Snapshot cadence in total env steps (only used with --snapshot-dir).",
+    )
+    p.add_argument(
+        "--snapshot-pool-cap",
+        type=int,
+        default=40,
+        help="Max snapshots the env-server league holds live (FIFO-by-step; forwarded to the server).",
+    )
     return p
 
 
@@ -235,6 +274,15 @@ def _validate_args(args: argparse.Namespace) -> None:
         raise SystemExit("--n-envs must be >= 1.")
     if not Path(args.checkpoint).is_file():
         raise SystemExit(f"--checkpoint not found: {args.checkpoint}")
+    if args.snapshot_dir is not None:
+        if args.snapshot_every <= 0:
+            raise SystemExit("--snapshot-every must be > 0 when --snapshot-dir is set.")
+        if args.snapshot_pool_cap <= 0:
+            raise SystemExit("--snapshot-pool-cap must be > 0.")
+        # Absolutize so the producer (this process) and the Node consumers (cwd=repo-root) resolve the
+        # same manifest path; create it now so the env-servers can stat() it from episode 0.
+        args.snapshot_dir = str(Path(args.snapshot_dir).resolve())
+        Path(args.snapshot_dir).mkdir(parents=True, exist_ok=True)
 
 
 def main() -> None:

--- a/ml/tests/test_snapshot_callback.py
+++ b/ml/tests/test_snapshot_callback.py
@@ -1,11 +1,11 @@
 """Tests for the PFSP snapshot publisher (Phase 3, task B step B3 — [D-22]/[D-23]).
 
 The callback's NEW logic is the atomic manifest publish + the schema the Node consumer
-(``scripts/lib/ppo-league.mjs`` ``refresh()``) reads. The repack→export step it wraps is the exact
-step-7 gate path, already proven to produce a ``makeBC``-loadable module — so these tests monkeypatch
-``repack_to_bc_checkpoint`` + ``export`` and focus on the cadence, the atomic publish, and the manifest
-schema. A torn or schema-drifted manifest is the failure these guard against; the JS side's
-``ppo-league-snapshots.test.js`` proves the same schema loads.
+(``scripts/lib/ppo-league.mjs`` ``refresh()``) reads. The repack→export step it wraps is the
+exact step-7 gate path, already proven to produce a ``makeBC``-loadable module — so these tests
+monkeypatch ``repack_to_bc_checkpoint`` + ``export`` and focus on the cadence, the atomic
+publish, and the manifest schema. A torn or schema-drifted manifest is the failure these guard
+against; the JS side's ``ppo-league-snapshots.test.js`` proves the same schema loads.
 """
 
 from __future__ import annotations
@@ -21,7 +21,7 @@ from dicewars_ppo.snapshot_callback import SnapshotCallback
 
 
 def _patch_export(monkeypatch):
-    """Replace repack+export with cheap fakes: repack returns a tiny dict; export writes a stub .js."""
+    """Replace repack+export with fakes: repack returns a dict; export writes a stub .js."""
 
     def fake_repack(policy, *, extra=None):
         return {"fake_state": 1, "extra": dict(extra or {})}
@@ -46,8 +46,18 @@ def test_write_manifest_atomic_schema(tmp_path):
     cb = SnapshotCallback(tmp_path, snapshot_every=10)
     cb._on_training_start()
     cb._snapshots = [
-        {"id": "snap-000000010", "step": 10, "weights": "snap-000000010.weights.js", "createdAt": "t0"},
-        {"id": "snap-000000020", "step": 20, "weights": "snap-000000020.weights.js", "createdAt": "t1"},
+        {
+            "id": "snap-000000010",
+            "step": 10,
+            "weights": "snap-000000010.weights.js",
+            "createdAt": "t0",
+        },
+        {
+            "id": "snap-000000020",
+            "step": 20,
+            "weights": "snap-000000020.weights.js",
+            "createdAt": "t1",
+        },
     ]
     cb._write_manifest_atomic()
 

--- a/ml/tests/test_snapshot_callback.py
+++ b/ml/tests/test_snapshot_callback.py
@@ -15,9 +15,15 @@ from types import SimpleNamespace
 
 import pytest
 
-import dicewars_ppo.snapshot_callback as snapshot_callback
-from dicewars_bc.manifest import EXPECTED_ENCODING_VERSION
-from dicewars_ppo.snapshot_callback import SnapshotCallback
+# Skip the whole module if the PPO `[rl]` stack is absent (e.g. the CI `ml-test` job, which installs
+# only `.[onnx,dev]`+gymnasium): snapshot_callback imports SB3's BaseCallback. Runs on shodan, where
+# the full stack is installed. Mirrors test_ppo_policy.py.
+pytest.importorskip("torch")
+pytest.importorskip("stable_baselines3")
+
+import dicewars_ppo.snapshot_callback as snapshot_callback  # noqa: E402
+from dicewars_bc.manifest import EXPECTED_ENCODING_VERSION  # noqa: E402
+from dicewars_ppo.snapshot_callback import SnapshotCallback  # noqa: E402
 
 
 def _patch_export(monkeypatch):

--- a/ml/tests/test_snapshot_callback.py
+++ b/ml/tests/test_snapshot_callback.py
@@ -1,0 +1,107 @@
+"""Tests for the PFSP snapshot publisher (Phase 3, task B step B3 — [D-22]/[D-23]).
+
+The callback's NEW logic is the atomic manifest publish + the schema the Node consumer
+(``scripts/lib/ppo-league.mjs`` ``refresh()``) reads. The repack→export step it wraps is the exact
+step-7 gate path, already proven to produce a ``makeBC``-loadable module — so these tests monkeypatch
+``repack_to_bc_checkpoint`` + ``export`` and focus on the cadence, the atomic publish, and the manifest
+schema. A torn or schema-drifted manifest is the failure these guard against; the JS side's
+``ppo-league-snapshots.test.js`` proves the same schema loads.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+import dicewars_ppo.snapshot_callback as snapshot_callback
+from dicewars_bc.manifest import EXPECTED_ENCODING_VERSION
+from dicewars_ppo.snapshot_callback import SnapshotCallback
+
+
+def _patch_export(monkeypatch):
+    """Replace repack+export with cheap fakes: repack returns a tiny dict; export writes a stub .js."""
+
+    def fake_repack(policy, *, extra=None):
+        return {"fake_state": 1, "extra": dict(extra or {})}
+
+    def fake_export(ckpt_path, out_path, fixture_path=None):
+        from pathlib import Path
+
+        Path(out_path).write_text("export const BC_POLICY = {};\n")
+        return Path(out_path)
+
+    monkeypatch.setattr(snapshot_callback, "repack_to_bc_checkpoint", fake_repack)
+    monkeypatch.setattr(snapshot_callback, "export", fake_export)
+
+
+def test_snapshot_every_must_be_positive():
+    with pytest.raises(ValueError, match="snapshot_every must be a positive int"):
+        SnapshotCallback("/tmp/snaps", 0)
+
+
+def test_write_manifest_atomic_schema(tmp_path):
+    """The manifest matches the Node consumer's schema exactly; no torn temp file is left behind."""
+    cb = SnapshotCallback(tmp_path, snapshot_every=10)
+    cb._on_training_start()
+    cb._snapshots = [
+        {"id": "snap-000000010", "step": 10, "weights": "snap-000000010.weights.js", "createdAt": "t0"},
+        {"id": "snap-000000020", "step": 20, "weights": "snap-000000020.weights.js", "createdAt": "t1"},
+    ]
+    cb._write_manifest_atomic()
+
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+    assert manifest["encodingVersion"] == EXPECTED_ENCODING_VERSION == 2
+    assert manifest["latestStep"] == 20
+    assert [s["id"] for s in manifest["snapshots"]] == ["snap-000000010", "snap-000000020"]
+    assert set(manifest["snapshots"][0]) == {"id", "step", "weights", "createdAt"}
+    assert not (tmp_path / "manifest.json.tmp").exists()  # temp renamed away, not left torn
+
+
+def test_publish_exports_weights_and_lists_them(tmp_path, monkeypatch):
+    _patch_export(monkeypatch)
+    cb = SnapshotCallback(tmp_path, snapshot_every=256, teacher="ppo-snapshot")
+    cb.model = SimpleNamespace(policy=SimpleNamespace())  # repack is faked → policy unused
+    cb._on_training_start()
+
+    cb._publish(256)
+
+    weights = tmp_path / "snap-000000256.weights.js"
+    assert weights.exists() and weights.read_text().startswith("export const BC_POLICY")
+    snaps = json.loads((tmp_path / "manifest.json").read_text())["snapshots"]
+    assert len(snaps) == 1
+    assert snaps[0] == {
+        "id": "snap-000000256",
+        "step": 256,
+        "weights": "snap-000000256.weights.js",
+        "createdAt": snaps[0]["createdAt"],  # timestamp present (exact value not pinned)
+    }
+    assert snaps[0]["createdAt"]  # non-empty ISO stamp
+    # No leftover temp checkpoint (.pt) or torn manifest temp.
+    assert not list(tmp_path.glob("*.pt"))
+    assert not list(tmp_path.glob("manifest.json.tmp"))
+
+
+def test_on_step_publishes_on_cadence_only(tmp_path, monkeypatch):
+    cb = SnapshotCallback(tmp_path, snapshot_every=10)
+    published: list[int] = []
+    monkeypatch.setattr(cb, "_publish", lambda step: published.append(step))
+
+    for ts, expected in [(5, []), (10, [10]), (15, [10]), (20, [10, 20]), (33, [10, 20, 33])]:
+        cb.num_timesteps = ts
+        cb._on_step()
+        assert published == expected
+
+
+def test_publish_appends_in_step_order(tmp_path, monkeypatch):
+    _patch_export(monkeypatch)
+    cb = SnapshotCallback(tmp_path, snapshot_every=100)
+    cb.model = SimpleNamespace(policy=SimpleNamespace())
+    cb._on_training_start()
+
+    cb._publish(100)
+    cb._publish(200)
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+    assert [s["step"] for s in manifest["snapshots"]] == [100, 200]
+    assert manifest["latestStep"] == 200

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "ppo:env-server": "node scripts/ppo-env-server.mjs",
     "ppo:env-smoke": "node scripts/ppo-env-smoke.mjs",
     "ppo:disconnect-smoke": "node scripts/ppo-env-disconnect-smoke.mjs",
+    "ppo:booking-smoke": "node scripts/ppo-env-booking-smoke.mjs",
     "ppo:throughput-probe": "node scripts/ppo-throughput-probe.mjs",
     "ppo:export": "cd ml && python -m dicewars_bc.export_weights --ckpt checkpoints/ppo-tracer.pt --out ../src/ai/ppoPolicyWeights.js --fixture ../tests/fixtures/bc/ppoForwardCases.json",
     "ppo:gate": "node scripts/ppo-gate.mjs"

--- a/scripts/lib/ppo-env.mjs
+++ b/scripts/lib/ppo-env.mjs
@@ -142,9 +142,10 @@ export function scaledPlacement(placements, learnerSeat, playerCount) {
  *   off keeps the full-game result byte-identical (the integration oracle). When the learner
  *   instead survives to win/stalemate, the flag is a pure no-op.
  * @returns {{winner:number|null, won:number, placement:number, placements:number[]|null,
- *   turnCount:number, learnerSeat:number, playerCount:number, eliminated:boolean,
- *   truncated:boolean, finalState:import('../../src/engine/types.js').GameState,
- *   botStats:Object[]|null}} `placements`/`botStats` are null on an early elimination (the match
+ *   seatBeat:(number|null)[]|null, turnCount:number, learnerSeat:number, playerCount:number,
+ *   eliminated:boolean, truncated:boolean, finalState:import('../../src/engine/types.js').GameState,
+ *   botStats:Object[]|null}} `seatBeat[s]` = did the learner outplace seat `s` (1/0, null at its own
+ *   seat) — the league's per-opponent win-rate input ([D-22]/[D-23]). `placements`/`botStats` are null on an early elimination (the match
  *   was aborted before `runMatch` computed them); `eliminated` flags that path. `truncated` is
  *   true ONLY when the learner survived to the `maxTurns` stalemate cap (a Gym truncation — the
  *   game did not actually end, so the learner's value should be bootstrapped); a win or an
@@ -204,7 +205,7 @@ export function runSelfPlayEpisode(cfg) {
      */
     let abortState = null;
     let abortTurn = 0;
-    let abortCoElimAbove = 0;
+    let abortCoElimSeats = null;
     let prevEliminated = new Set();
     const guardedOnTurn = (turnCount, state) => {
       if (onTurn) onTurn(turnCount, state);
@@ -213,13 +214,17 @@ export function runSelfPlayEpisode(cfg) {
          * Co-eliminees: players who lost their last territory on this SAME turn as the learner.
          * `runMatch` appends simultaneous eliminations to its eliminationOrder in ascending seat-id
          * order and `calculatePlacements` reverses that, so a same-turn co-eliminee with a HIGHER
-         * seat id than the learner finishes ABOVE it. `aliveCount` cannot see them (they are
-         * eliminated, not alive), so count them here and add them to the rank — making the
-         * synthesized placement match `calculatePlacements` exactly even on a multi-elimination turn.
+         * seat id than the learner finishes ABOVE it (a LOWER one below). Capture the whole same-turn
+         * set — the seats newly eliminated this turn, learner included — so `eliminationOutcome` can
+         * both correct the synthesized RANK and attribute the per-seat win/loss (`seatBeat`) exactly
+         * as `calculatePlacements` would, even on a multi-elimination turn. `aliveCount` cannot see
+         * these seats (they are eliminated, not alive).
          */
+        const coElimSeats = new Set();
         for (const p of state.players) {
-          if (p.id > learnerSeat && p.eliminated && !prevEliminated.has(p.id)) abortCoElimAbove++;
+          if (p.eliminated && !prevEliminated.has(p.id)) coElimSeats.add(p.id);
         }
+        abortCoElimSeats = coElimSeats;
         abortState = state;
         abortTurn = turnCount;
         throw LEARNER_ELIMINATED;
@@ -241,12 +246,42 @@ export function runSelfPlayEpisode(cfg) {
     } catch (err) {
       // re-raise a user onTurn throw (e.g. the env-server's EnvClosed disconnect signal).
       if (err !== LEARNER_ELIMINATED) throw err;
-      return eliminationOutcome(abortState, abortTurn, learnerSeat, playerCount, abortCoElimAbove);
+      return eliminationOutcome(abortState, abortTurn, learnerSeat, playerCount, abortCoElimSeats);
     }
   }
 
   const result = runMatch({ bots: roster, seed, maxTurns, recordHistory: false, onTurn });
   return summarizeOutcome(result, learnerSeat, playerCount);
+}
+
+/**
+ * Per-seat pairwise outcome vector for the league's win-rate book (ml-bot task B — [D-22]/[D-23]).
+ * `seatBeat[s]` answers "did the LEARNER outplace the player at board seat `s`?" — `1` yes, `0` no,
+ * `null` for the learner's own seat (and any seat the order can't rank). Strict pairwise
+ * placement-relative comparison (the `elo.js` pairwise rule restricted to learner-containing pairs),
+ * so the league can attribute one FFA game to one win/loss record per opponent seat. Built from the
+ * authoritative placement order (best-first list of seat ids); a total order means no `0.5` ties in
+ * practice, but the rule is kept defensively. Index = board seat (`state.players[i].id === i`).
+ *
+ * @param {number[]} placements - placement order, best-first (seat ids); `placements.indexOf(seat)` = rank.
+ * @param {number} learnerSeat
+ * @param {number} playerCount
+ * @returns {(number|null)[]} length `playerCount`, indexed by seat.
+ */
+function seatBeatFromPlacements(placements, learnerSeat, playerCount) {
+  const rank = new Array(playerCount).fill(-1);
+  placements.forEach((seat, i) => {
+    rank[seat] = i;
+  });
+  const learnerRank = rank[learnerSeat];
+  return Array.from({ length: playerCount }, (_, seat) => {
+    if (seat === learnerSeat) return null;
+    const r = rank[seat];
+    if (r < 0 || learnerRank < 0) return null; // seat absent from the order — unrankable
+    if (learnerRank < r) return 1; // learner placed higher (lower index) → beat seat
+    if (learnerRank > r) return 0;
+    return 0.5; // exact tie — unreachable for a strict placement order, kept for elo parity
+  });
 }
 
 /**
@@ -262,6 +297,14 @@ function summarizeOutcome(result, learnerSeat, playerCount) {
     won: result.winner === learnerSeat ? 1 : 0,
     placement: scaledPlacement(result.placements, learnerSeat, playerCount),
     placements: result.placements,
+    /*
+     * Per-seat pairwise win/loss for the league's win-rate book ([D-22] decision 5). The completed-
+     * match path has the full placement order, so derive it directly. `recordResult` excludes
+     * `maxTurns` truncations from the book, so the value on a stalemate is computed-but-unused.
+     */
+    seatBeat: Array.isArray(result.placements)
+      ? seatBeatFromPlacements(result.placements, learnerSeat, playerCount)
+      : null,
     turnCount: result.turnCount,
     learnerSeat,
     playerCount,
@@ -284,25 +327,46 @@ function summarizeOutcome(result, learnerSeat, playerCount) {
  * PRIOR turn finished below it. So the base rank is `#players still alive` (`aliveCount`), plus a
  * correction for same-turn co-eliminees that outrank the learner: `runMatch` orders simultaneous
  * eliminations by ascending seat id and `calculatePlacements` reverses that, so a co-eliminee with
- * a higher seat id than the learner places above it (`coElimAbove`, counted by the caller).
+ * a higher seat id than the learner places above it (`coElimAbove`, derived here from `coElimSeats`).
  * `aliveCount + coElimAbove` reproduces `calculatePlacements`' game-over rank exactly, with no tail
  * simulated. `winner` is the engine's winner when the eliminating turn also ended the game (learner
  * = runner-up), else null (game still undecided); the reward is `won = 0` either way.
  * `placements`/`botStats` are null — the match was aborted before `runMatch` built them.
  *
+ * The same `coElimSeats` set also yields the per-seat win-rate vector (`seatBeat`) without the tail:
+ * every still-alive seat outlives the learner (`0`); a same-turn co-eliminee is split by the seat-id
+ * tie-break (higher id placed above → `0`, lower id below → `1`); every prior-turn elimination was
+ * outlived by the learner (`1`). This reproduces `seatBeatFromPlacements` over the never-built
+ * game-over placements exactly, preserving the ~2× early-termination throughput.
+ *
  * @param {import('../../src/engine/types.js').GameState} state - board at the learner's elimination.
  * @param {number} turnCount - turns played when the learner was eliminated.
  * @param {number} learnerSeat
  * @param {number} playerCount
- * @param {number} [coElimAbove=0] - same-turn co-eliminees with a higher seat id than the learner.
+ * @param {Set<number>|null} [coElimSeats=null] - seats eliminated on the learner's death turn
+ *   (learner included); same-turn co-eliminees with a higher seat id than the learner outrank it.
  */
-function eliminationOutcome(state, turnCount, learnerSeat, playerCount, coElimAbove = 0) {
+function eliminationOutcome(state, turnCount, learnerSeat, playerCount, coElimSeats = null) {
   const aliveCount = state.players.filter(p => !p.eliminated).length; // players who outlive the learner
+  const coElim = coElimSeats ?? new Set();
+  // Same-turn co-eliminees with a higher seat id than the learner finish ABOVE it (the rank correction).
+  let coElimAbove = 0;
+  for (const id of coElim) if (id > learnerSeat) coElimAbove++;
   return {
     winner: state.winner,
     won: 0,
     placement: scaledPlacementFromRank(aliveCount + coElimAbove, playerCount),
     placements: null,
+    /*
+     * Per-seat pairwise win/loss synthesized at the learner's death — no game-over placements exist,
+     * but this matches what `seatBeatFromPlacements` would return for the full game (see doc above).
+     */
+    seatBeat: state.players.map(p => {
+      if (p.id === learnerSeat) return null;
+      if (!p.eliminated) return 0; // alive → outlives the learner → learner did NOT beat it
+      if (coElim.has(p.id)) return p.id > learnerSeat ? 0 : 1; // same-turn tie-break by seat id
+      return 1; // eliminated on a prior turn → the learner outlived it
+    }),
     turnCount,
     learnerSeat,
     playerCount,

--- a/scripts/lib/ppo-league.mjs
+++ b/scripts/lib/ppo-league.mjs
@@ -25,15 +25,15 @@ import { readFileSync, statSync, unlinkSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
+import { makeBC } from '../../src/ai/ai_bc.js';
 import { BUILT_IN_BOTS } from '../../src/arena/builtInBots.js';
+import { ENCODING_VERSION } from '../../src/arena/encodeObservation.js';
 
 /*
- * `makeBC` + `ENCODING_VERSION` are dynamic-imported inside `refresh()` purely for code locality —
- * they are only referenced once a real manifest exists. This defers no LOAD cost: the ~2 MB
- * `bcPolicyWeights.js` is already pulled in eagerly at the top of this module via `BUILT_IN_BOTS`
- * (→ `ai_bc.js` → `bcPolicyWeights.js`), and the env-server imports `BC_POLICY` directly too, so the
- * `import()` below just hits the module cache. (`ENCODING_VERSION` comes from the far lighter
- * `encodeObservation.js`, also already loaded.) The B1/B2 unit tests pay the weights cost regardless.
+ * `makeBC` (snapshot loader, B3) and `ENCODING_VERSION` (manifest compat gate) are imported
+ * statically with no extra load cost: the ~2 MB `bcPolicyWeights.js` `makeBC` pulls in is already
+ * loaded eagerly via the `BUILT_IN_BOTS` import below (→ `ai_bc.js` → `bcPolicyWeights.js`), and
+ * `ENCODING_VERSION` rides the far lighter `encodeObservation.js`.
  */
 
 /** Split + trim the opponent id CSV, dropping blanks; throws if it resolves to nothing. */
@@ -282,14 +282,6 @@ export function makeLeague({
       if (stat.mtimeMs === manifestMtimeMs) return { added: 0, poolSize: pool.length };
 
       const manifest = JSON.parse(readFileSync(snapshotManifest, 'utf8'));
-      /*
-       * Pull in makeBC/ENCODING_VERSION here for code locality — both are already module-cached
-       * (loaded eagerly via the top-of-file BUILT_IN_BOTS import; see the note there).
-       */
-      const [{ makeBC }, { ENCODING_VERSION }] = await Promise.all([
-        import('../../src/ai/ai_bc.js'),
-        import('../../src/arena/encodeObservation.js'),
-      ]);
       if (manifest.encodingVersion !== ENCODING_VERSION) {
         throw new Error(
           `ppo-league.refresh: snapshot manifest encodingVersion ${manifest.encodingVersion} != ` +

--- a/scripts/lib/ppo-league.mjs
+++ b/scripts/lib/ppo-league.mjs
@@ -28,9 +28,12 @@ import { pathToFileURL } from 'node:url';
 import { BUILT_IN_BOTS } from '../../src/arena/builtInBots.js';
 
 /*
- * `makeBC` + `ENCODING_VERSION` are lazy-imported inside `refresh()` (they pull in the ~2 MB deployed
- * BC weights via ai_bc.js) so the empty-pool fixed-field path — the common B1/B2 case and its fast unit
- * tests — never loads them. They are imported once, on the first refresh that actually has a manifest.
+ * `makeBC` + `ENCODING_VERSION` are dynamic-imported inside `refresh()` purely for code locality —
+ * they are only referenced once a real manifest exists. This defers no LOAD cost: the ~2 MB
+ * `bcPolicyWeights.js` is already pulled in eagerly at the top of this module via `BUILT_IN_BOTS`
+ * (→ `ai_bc.js` → `bcPolicyWeights.js`), and the env-server imports `BC_POLICY` directly too, so the
+ * `import()` below just hits the module cache. (`ENCODING_VERSION` comes from the far lighter
+ * `encodeObservation.js`, also already loaded.) The B1/B2 unit tests pay the weights cost regardless.
  */
 
 /** Split + trim the opponent id CSV, dropping blanks; throws if it resolves to nothing. */
@@ -87,8 +90,13 @@ export function resolveBaselineField(idCsv, count) {
  *   (B3). When set, `refresh()` polls it and hot-loads new self-play snapshots into the pool via
  *   `makeBC`. `null` (the default / no `--snapshot-manifest`) keeps the empty-pool fixed-field mode —
  *   `refresh()` is a no-op, so B3 is fully backward-compatible with task A / B1 / B2.
- * @param {number} [opts.poolCap=40] max snapshots held live in memory (B3). FIFO-by-step eviction
- *   keeps the most recent/hardest snapshots ([D-23]); the evicted snapshot's `.js` file is GC'd.
+ * @param {number} [opts.poolCap=40] max snapshots kept live (sampleable) and on disk (B3). FIFO-by-
+ *   step eviction keeps the most recent/hardest snapshots ([D-23]) and `unlinkSync`s the evicted
+ *   `.js`, so this bounds DISK and the sampleable set. It does NOT bound process memory: Node's ESM
+ *   module registry retains every dynamic-`import()`ed snapshot module for the process lifetime (each
+ *   fresh filename is a distinct, permanently-cached module), so resident weights grow with the total
+ *   number of snapshots ever loaded, not `poolCap`. Modest at realistic cadences (~2 MB each); if a
+ *   long run needs a hard memory bound, load weights without `import()` caching (B4/B5 concern).
  * @returns {{draw: Function, recordResult: Function, winRate: Function, refresh: Function,
  *   stats: Function}}
  */
@@ -137,6 +145,8 @@ export function makeLeague({
    * learner) earns a higher weight. maxTurns truncations are excluded (see recordResult).
    */
   const book = new Map();
+  // One-shot guard so a broken-contract decisive game (no seatBeat[]) warns once, not per-episode.
+  let warnedNoSeatBeat = false;
 
   /*
    * Snapshot pool (B3): hot-loaded self-play snapshots the trainer published, FIFO-capped at
@@ -188,10 +198,35 @@ export function makeLeague({
       }
       decisiveGames++;
       const { seatBeat } = result;
-      if (!Array.isArray(seatBeat)) return; // no attribution available (defensive)
+      if (!Array.isArray(seatBeat)) {
+        /*
+         * Both shapers always return a seatBeat[] for a decisive game (ppo-env.mjs), so a missing one
+         * means an upstream shaper/contract break. Don't crash a long training run over a single bad
+         * outcome — but don't let it silently empty the book either (the failure mode that would make
+         * B4's PFSP sampler quietly collapse to ~uniform). Warn ONCE so the regression is visible.
+         */
+        if (!warnedNoSeatBeat) {
+          warnedNoSeatBeat = true;
+          process.stderr.write(
+            '[ppo-league] decisive game had no seatBeat[] — win-rate book not credited; check the ' +
+              'runSelfPlayEpisode/runMatch placement contract.\n'
+          );
+        }
+        return;
+      }
       for (const d of drawn) {
         const beat = seatBeat[d.seat];
-        if (typeof beat !== 'number') continue; // learner's own seat / an unrankable seat
+        if (beat === null || beat === undefined) continue; // an unrankable seat (drawn never holds the learner)
+        if (beat !== 0 && beat !== 1 && beat !== 0.5) {
+          /*
+           * Anything outside the documented {0, 0.5, 1} domain is a shaper/seat desync — fail loud
+           * rather than fold a garbage value into `wins` and violate the book's `games >= wins`.
+           */
+          throw new Error(
+            `ppo-league.recordResult: seatBeat[${d.seat}]=${beat} outside {0,0.5,1} — shaper/seat ` +
+              `desync (a corrupt win-rate book would poison B4's PFSP sampler).`
+          );
+        }
         let rec = book.get(d.id);
         if (!rec) {
           rec = { wins: 0, games: 0 };
@@ -231,13 +266,26 @@ export function makeLeague({
       let stat;
       try {
         stat = statSync(snapshotManifest);
-      } catch {
-        return { added: 0, poolSize: pool.length }; // not written yet — no snapshots to load
+      } catch (err) {
+        /*
+         * ENOENT is the only benign case: the producer simply hasn't published its first snapshot
+         * yet (expected for the first ~--snapshot-every steps). Any other errno (EACCES/ENOTDIR/an
+         * unmounted share) is a misconfiguration that will never self-resolve — surface it loudly
+         * instead of silently running forever in empty-pool fixed-field mode.
+         */
+        if (err.code === 'ENOENT') return { added: 0, poolSize: pool.length };
+        throw new Error(
+          `ppo-league.refresh: cannot stat snapshot manifest ${snapshotManifest} ` +
+            `(${err.code ?? err.message}). Check --snapshot-manifest / the producer's --snapshot-dir.`
+        );
       }
       if (stat.mtimeMs === manifestMtimeMs) return { added: 0, poolSize: pool.length };
 
       const manifest = JSON.parse(readFileSync(snapshotManifest, 'utf8'));
-      // Lazy-load the heavy ai_bc deps only now that a real manifest exists (see top-of-file note).
+      /*
+       * Pull in makeBC/ENCODING_VERSION here for code locality — both are already module-cached
+       * (loaded eagerly via the top-of-file BUILT_IN_BOTS import; see the note there).
+       */
       const [{ makeBC }, { ENCODING_VERSION }] = await Promise.all([
         import('../../src/ai/ai_bc.js'),
         import('../../src/arena/encodeObservation.js'),
@@ -266,8 +314,11 @@ export function makeLeague({
       }
 
       /*
-       * FIFO eviction: keep the most recent `poolCap`; GC the evicted snapshot's `.js` (D-23 disk
-       * retention — `poolCap` bounds memory, not disk, and the fresh-filename rule grows disk forever).
+       * FIFO eviction: keep the most recent `poolCap` sampleable and `unlinkSync` the evicted `.js`
+       * (D-23 disk retention — the fresh-filename rule would otherwise grow disk forever). This bounds
+       * DISK and the sampleable set, NOT process memory: the dynamic-`import()`ed module stays in
+       * Node's ESM registry for the process lifetime, so dropping the `fn` here does not free the
+       * ~2 MB weights (see the `poolCap` JSDoc note).
        */
       while (pool.length > poolCap) {
         const evicted = pool.shift();
@@ -282,7 +333,13 @@ export function makeLeague({
       return { added, poolSize: pool.length };
     },
 
-    /** League health snapshot (the throughput/decisive-rate re-probe in B5 reads this). */
+    /**
+     * League health snapshot. The env-server emits this on its `PPO_ENV_SERVER DONE` line (the B5
+     * throughput/decisive-rate re-probe reads it; until B4 wires the book into `draw()` it is the
+     * only external window onto the win-rate book). `decisiveGames` counts every booked decisive
+     * episode incl. zero-decision skips, so `decisiveGames > <wire terminals>` evidences the B2
+     * "book before the zero-decision wire gate" reordering.
+     */
     stats() {
       const total = decisiveGames + truncatedGames;
       return {

--- a/scripts/lib/ppo-league.mjs
+++ b/scripts/lib/ppo-league.mjs
@@ -10,14 +10,28 @@
  * snapshots, `draw()` returns exactly the cycled baseline field the env-server used
  * before — content-identical (same names + fn refs), so task A's outcomes reproduce.
  * This file (step **B1**)
- * ships that empty-pool path plus a decisive/truncated telemetry tally; the snapshot
- * pipeline (B3), PFSP weighting (B4), and persistence (B6) extend the same object.
- * See docs/ml-bot/DECISIONS.md D-22 for the full build sequence.
+ * ships that empty-pool path plus a decisive/truncated telemetry tally; **step B2 adds the
+ * per-opponent win-rate book** (`recordResult` crediting + `winRate(id)`); **step B3 adds the
+ * snapshot pool + `refresh()`** — poll the producer's `manifest.json`, hot-load each new self-play
+ * snapshot via `makeBC` (fresh filename per snapshot → ESM URL cache), FIFO-evict past `poolCap` and
+ * GC the evicted `.js`. PFSP weighting (B4, samples the pool in `draw()`) and persistence (B6) extend
+ * the same object. See docs/ml-bot/DECISIONS.md D-23 for the full B0–B6 build sequence (D-22 for the
+ * league architecture + the win-rate-attribution decision).
  *
  * @module scripts/lib/ppo-league
  */
 
+import { readFileSync, statSync, unlinkSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
 import { BUILT_IN_BOTS } from '../../src/arena/builtInBots.js';
+
+/*
+ * `makeBC` + `ENCODING_VERSION` are lazy-imported inside `refresh()` (they pull in the ~2 MB deployed
+ * BC weights via ai_bc.js) so the empty-pool fixed-field path — the common B1/B2 case and its fast unit
+ * tests — never loads them. They are imported once, on the first refresh that actually has a manifest.
+ */
 
 /** Split + trim the opponent id CSV, dropping blanks; throws if it resolves to nothing. */
 function parseIds(idCsv) {
@@ -55,9 +69,11 @@ export function resolveBaselineField(idCsv, count) {
 }
 
 /**
- * Construct a league. Step **B1** ships the empty-pool path (== task A's fixed field)
- * plus a decisive/truncated telemetry tally; later steps extend the returned object
- * (B3 `refresh`/`addSnapshot`, B4 PFSP `learnerWinRate` weighting, B6 `toJSON`/`restore`).
+ * Construct a league. Step **B1** ships the empty-pool path (== task A's fixed field) plus a
+ * decisive/truncated telemetry tally; step **B2** adds the per-opponent win-rate book
+ * (`recordResult` pairwise crediting + `winRate(id)`); later steps extend the returned object
+ * (B3 `refresh`/`addSnapshot`, B4 PFSP `w(S)=max(ε,1−learnerWinRate(S))^k` weighting, B6
+ * `toJSON`/`restore`).
  *
  * @param {object} opts
  * @param {string} opts.baselineCsv the resolved `--opponents` CSV. The trainer passes
@@ -67,9 +83,22 @@ export function resolveBaselineField(idCsv, count) {
  *   returns exactly this many (holds player_count constant, [D-22]).
  * @param {number} opts.learnerSeat the learner's seat; used to map an opponent's array
  *   index to its seat for the (B2) win-rate attribution.
- * @returns {{draw: Function, recordResult: Function, stats: Function}}
+ * @param {string|null} [opts.snapshotManifest=null] path to the producer's snapshot `manifest.json`
+ *   (B3). When set, `refresh()` polls it and hot-loads new self-play snapshots into the pool via
+ *   `makeBC`. `null` (the default / no `--snapshot-manifest`) keeps the empty-pool fixed-field mode —
+ *   `refresh()` is a no-op, so B3 is fully backward-compatible with task A / B1 / B2.
+ * @param {number} [opts.poolCap=40] max snapshots held live in memory (B3). FIFO-by-step eviction
+ *   keeps the most recent/hardest snapshots ([D-23]); the evicted snapshot's `.js` file is GC'd.
+ * @returns {{draw: Function, recordResult: Function, winRate: Function, refresh: Function,
+ *   stats: Function}}
  */
-export function makeLeague({ baselineCsv, count, learnerSeat }) {
+export function makeLeague({
+  baselineCsv,
+  count,
+  learnerSeat,
+  snapshotManifest = null,
+  poolCap = 40,
+}) {
   /*
    * Fail loud at construction — both inputs are in scope here, so a bad value is caught at the
    * cheapest spot rather than surfacing later as a silently-wrong `seatOf` map (B2's win-rate
@@ -85,6 +114,9 @@ export function makeLeague({ baselineCsv, count, learnerSeat }) {
       `makeLeague: learnerSeat ${learnerSeat} out of range [0, ${count}] for count ${count}.`
     );
   }
+  if (!Number.isInteger(poolCap) || poolCap <= 0) {
+    throw new Error(`makeLeague: poolCap must be a positive integer, got ${poolCap}.`);
+  }
   const baselineField = resolveBaselineField(baselineCsv, count);
   /*
    * `draw()` hands out this same array reference every episode, so freeze it (and its entries):
@@ -96,6 +128,26 @@ export function makeLeague({ baselineCsv, count, learnerSeat }) {
 
   let decisiveGames = 0;
   let truncatedGames = 0;
+  /*
+   * Win-rate book (B2): stable opponent id → the LEARNER's pairwise record against it. `wins` is the
+   * count of decisive games in which the learner outplaced that opponent; `games` the decisive games
+   * the opponent appeared in (a cycled baseline seated twice in one game contributes two records).
+   * Keyed on the stable id, never the `uniquifyNames` `#N` display name. B4 samples snapshots by
+   * `w(S) = max(ε, 1 − winRate(S))^k`, so a lower learner-win-rate (an opponent that beats the
+   * learner) earns a higher weight. maxTurns truncations are excluded (see recordResult).
+   */
+  const book = new Map();
+
+  /*
+   * Snapshot pool (B3): hot-loaded self-play snapshots the trainer published, FIFO-capped at
+   * `poolCap`. `pool` holds the LIVE snapshots (ascending step → `shift()` evicts the oldest); B4's
+   * `draw()` samples from it. `loadedIds` records every id ever imported — an evicted id stays here so
+   * `refresh()` never re-imports it after its `.js` is GC'd (a re-import would hit a deleted file).
+   * `manifestMtimeMs` is a cheap no-change guard so the per-episode poll re-parses only on a rewrite.
+   */
+  const pool = [];
+  const loadedIds = new Set();
+  let manifestMtimeMs = -1;
 
   /*
    * Opponent-array index → seat: the learner sits at `learnerSeat`; opponents fill the remaining
@@ -121,20 +173,122 @@ export function makeLeague({ baselineCsv, count, learnerSeat }) {
     },
 
     /*
-     * Tally the episode outcome. B1: telemetry only — count decisive vs maxTurns-truncated games
-     * (the [D-22] decisive-rate health metric). B2 adds per-opponent pairwise win-rate attribution
-     * via a per-seat `seatBeat[]` vector keyed on `drawn[k].id`, EXCLUDING truncations.
+     * Tally the episode outcome. Decisive vs maxTurns-truncated counters feed the [D-22] decisive-
+     * rate health metric. B2: a decisive game also credits the win-rate book — for each drawn
+     * opponent, read the learner's pairwise result at that opponent's board seat from
+     * `result.seatBeat[seat]` and fold it into `book[id]`. maxTurns truncations are EXCLUDED from the
+     * book entirely ([D-22] decision 5: counting stalemates as losses biases the sampler toward
+     * turtle fields) — they bump only the truncated counter. A cycled baseline seated at two seats
+     * yields two independent records for its id (one per seat), which is correct.
      */
     recordResult(drawn, result) {
-      if (result.truncated) truncatedGames++;
-      else decisiveGames++;
+      if (result.truncated) {
+        truncatedGames++;
+        return;
+      }
+      decisiveGames++;
+      const { seatBeat } = result;
+      if (!Array.isArray(seatBeat)) return; // no attribution available (defensive)
+      for (const d of drawn) {
+        const beat = seatBeat[d.seat];
+        if (typeof beat !== 'number') continue; // learner's own seat / an unrankable seat
+        let rec = book.get(d.id);
+        if (!rec) {
+          rec = { wins: 0, games: 0 };
+          book.set(d.id, rec);
+        }
+        rec.games++;
+        rec.wins += beat;
+      }
+    },
+
+    /**
+     * The LEARNER's win-rate against opponent `id` (B2) — the [D-19]/[D-22] PFSP signal. Returns
+     * `0` for an unseen id (cold-start: a never-recorded snapshot then earns max weight
+     * `w = max(ε, 1)^k`, so it is sampled hardest first — [D-23]). Indistinguishable from "lost every
+     * game", which is intentional: both should be prioritised by the sampler.
+     */
+    winRate(id) {
+      const rec = book.get(id);
+      return rec && rec.games > 0 ? rec.wins / rec.games : 0;
+    },
+
+    /**
+     * Poll the producer's snapshot manifest and hot-load any new self-play snapshots into the pool
+     * (B3). Called at each episode boundary by the env-server. No manifest configured → a no-op
+     * (empty-pool fixed-field mode). Cheap when nothing changed: a single `statSync` mtime check short-
+     * circuits before any parse/import. On a rewrite it diffs the manifest by stable id, dynamic-
+     * `import()`s each NEW snapshot's `.js` (a fresh filename per snapshot, so the ESM URL cache never
+     * serves a stale module), wraps it with `makeBC({ policy })`, and FIFO-evicts past `poolCap`,
+     * GC-ing the evicted snapshot's `.js` file (the manifest still lists it, but `loadedIds` stops it
+     * being re-imported — restart recovery is a B6 concern). `draw()` does not sample the pool until
+     * B4, so in B3 this only grows `poolSize`; episode outcomes are unchanged.
+     *
+     * @returns {Promise<{added:number, poolSize:number}>}
+     */
+    async refresh() {
+      if (!snapshotManifest) return { added: 0, poolSize: pool.length };
+      let stat;
+      try {
+        stat = statSync(snapshotManifest);
+      } catch {
+        return { added: 0, poolSize: pool.length }; // not written yet — no snapshots to load
+      }
+      if (stat.mtimeMs === manifestMtimeMs) return { added: 0, poolSize: pool.length };
+
+      const manifest = JSON.parse(readFileSync(snapshotManifest, 'utf8'));
+      // Lazy-load the heavy ai_bc deps only now that a real manifest exists (see top-of-file note).
+      const [{ makeBC }, { ENCODING_VERSION }] = await Promise.all([
+        import('../../src/ai/ai_bc.js'),
+        import('../../src/arena/encodeObservation.js'),
+      ]);
+      if (manifest.encodingVersion !== ENCODING_VERSION) {
+        throw new Error(
+          `ppo-league.refresh: snapshot manifest encodingVersion ${manifest.encodingVersion} != ` +
+            `encoder ENCODING_VERSION ${ENCODING_VERSION} (${snapshotManifest}). The run must freeze ` +
+            `ENCODING_VERSION — re-export the snapshots against the current encoding.`
+        );
+      }
+
+      const dir = dirname(snapshotManifest);
+      const fresh = (manifest.snapshots ?? [])
+        .filter(s => !loadedIds.has(s.id))
+        .sort((a, b) => a.step - b.step); // ascending step → push order == FIFO eviction order
+
+      let added = 0;
+      for (const snap of fresh) {
+        const weightsPath = resolve(dir, snap.weights);
+        const mod = await import(pathToFileURL(weightsPath).href);
+        const fn = makeBC({ policy: mod.BC_POLICY }); // re-checks encodingVersion per snapshot
+        pool.push({ id: snap.id, step: snap.step, fn, weightsPath });
+        loadedIds.add(snap.id);
+        added++;
+      }
+
+      /*
+       * FIFO eviction: keep the most recent `poolCap`; GC the evicted snapshot's `.js` (D-23 disk
+       * retention — `poolCap` bounds memory, not disk, and the fresh-filename rule grows disk forever).
+       */
+      while (pool.length > poolCap) {
+        const evicted = pool.shift();
+        try {
+          unlinkSync(evicted.weightsPath);
+        } catch {
+          /* already gone / shared / read-only — best-effort GC, never fail a refresh on it */
+        }
+      }
+
+      manifestMtimeMs = stat.mtimeMs; // commit only after a clean load, so a throw retries next poll
+      return { added, poolSize: pool.length };
     },
 
     /** League health snapshot (the throughput/decisive-rate re-probe in B5 reads this). */
     stats() {
       const total = decisiveGames + truncatedGames;
       return {
-        poolSize: 0,
+        poolSize: pool.length,
+        loadedSnapshots: loadedIds.size,
+        bookSize: book.size,
         decisiveGames,
         truncatedGames,
         decisiveRate: total > 0 ? decisiveGames / total : 0,

--- a/scripts/ppo-env-booking-smoke.mjs
+++ b/scripts/ppo-env-booking-smoke.mjs
@@ -1,0 +1,140 @@
+/**
+ * PPO env-server zero-decision booking smoke (ml-bot Phase 3, task B step B2 — [D-22]/[D-23]).
+ *
+ * Regression guard for the B2 reordering: `league.recordResult(...)` runs ABOVE the wire
+ * zero-decision gate in `ppo-env-server.mjs`, so a zero-decision episode (the learner eliminated
+ * before it ever acts — no obs frame, no terminal frame) is still BOOKED into the league win-rate.
+ * Booking these honest decisive losses is what lets B4's PFSP sampler up-weight the fields that
+ * crush the learner fastest; if the `recordResult` call ever slips back below the `continue`, the
+ * book silently drops them and the sampler quietly skews — a failure no other test catches (the
+ * book is internal Node state, never on the wire; the Python e2e is structurally blind to it).
+ *
+ * The book is observable only via the `PPO_ENV_SERVER DONE` stats line. With the canonical
+ * zero-decision anchor (7-player full field, `--seed-base=35`; pinned by `tests/ml/ppo-env.test.js`
+ * and `ml/tests/test_ppo_env.py`) and `--episodes=1`, episode 0 is zero-decision: it surfaces NO
+ * wire terminal (`episodes=0`) yet IS booked (`decisiveGames=1`). That pair — booked-but-not-surfaced
+ * — is the discriminating signature of the reordering. If seed 35 ever stops being zero-decision
+ * (engine RNG drift), this fails loud (episodes=1) → re-find a zero-decision seed and update the
+ * three call sites in lockstep.
+ *
+ * Run: `node scripts/ppo-env-booking-smoke.mjs`  (exit 0 = pass). Manual transport check, kept out
+ * of the vitest suite (forks a child server + live socket), mirroring the other ppo:*-smoke checks.
+ *
+ * @module scripts/ppo-env-booking-smoke
+ */
+
+import net from 'node:net';
+import readline from 'node:readline';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SERVER = path.join(HERE, 'ppo-env-server.mjs');
+const PLAYERS = 7;
+// The canonical zero-decision anchor: the full 7-player training field + seed 35 (see module doc).
+const OPPONENTS = 'ai_lookahead,ai_strategist,ai_expectimax,ai_bc,ai_defensive';
+const SEED_BASE = 35;
+
+function fail(msg) {
+  process.stderr.write(`BOOKING SMOKE FAIL: ${msg}\n`);
+  process.exit(1);
+}
+
+/** Parse the `key=value` fields off a `PPO_ENV_SERVER DONE ...` line into a number map. */
+function parseDone(line) {
+  const fields = {};
+  for (const tok of line.split(/\s+/)) {
+    const m = /^([a-zA-Z]+)=(-?[\d.]+)$/.exec(tok);
+    if (m) fields[m[1]] = Number(m[2]);
+  }
+  return fields;
+}
+
+async function main() {
+  const child = spawn(
+    process.execPath,
+    [
+      SERVER,
+      '--port=0',
+      `--players=${PLAYERS}`,
+      '--learner-seat=0',
+      `--opponents=${OPPONENTS}`,
+      `--seed-base=${SEED_BASE}`,
+      '--episodes=1', // run exactly episode 0 (seed 35, zero-decision) then print DONE
+    ],
+    { stdio: ['ignore', 'pipe', 'inherit'] }
+  );
+
+  const killTimer = setTimeout(() => {
+    child.kill('SIGKILL');
+    fail('timed out (10s) — server hung');
+  }, 10_000);
+
+  let port = null;
+  let done = null;
+  const rl = readline.createInterface({ input: child.stdout });
+  rl.on('line', line => {
+    const lis = /^PPO_ENV_SERVER LISTENING (\S+) (\d+)$/.exec(line);
+    if (lis) {
+      port = Number(lis[2]);
+      connect(port);
+      return;
+    }
+    if (line.startsWith('PPO_ENV_SERVER DONE')) done = parseDone(line);
+    process.stdout.write(`[server] ${line}\n`);
+  });
+
+  let socket;
+  function connect(p) {
+    /*
+     * A client must connect for the server to leave `await connected` and run the episode. The
+     * zero-decision episode 0 emits no obs frame, so this socket exchanges nothing — but if seed 35
+     * ever yields a decision, reply STOP so the server can finish rather than park (the assertion
+     * below still fails loudly on the resulting episodes=1, flagging the seed drift).
+     */
+    socket = net.connect(p, '127.0.0.1');
+    socket.on('data', chunk => {
+      /*
+       * If the server ever offers a decision (it won't on the canonical zero-decision seed), reply
+       * index 0 — always legal since the server validates [0, numEdges) and numEdges >= 1. We don't
+       * parse the frame here; this is purely a drift safety net so a non-zero-decision seed finishes
+       * the episode rather than parking (the episodes=0 assertion below then fails loud on the drift).
+       */
+      void chunk;
+      const action = Buffer.allocUnsafe(4);
+      action.writeInt32LE(0, 0);
+      socket.write(action);
+    });
+    socket.on('error', () => {}); // server tears the socket down on shutdown — ignore
+  }
+
+  await new Promise(resolve => child.on('exit', resolve));
+  clearTimeout(killTimer);
+  rl.close();
+  if (socket) socket.destroy();
+
+  if (child.exitCode !== 0) fail(`server exited ${child.exitCode} (expected 0)`);
+  if (!done) fail('never saw a PPO_ENV_SERVER DONE line');
+  if (done.decisiveGames !== 1) {
+    fail(
+      `decisiveGames=${done.decisiveGames}, expected 1 — the zero-decision episode was NOT booked`
+    );
+  }
+  if (!(done.bookSize > 0)) {
+    fail(`bookSize=${done.bookSize}, expected > 0 — the win-rate book was not credited`);
+  }
+  if (done.episodes !== 0) {
+    fail(
+      `episodes=${done.episodes}, expected 0 — seed ${SEED_BASE} is no longer zero-decision ` +
+        `(engine RNG drift). Re-find a zero-decision seed and update the JS/Python anchors in lockstep.`
+    );
+  }
+  process.stdout.write(
+    `BOOKING SMOKE PASS: zero-decision episode booked (decisiveGames=1) but surfaced no wire ` +
+      `terminal (episodes=0) — the B2 reordering holds.\n`
+  );
+  process.exit(0);
+}
+
+main().catch(err => fail(err.stack || err.message));

--- a/scripts/ppo-env-server.mjs
+++ b/scripts/ppo-env-server.mjs
@@ -60,6 +60,14 @@ const KNOWN_FLAGS = new Set([
   'seed-base',
   'opponents',
   'decision-timeout-ms',
+  /*
+   * Snapshot pool (B3 / [D-23]). `snapshot-manifest` = the producer's manifest.json to poll for new
+   * self-play snapshots; absent → empty-pool fixed-field mode. `snapshot-pool-cap` bounds the live
+   * in-memory pool (FIFO-by-step). (`snapshot-store` — the pluggable shared-disk win-rate backend —
+   * lands with B6/Task-E, so it is intentionally NOT a flag yet.)
+   */
+  'snapshot-manifest',
+  'snapshot-pool-cap',
 ]);
 
 function parseArgs(argv) {
@@ -107,15 +115,19 @@ async function main() {
   // Per-decision watchdog deadline (ms). Generous — inference is sub-second; 0 disables it.
   const decisionTimeoutMs = numArg(opts, 'decision-timeout-ms', 120000);
   /*
-   * The opponent league (ml-bot task B — [D-22]). B1: the pool is empty, so every `draw()` returns
-   * the cycled baseline field — content-identical to the static field task A trained on (the env-server
-   * default is the single bot `ai_bc`; the trainer passes the full `--opponents` CSV). Snapshots
-   * (B3) and PFSP weighting (B4) extend the same league; fixed-field is its empty-pool mode.
+   * The opponent league (ml-bot task B — [D-22]). With no `--snapshot-manifest` the pool is empty, so
+   * every `draw()` returns the cycled baseline field — content-identical to the static field task A
+   * trained on (the env-server default is the single bot `ai_bc`; the trainer passes the full
+   * `--opponents` CSV). B3: when a manifest is given, `league.refresh()` (polled per episode below)
+   * hot-loads published self-play snapshots into the pool; PFSP weighting (B4) then samples them in
+   * `draw()`. Fixed-field stays the empty-pool mode of this one pipeline.
    */
   const league = makeLeague({
     baselineCsv: opts.opponents ?? 'ai_bc',
     count: playerCount - 1,
     learnerSeat,
+    snapshotManifest: opts['snapshot-manifest'] ?? null,
+    poolCap: numArg(opts, 'snapshot-pool-cap', 40),
   });
 
   const sab = new SharedArrayBuffer(8); // 2 × Int32
@@ -259,6 +271,14 @@ async function main() {
     await connected;
     for (let ep = 0; episodes === 0 || ep < episodes; ep++) {
       if (closed || lostError) break;
+      /*
+       * Poll the snapshot manifest at the episode boundary (B3): hot-load any newly published
+       * self-play snapshots into the league pool before drawing this episode's field. No
+       * `--snapshot-manifest` → a cheap no-op (one `statSync`); an encoding-version skew throws and
+       * stops the run (the frozen-`ENCODING_VERSION` run-invariant — fail loud, never train on an
+       * unloadable pool).
+       */
+      await league.refresh();
       const seed = seedBase + ep;
       decisionsThisEpisode = 0;
       // Draw this episode's opponent field from the league (B1: the empty-pool baseline field).
@@ -286,6 +306,17 @@ async function main() {
       }
 
       /*
+       * Book this game into the league BEFORE the wire zero-decision gate below. A zero-decision
+       * episode (learner eliminated before it ever acts) emits no wire frame, but it is a real,
+       * decisive loss — recording it keeps the win-rate book and decisive-rate honest and up-weights
+       * the fields that crush the learner fastest (PFSP, [D-22]/[D-23]). The wire-skip is a frame
+       * concern; the Node-side league is orthogonal. `recordResult` excludes maxTurns truncations
+       * from the win-rate book internally. (Disconnect/error paths break/throw above, so a booked
+       * episode always carries a real terminal result.)
+       */
+      league.recordResult(drawn, result);
+
+      /*
        * Zero-decision episode: the learner was eliminated before it ever took a turn, so NO obs
        * frame was emitted (chooseAction never fired). The wire contract is a run of obs frames then
        * ONE terminal; a bare terminal with no preceding obs would land in the client's reset() —
@@ -304,12 +335,6 @@ async function main() {
         continue;
       }
       consecutiveZeroDecision = 0;
-
-      /*
-       * Tally the decisive episode into the league (B1: decisive/truncated counters; B2 adds
-       * per-opponent win-rate attribution). Zero-decision skips above are intentionally not counted.
-       */
-      league.recordResult(drawn, result);
 
       /*
        * Terminal frame: the learner's view of the board at the episode terminal (its elimination,

--- a/scripts/ppo-env-server.mjs
+++ b/scripts/ppo-env-server.mjs
@@ -369,7 +369,21 @@ async function main() {
       await new Promise(res => setImmediate(res));
     }
 
-    process.stdout.write(`PPO_ENV_SERVER DONE episodes=${played}\n`);
+    /*
+     * Emit the league health snapshot on the DONE line (the B5 throughput/decisive-rate re-probe
+     * reads this; it is the only window onto the otherwise-internal win-rate book until B4 wires it
+     * into `draw()`). `played` counts surfaced wire terminals; `decisiveGames` counts every booked
+     * decisive episode INCLUDING zero-decision skips — so `episodes < decisiveGames` is the visible
+     * signature of a zero-decision episode that was booked but surfaced no frame (the B2 reordering).
+     * env.py drains and drops this line (only the anchored LISTENING line is parsed), so appending
+     * fields is safe.
+     */
+    const s = league.stats();
+    process.stdout.write(
+      `PPO_ENV_SERVER DONE episodes=${played} decisiveGames=${s.decisiveGames} ` +
+        `truncatedGames=${s.truncatedGames} decisiveRate=${s.decisiveRate.toFixed(4)} ` +
+        `poolSize=${s.poolSize} loadedSnapshots=${s.loadedSnapshots} bookSize=${s.bookSize}\n`
+    );
   } finally {
     /*
      * Always reap the worker — otherwise its still-listening server keeps the process alive (a

--- a/tests/ml/ppo-env.test.js
+++ b/tests/ml/ppo-env.test.js
@@ -68,6 +68,24 @@ const fieldOpponents = count => {
   });
 };
 
+/**
+ * Independent oracle for the win-rate `seatBeat[]` vector (task B / [D-22]): derive "did the learner
+ * outplace seat `s`?" straight from a FINISHED game's placement order. Both outcome shapers
+ * (`summarizeOutcome` from placements, `eliminationOutcome` synthesized at death) must agree with
+ * this — deliberately a separate, simpler reimplementation than the production code so the assertion
+ * is a real cross-check, not a tautology. Placements are a strict total order, so no `0.5` ties.
+ */
+function seatBeatOracle(placements, learnerSeat, playerCount) {
+  const rank = new Array(playerCount).fill(-1);
+  placements.forEach((seat, i) => {
+    rank[seat] = i;
+  });
+  const learnerRank = rank[learnerSeat];
+  return Array.from({ length: playerCount }, (_, seat) =>
+    seat === learnerSeat ? null : learnerRank < rank[seat] ? 1 : 0
+  );
+}
+
 /** Compare the salient, data-only parts of two final states. */
 function projectState(s) {
   return {
@@ -216,6 +234,17 @@ describe('runSelfPlayEpisode — zero-decision episodes (the env-server desync h
     expect(ep.eliminated).toBe(true); // ended by elimination, not a win or stalemate cap
     expect(ep.won).toBe(0);
     expect(ep.truncated).toBe(false); // a genuine terminal (elimination), not a maxTurns truncation
+    /*
+     * The env-server now BOOKS zero-decision episodes into the league win-rate (a real decisive loss
+     * — [D-23] open-Q2, Ivan's call), so the outcome must still carry a well-formed seatBeat even
+     * though no obs frame was ever emitted: length playerCount, null at the learner's own seat, every
+     * other seat a 0/1. The learner was wiped before acting, so it beat nobody who outlived it.
+     */
+    expect(ep.seatBeat).toHaveLength(PLAYER_COUNT);
+    expect(ep.seatBeat[0]).toBeNull();
+    ep.seatBeat.forEach((v, s) => {
+      if (s !== 0) expect(v === 0 || v === 1).toBe(true);
+    });
   });
 });
 
@@ -293,6 +322,8 @@ describe('runSelfPlayEpisode — terminateOnElimination (PPO terminal)', () => {
     expect(early.turnCount).toBe(firstElimTurn);
     // Placement synthesized at death (rank = #alive) equals calculatePlacements at game-over.
     expect(early.placement).toBe(scaledPlacement(full.placements, 2, PLAYER_COUNT));
+    // ...and so does the per-seat win/loss vector the league books for win-rate attribution.
+    expect(early.seatBeat).toEqual(seatBeatOracle(full.placements, 2, PLAYER_COUNT));
   });
 
   /*
@@ -344,6 +375,15 @@ describe('runSelfPlayEpisode — terminateOnElimination (PPO terminal)', () => {
     expect(deathElims).toBeGreaterThan(1); // precondition: this seed really IS a co-elimination turn
     expect(early.eliminated).toBe(true);
     expect(early.placement).toBe(scaledPlacement(full.placements, seat, PLAYER_COUNT));
+    /*
+     * The win-rate `seatBeat[]` from BOTH shapers agrees with the engine's placement order even on a
+     * multi-elimination turn — the early path synthesizes it from alive/co-elim with the seat-id
+     * tie-break (higher-id co-eliminee placed above the learner), the full path reads placements, and
+     * both equal the independent oracle. This is the load-bearing B2 attribution correctness check.
+     */
+    const oracle = seatBeatOracle(full.placements, seat, PLAYER_COUNT);
+    expect(early.seatBeat).toEqual(oracle);
+    expect(full.seatBeat).toEqual(oracle);
   });
 
   it('an elimination that also ends the game reports the engine winner with won=0 (runner-up)', async () => {
@@ -379,6 +419,10 @@ describe('runSelfPlayEpisode — terminateOnElimination (PPO terminal)', () => {
     expect(early.won).toBe(0);
     // Exact parity with the engine's game-over placement, not just a [0,1] bounds check.
     expect(early.placement).toBe(scaledPlacement(full.placements, seat, PLAYER_COUNT));
+    // Runner-up: the learner outplaced everyone except the game's winner → exactly one 0 in seatBeat.
+    const oracle = seatBeatOracle(full.placements, seat, PLAYER_COUNT);
+    expect(early.seatBeat).toEqual(oracle);
+    expect(oracle.filter(v => v === 0)).toHaveLength(1);
   });
 
   it('is a no-op when the learner wins — identical to the full game', async () => {
@@ -407,6 +451,10 @@ describe('runSelfPlayEpisode — terminateOnElimination (PPO terminal)', () => {
     expect(early.placement).toBe(full.placement);
     expect(early.placements).toEqual(full.placements);
     expect(projectState(early.finalState)).toEqual(projectState(full.finalState));
+    // A winning learner outplaces every other seat → seatBeat is all 1s, null only at its own seat.
+    expect(early.seatBeat).toEqual(full.seatBeat);
+    expect(early.seatBeat[0]).toBeNull();
+    expect(early.seatBeat.filter(v => v === 1)).toHaveLength(PLAYER_COUNT - 1);
   });
 });
 

--- a/tests/ml/ppo-league-snapshots.test.js
+++ b/tests/ml/ppo-league-snapshots.test.js
@@ -1,0 +1,169 @@
+/**
+ * PFSP league snapshot pool — `refresh()` hot-loading (ml-bot Phase 3, task B step B3 — [D-22]/[D-23]).
+ *
+ * The producer (a Python SB3 callback) publishes self-play snapshots as exported `.weights.js`
+ * modules + an atomic `manifest.json`; the env-server polls `league.refresh()` at each episode
+ * boundary to hot-load the new ones via `makeBC`. These tests drive that consumer side against
+ * hand-written manifests + minimal weights modules in a temp dir — covering the no-op/empty-pool
+ * path, incremental loading, the mtime no-change short-circuit, FIFO eviction + disk GC, the
+ * `loadedIds` guard (an evicted id is never re-imported from its deleted file), and the frozen-
+ * `ENCODING_VERSION` fail-loud (manifest-level and per-snapshot).
+ *
+ * A "snapshot" here is a minimal `export const BC_POLICY = { encodingVersion, config:{maxAreas} }`
+ * module — enough for `makeBC` to accept it (it validates encodingVersion + reads config.maxAreas;
+ * the forward pass only runs when the bot acts, which `refresh()` never does). Real exported policies
+ * are 2 MB; the loading logic under test is identical, so tiny stand-ins keep the suite fast.
+ */
+
+import { existsSync, mkdtempSync, rmSync, writeFileSync, utimesSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { makeLeague } from '../../scripts/lib/ppo-league.mjs';
+
+const DEFAULT_OPPONENTS = 'ai_lookahead,ai_strategist,ai_expectimax,ai_bc,ai_defensive';
+const COUNT = 6;
+
+let dir;
+let mtimeTick; // monotonic mtime stamp so manifest rewrites are always seen as "changed"
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'ppo-snap-'));
+  mtimeTick = 1_700_000_000; // fixed base (seconds) — bumped per manifest write
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+/** Write a minimal exported-policy module `snap-<step>.weights.js`; returns its bare filename. */
+function writeSnapshot(step, { encodingVersion = 2, maxAreas = 32 } = {}) {
+  const file = `snap-${String(step).padStart(6, '0')}.weights.js`;
+  writeFileSync(
+    join(dir, file),
+    `export const BC_POLICY = ${JSON.stringify({ encodingVersion, config: { maxAreas } })};\n`
+  );
+  return file;
+}
+
+/** Write `manifest.json` and stamp it with a strictly-increasing mtime (defeats coarse fs clocks). */
+function writeManifest(snapshots, { encodingVersion = 2 } = {}) {
+  const path = join(dir, 'manifest.json');
+  const latestStep = snapshots.reduce((m, s) => Math.max(m, s.step), 0);
+  writeFileSync(path, JSON.stringify({ encodingVersion, snapshots, latestStep }));
+  const t = ++mtimeTick;
+  utimesSync(path, t, t);
+  return path;
+}
+
+/** Manifest entry for a freshly-written snapshot at `step`. */
+function snap(step, opts) {
+  return { id: `snap-${step}`, step, weights: writeSnapshot(step, opts), createdAt: '2026-06-27' };
+}
+
+const league = (snapshotManifest, extra = {}) =>
+  makeLeague({
+    baselineCsv: DEFAULT_OPPONENTS,
+    count: COUNT,
+    learnerSeat: 0,
+    snapshotManifest,
+    ...extra,
+  });
+
+describe('ppo-league snapshots — refresh() no-op paths', () => {
+  it('is a no-op with no manifest configured (empty-pool fixed-field mode)', async () => {
+    const lg = league(null);
+    expect(await lg.refresh()).toEqual({ added: 0, poolSize: 0 });
+    expect(lg.stats()).toMatchObject({ poolSize: 0, loadedSnapshots: 0 });
+  });
+
+  it('is a no-op when the manifest file does not exist yet (producer has not published)', async () => {
+    const lg = league(join(dir, 'manifest.json')); // path valid, file absent
+    expect(await lg.refresh()).toEqual({ added: 0, poolSize: 0 });
+  });
+});
+
+describe('ppo-league snapshots — hot-loading into the pool', () => {
+  it('loads each new snapshot via makeBC and grows the pool', async () => {
+    const manifest = writeManifest([snap(100), snap(200)]);
+    const lg = league(manifest);
+    expect(await lg.refresh()).toEqual({ added: 2, poolSize: 2 });
+    expect(lg.stats()).toMatchObject({ poolSize: 2, loadedSnapshots: 2 });
+  });
+
+  it('does NOT seat snapshots in draw() yet (B3 only loads; B4 samples)', async () => {
+    const lg = league(writeManifest([snap(100), snap(200)]));
+    const before = lg.draw(7).opponents.map(o => o.name);
+    await lg.refresh();
+    const after = lg.draw(7).opponents.map(o => o.name);
+    // The drawn field is byte-identical baselines before and after snapshots enter the pool.
+    expect(after).toEqual(before);
+    expect(after).not.toContain('snap-100');
+  });
+
+  it('re-refresh with an unchanged manifest loads nothing (mtime short-circuit)', async () => {
+    const lg = league(writeManifest([snap(100)]));
+    expect(await lg.refresh()).toEqual({ added: 1, poolSize: 1 });
+    expect(await lg.refresh()).toEqual({ added: 0, poolSize: 1 }); // same mtime → skipped
+  });
+
+  it('loads only the newly-added snapshot on a manifest rewrite (diff by id)', async () => {
+    const lg = league(join(dir, 'manifest.json'));
+    writeManifest([snap(100)]);
+    expect(await lg.refresh()).toEqual({ added: 1, poolSize: 1 });
+    // Rewrite with one more entry (snap-100 reused; snap-300 new) and a strictly-newer mtime.
+    writeManifest([{ id: 'snap-100', step: 100, weights: 'snap-000100.weights.js' }, snap(300)]);
+    expect(await lg.refresh()).toEqual({ added: 1, poolSize: 2 });
+    expect(lg.stats()).toMatchObject({ loadedSnapshots: 2 });
+  });
+});
+
+describe('ppo-league snapshots — FIFO eviction + disk GC', () => {
+  it('keeps the most-recent poolCap and GCs the evicted snapshot .js (FIFO by step)', async () => {
+    const f100 = snap(100);
+    const f200 = snap(200);
+    const f300 = snap(300);
+    const lg = league(writeManifest([f100, f200, f300]), { poolCap: 2 });
+    expect(await lg.refresh()).toEqual({ added: 3, poolSize: 2 }); // loaded 3, evicted oldest
+
+    expect(lg.stats()).toMatchObject({ poolSize: 2, loadedSnapshots: 3 });
+    expect(existsSync(join(dir, f100.weights))).toBe(false); // step 100 evicted → file GC'd
+    expect(existsSync(join(dir, f200.weights))).toBe(true);
+    expect(existsSync(join(dir, f300.weights))).toBe(true);
+  });
+
+  it('never re-imports an evicted (GC-deleted) snapshot — the loadedIds guard', async () => {
+    const f100 = snap(100);
+    const path = writeManifest([f100, snap(200), snap(300)]);
+    const lg = league(path, { poolCap: 2 });
+    await lg.refresh();
+    expect(existsSync(join(dir, f100.weights))).toBe(false); // evicted + deleted
+
+    /*
+     * Force a re-read (bump mtime, same content). snap-100 is in loadedIds → not re-imported from the
+     * now-missing file, so refresh must not throw and must add nothing.
+     */
+    utimesSync(path, ++mtimeTick, mtimeTick);
+    expect(await lg.refresh()).toEqual({ added: 0, poolSize: 2 });
+  });
+});
+
+describe('ppo-league snapshots — frozen ENCODING_VERSION fail-loud', () => {
+  it('rejects a manifest whose encodingVersion != the encoder (fail fast, before any import)', async () => {
+    const lg = league(writeManifest([snap(100)], { encodingVersion: 99 }));
+    await expect(lg.refresh()).rejects.toThrow(/encodingVersion 99/);
+  });
+
+  it('rejects a snapshot module whose own encodingVersion is skewed (per-snapshot makeBC guard)', async () => {
+    // Manifest says 2 (passes the manifest check), but the weights module declares 99 → makeBC throws.
+    const lg = league(writeManifest([snap(100, { encodingVersion: 99 })]));
+    await expect(lg.refresh()).rejects.toThrow(/encodingVersion/);
+  });
+});
+
+describe('ppo-league snapshots — construction validation', () => {
+  it('rejects a non-positive or fractional poolCap', () => {
+    for (const poolCap of [0, -1, 2.5]) {
+      expect(() => league(null, { poolCap })).toThrow(/poolCap must be a positive integer/);
+    }
+  });
+});

--- a/tests/ml/ppo-league.test.js
+++ b/tests/ml/ppo-league.test.js
@@ -144,10 +144,15 @@ describe('ppo-league — telemetry tally (B1)', () => {
   it('counts decisive vs maxTurns-truncated games and reports decisive-rate', () => {
     const league = makeLeague({ baselineCsv: DEFAULT_OPPONENTS, count: COUNT, learnerSeat: 0 });
     const { drawn } = league.draw(0);
-    league.recordResult(drawn, { truncated: false });
-    league.recordResult(drawn, { truncated: false });
-    league.recordResult(drawn, { truncated: false });
-    league.recordResult(drawn, { truncated: true });
+    /*
+     * Realistic decisive games carry a seatBeat[] (the all-loss vector here); this test asserts only
+     * the counters, but supplying it keeps the path realistic and avoids the no-seatBeat warn.
+     */
+    const seatBeat = [null, 0, 0, 0, 0, 0, 0];
+    league.recordResult(drawn, { truncated: false, seatBeat });
+    league.recordResult(drawn, { truncated: false, seatBeat });
+    league.recordResult(drawn, { truncated: false, seatBeat });
+    league.recordResult(drawn, { truncated: true, seatBeat });
     const s = league.stats();
     expect(s.decisiveGames).toBe(3);
     expect(s.truncatedGames).toBe(1);
@@ -232,11 +237,51 @@ describe('ppo-league — win-rate book (B2)', () => {
     expect(league.winRate('ai_strategist')).toBe(0);
   });
 
-  it('counts the decisive game but books nothing when no seatBeat is present (defensive)', () => {
+  it('counts the decisive game, books nothing, and warns ONCE when no seatBeat is present (defensive)', () => {
     const league = newLeague(0);
     const { drawn } = league.draw(0);
-    league.recordResult(drawn, { truncated: false }); // no seatBeat
-    expect(league.stats()).toMatchObject({ bookSize: 0, decisiveGames: 1 });
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      league.recordResult(drawn, { truncated: false }); // no seatBeat → warn + skip booking
+      league.recordResult(drawn, { truncated: false }); // second offence must NOT re-warn (warn-once)
+      // Both games are still counted as decisive; the book stays empty.
+      expect(league.stats()).toMatchObject({ bookSize: 0, decisiveGames: 2 });
+      // The contract-break is surfaced exactly once (the regression-visibility signal FIX 3 adds).
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0][0]).toMatch(/no seatBeat/);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('throws on an out-of-domain seatBeat value (shaper/seat desync — never folds garbage into wins)', () => {
+    const league = newLeague(0);
+    const { drawn } = league.draw(0);
+    // 2 is outside {0, 0.5, 1}; the old `typeof === 'number'` guard would have done `wins += 2`.
+    expect(() =>
+      league.recordResult(drawn, { truncated: false, seatBeat: [null, 2, 0, 0, 0, 0, 0] })
+    ).toThrow(/outside \{0,0\.5,1\}/);
+  });
+
+  it('throws on a NaN seatBeat value (the load-bearing triple-inequality case)', () => {
+    const league = newLeague(0);
+    const { drawn } = league.draw(0);
+    // NaN !== 0 && NaN !== 1 && NaN !== 0.5 is all-true, so NaN must THROW, not silently poison wins.
+    expect(() =>
+      league.recordResult(drawn, { truncated: false, seatBeat: [null, NaN, 0, 0, 0, 0, 0] })
+    ).toThrow(/outside \{0,0\.5,1\}/);
+  });
+
+  it('accepts a 0.5 tie without throwing and credits half a win', () => {
+    const league = newLeague(0);
+    const { drawn } = league.draw(0);
+    /*
+     * 0.5 is the documented (unreachable-in-practice) elo-parity tie; it must be booked, not rejected.
+     * ai_strategist sits at board seat 2 (only ai_lookahead is cycled onto two seats), so the tie
+     * goes at index 2 → its win-rate is exactly 0.5 (half a win / one game).
+     */
+    league.recordResult(drawn, { truncated: false, seatBeat: [null, 0, 0.5, 0, 0, 0, 0] });
+    expect(league.winRate('ai_strategist')).toBeCloseTo(0.5, 10); // 0.5 wins / 1 game
   });
 });
 

--- a/tests/ml/ppo-league.test.js
+++ b/tests/ml/ppo-league.test.js
@@ -161,6 +161,85 @@ describe('ppo-league — telemetry tally (B1)', () => {
   });
 });
 
+describe('ppo-league — win-rate book (B2)', () => {
+  /*
+   * The book credits the LEARNER's pairwise record against each drawn opponent, reading the result's
+   * per-board-seat `seatBeat[]` at `drawn[k].seat`. These tests drive `recordResult` with hand-built
+   * `seatBeat` vectors (the shaper correctness is pinned separately in ppo-env.test.js) and assert the
+   * id-keyed `winRate`. count=6 over DEFAULT_OPPONENTS cycles ai_lookahead onto two seats, so one game
+   * yields two records for it — the load-bearing "cycled baseline → independent per-seat records" case.
+   */
+  const newLeague = (learnerSeat = 0) =>
+    makeLeague({ baselineCsv: DEFAULT_OPPONENTS, count: COUNT, learnerSeat });
+
+  it('credits each opponent id pairwise from seatBeat, double-recording a cycled baseline', () => {
+    const league = newLeague(0);
+    const { drawn } = league.draw(0); // seats [1..6], ids [look, strat, expect, bc, def, look]
+    // seatBeat indexed by board seat (learner seat 0 → null): beat seats 1,3,5; lost seats 2,4,6.
+    league.recordResult(drawn, { truncated: false, seatBeat: [null, 1, 0, 1, 0, 1, 0] });
+
+    expect(league.winRate('ai_lookahead')).toBeCloseTo(0.5, 10); // seat1 beat + seat6 lost → 1/2
+    expect(league.winRate('ai_strategist')).toBe(0); // seat2 lost
+    expect(league.winRate('ai_expectimax')).toBe(1); // seat3 beat
+    expect(league.winRate('ai_bc')).toBe(0); // seat4 lost
+    expect(league.winRate('ai_defensive')).toBe(1); // seat5 beat
+    expect(league.stats().bookSize).toBe(5); // 5 distinct ids (ai_lookahead counted once)
+  });
+
+  it('reads seatBeat at the BOARD seat, not the opponent-array index (interior learner)', () => {
+    /*
+     * learnerSeat=3 → opponents fill seats [0,1,2,4,5,6]; the array index and the board seat diverge,
+     * so a book that keyed on the array index instead of `drawn[k].seat` would mis-credit. seatBeat is
+     * board-seat indexed with null at seat 3.
+     */
+    const league = newLeague(3);
+    const { drawn } = league.draw(0); // ids [look@0, strat@1, expect@2, bc@4, def@5, look@6]
+    league.recordResult(drawn, { truncated: false, seatBeat: [1, 0, 1, null, 0, 1, 0] });
+
+    expect(league.winRate('ai_lookahead')).toBeCloseTo(0.5, 10); // seat0 beat + seat6 lost
+    expect(league.winRate('ai_strategist')).toBe(0); // seat1 lost
+    expect(league.winRate('ai_expectimax')).toBe(1); // seat2 beat
+    expect(league.winRate('ai_bc')).toBe(0); // seat4 lost
+    expect(league.winRate('ai_defensive')).toBe(1); // seat5 beat
+  });
+
+  it('accumulates win-rate across games', () => {
+    const league = newLeague(0);
+    const { drawn } = league.draw(0);
+    // Game 1: beat strategist (seat 2). Game 2: lost to strategist. → 1/2.
+    league.recordResult(drawn, { truncated: false, seatBeat: [null, 0, 1, 0, 0, 0, 0] });
+    league.recordResult(drawn, { truncated: false, seatBeat: [null, 0, 0, 0, 0, 0, 0] });
+    expect(league.winRate('ai_strategist')).toBeCloseTo(0.5, 10);
+    expect(league.stats().decisiveGames).toBe(2);
+  });
+
+  it('EXCLUDES maxTurns truncations from the book (counts only the truncated tally)', () => {
+    const league = newLeague(0);
+    const { drawn } = league.draw(0);
+    // A truncated game carries a seatBeat, but it must NOT touch the win-rate book ([D-22] decision 5).
+    league.recordResult(drawn, { truncated: true, seatBeat: [null, 1, 1, 1, 1, 1, 1] });
+    expect(league.winRate('ai_lookahead')).toBe(0); // unchanged — cold-start
+    expect(league.stats()).toMatchObject({ bookSize: 0, truncatedGames: 1, decisiveGames: 0 });
+  });
+
+  it('returns winRate 0 for an unseen id (cold-start = max PFSP weight), same as all-losses', () => {
+    const league = newLeague(0);
+    expect(league.winRate('ai_lookahead')).toBe(0); // never recorded
+    expect(league.winRate('totally-unknown-snapshot')).toBe(0);
+    // A recorded all-losses id is also 0 — intentionally indistinguishable; both want max weight.
+    const { drawn } = league.draw(0);
+    league.recordResult(drawn, { truncated: false, seatBeat: [null, 0, 0, 0, 0, 0, 0] });
+    expect(league.winRate('ai_strategist')).toBe(0);
+  });
+
+  it('counts the decisive game but books nothing when no seatBeat is present (defensive)', () => {
+    const league = newLeague(0);
+    const { drawn } = league.draw(0);
+    league.recordResult(drawn, { truncated: false }); // no seatBeat
+    expect(league.stats()).toMatchObject({ bookSize: 0, decisiveGames: 1 });
+  });
+});
+
 describe('ppo-league — error handling', () => {
   it('throws on an empty opponents CSV', () => {
     expect(() => makeLeague({ baselineCsv: '  ,  ', count: COUNT, learnerSeat: 0 })).toThrow(


### PR DESCRIPTION
Task B steps **B2** (win-rate attribution) and **B3** (snapshot pipeline) of the PFSP opponent league ([D-22]/[D-23]). Builds on the merged B1 (#64). **Behavior-preserving for episode outcomes** — `draw()` does not sample the snapshot pool until B4, so training games are still the fixed baseline field.

## B2 — per-opponent win-rate book (the [D-22] "real work item")
- **`seatBeat[]` on both outcome shapers** (`scripts/lib/ppo-env.mjs`): `summarizeOutcome` derives "did the learner outplace seat *s*?" from the placement order; `eliminationOutcome` synthesizes it at the learner's death (alive→0, prior-elim→1, same-turn co-elim split by the seat-id tie-break) via a `coElimSeats` **Set** threaded out of `guardedOnTurn` — keeping the ~2× early-termination throughput (no full `placements` build).
- **id-keyed win-rate book** (`scripts/lib/ppo-league.mjs`): `recordResult` credits `book[id].wins += seatBeat[seat]` per drawn opponent, **excluding `maxTurns` truncations** ([D-22] decision 5). `winRate(id)` → `wins/games`, **0 on cold-start** (= max PFSP weight). A cycled baseline seated twice → two independent records.
- **env-server books every real game incl. zero-decision losses** — moved `recordResult` above the wire zero-decision gate (Ivan's call on [D-23] open-Q2: the wire-skip is a frame concern; the Node league is orthogonal).

## B3 — snapshot pipeline (producer + consumer)
- **Producer** (`ml/dicewars_ppo/snapshot_callback.py`): `SnapshotCallback` publishes every `--snapshot-every` steps via the gate-proven `repack → export(…, fixture_path=None)`, then an **atomic** manifest (fsync weights → `os.replace`). `train_tracer.py` (`--snapshot-dir`/`-every`/`-pool-cap`, absolutized + callback attached); `EnvServerProcess` forwards the flags (`env.py` already splats `server_kwargs`).
- **Consumer** (`scripts/lib/ppo-league.mjs` `refresh()`): mtime-guarded manifest poll → diff by stable id → dynamic-`import()` each new `.weights.js` (fresh filename → ESM URL cache) → `makeBC({policy})` → **FIFO-evict past `poolCap` + GC the evicted `.js`**; `loadedIds` prevents re-importing a deleted file; encoding-version skew throws (frozen `ENCODING_VERSION` run-invariant). `makeBC`/`ENCODING_VERSION` are lazy-imported so the B1/B2 fast tests never pay the 2 MB load. Env-server: `--snapshot-manifest`/`--snapshot-pool-cap` + `await league.refresh()` at each episode boundary.

## Tests — full suite **1040 green**; lint + prettier clean
- **Node:** `tests/ml/ppo-league-snapshots.test.js` (11 — no-op paths, incremental diff, mtime short-circuit, FIFO eviction + disk GC, `loadedIds`-vs-deleted-file guard, encoding-version fail-loud); `seatBeat` oracle threaded into the existing co-elim/win fixtures in `ppo-env.test.js` (zero extra match runs); 6 win-rate-book tests in `ppo-league.test.js`.
- **Python:** `ml/tests/test_snapshot_callback.py` (5 — cadence, atomic manifest schema mirroring the JS consumer, publish orchestration). `py_compile` OK.

## ⚠️ Local-validation gap
No torch/sb3 on the dev Mac, so **the Python producer was not run locally** — it's covered by `py_compile` + the monkeypatched pytest (run on **shodan/CI**), and the `repack→export` step it wraps is already gate-proven (PR #61). Its first live exercise is at B4.

## Deviations from D-23 (folded into PLAN/LOG/DECISIONS)
- `--snapshot-store` deferred to B6 with `SharedDiskStore` (no dead flag now).
- `--snapshot-pool-cap` added + forwarded (the pool cap is the consumer-side setting that must reach Node).
- Producer `manifest.json` is append-only (tiny entries; prune in B5/B6 if needed).

**Next: B4** — turn PFSP weighting on in `draw()` (`w(S)=max(ε,1−winRate)^k`, R=3 reserved baselines, seeded `mulberry32`); the first step the league runs live with the Python producer on shodan.
