### PR TITLE
feat(ml): PPO league task B — B4 PFSP weighting on

### DIFF
--- a/docs/ml-bot/DECISIONS.md
+++ b/docs/ml-bot/DECISIONS.md
@@ -1294,16 +1294,34 @@ mode-agnostic; C is where cross-worker aggregation becomes load-bearing (intertw
 backend). Task D (reward shaping) — orthogonal (env-side JS reward). Task E (`SubprocVecEnv` +
 checkpoint/resume) — must persist the league pool + book + counters (B6).
 
-**Status: In progress (B0–B3 shipped 2026-06-27).** B0 (PR #62 merged) · B1 (PR #64, empty-pool
+**Status: In progress (B0–B4 shipped 2026-06-27).** B0 (PR #62 merged) · B1 (PR #64, empty-pool
 parity) · B2 (per-seat `seatBeat[]` + win-rate book) · B3 (snapshot pipeline:
-`ml/dicewars_ppo/snapshot_callback.py` + league `refresh()` + the `--snapshot-*` flags). **B3
+`ml/dicewars_ppo/snapshot_callback.py` + league `refresh()` + the `--snapshot-*` flags) · B4 (PFSP
+sampling on in `draw()`). **B3
 deviations from this scope:** (a) `--snapshot-store` deferred to B6 with `SharedDiskStore` rather than
 shipping a dead flag now; (b) `--snapshot-pool-cap` added and forwarded through `EnvServerProcess`
 (the pool cap is the consumer-side setting that must reach the Node league — D-23's literal list only
 named `snapshot_manifest`/`snapshot_store`); (c) the producer `manifest.json` is append-only (entries
 are tiny; prune in B5/B6 if it matters); (d) `draw()` does NOT sample the pool until B4, so B3 is
-behavior-preserving. The Python producer is validated by `py_compile` + a monkeypatched pytest (no
-local torch/sb3); it gets its first live exercise on shodan at B4. **Next: B4** (PFSP weighting on).
+behavior-preserving. **B4 implementation notes.** Non-empty-pool `draw(seed)` seeds a `mulberry32`
+stream and fills `count` seats: `reserveCount = min(R, count, #distinctReserveBaselines)` aggressive
+baselines (CSV ids minus `ai_bc`) sampled WITHOUT replacement, then `count − reserveCount` snapshots
+sampled WITH replacement by `w(S) = max(ε, 1 − learnerWinRate(S))^k` (ε=0.05, k=2; cold-start
+`winRate=0` → weight 1 → sampled hardest; ε>0 floors every weight at ε^k>0 for sane k so a mastered
+snapshot is never starved — with a `total===0 → uniform` fallback for the pathological-k case where
+ε^k underflows to 0.0 in IEEE-754), then a Fisher-Yates shuffle of opponent→seat (same seeded stream)
+so neither group binds to fixed turn-order seats. Deterministic given (seed, pool, book). The PFSP
+knobs are validated UNCONDITIONALLY on both sides (Node `makeLeague` and Python `_validate_args`), and
+the reserve-pool build re-validates ids beyond the cycled `count` (which `resolveBaselineField` skips).
+Knobs are env-server flags `--reserve-baselines`/`--pfsp-epsilon`/`--pfsp-k`, forwarded by
+`train_tracer`/`EnvServerProcess` on the `--snapshot-dir` branch (they only bite a non-empty pool).
+**B4 deviation from this scope:** `mulberry32` was **extracted to NEW `scripts/lib/mulberry32.mjs`**
+(re-exported from `ppo-probe-core.mjs` so its test/consumers are unchanged) instead of imported from
+`ppo-probe-core.mjs` as the file manifest said — the league is a runtime lib and should not pull the
+throughput-benchmark tool (and, through it, the env runner) into its module graph just to borrow a PRNG.
+The Node sampler is unit-tested (`tests/ml/ppo-league-pfsp.test.js`) and the Python flag bridge by
+`ml/tests/test_env_server_argv.py`; it gets its first live exercise on shodan at B5. **Next: B5**
+(throughput/decisive-rate re-probe on a snapshot-heavy field; re-validate `R` against the real `count`).
 
 **Grounding.** 9-agent scoping workflow (4 code-readers mapping env-server / training-snapshot /
 match-stats / locked-decisions → 3 design decisions → synthesize + adversarial verify). One design

--- a/docs/ml-bot/LOG.md
+++ b/docs/ml-bot/LOG.md
@@ -21,6 +21,83 @@ Entry template:
 
 ---
 
+## 2026-06-27 — Task B step B4: PFSP weighting on (the sampler goes live)
+
+**Phase:** 3 · **Who:** Ivan + Claude
+
+**Did:** Turned the PFSP sampler on in `scripts/lib/ppo-league.mjs` `draw()`. B3 only _loaded_ the
+snapshot pool; B4 seats it. With a non-empty pool, `draw(seed)` seeds a `mulberry32` stream and fills
+the `count` opponent seats with:
+
+- `reserveCount = min(R, count, #distinctReserveBaselines)` aggressive baselines (the resolved
+  `--opponents` ids, **distinct, minus `ai_bc`** — the [D-15] turtle-equilibrium defense), sampled
+  WITHOUT replacement; then
+- `count − reserveCount` snapshots sampled WITH replacement by `w(S) = max(ε, 1 − learnerWinRate(S))^k`
+  (`ε=0.05`, `k=2`): lower learner win-rate ⇒ higher weight, cold-start `winRate=0` ⇒ weight 1
+  (sampled hardest first), and ε>0 floors every weight at `ε^k > 0` so a fully-mastered snapshot is
+  never starved (with a uniform fallback if a pathological k underflows `ε^k` to 0 — see post-review);
+
+then a Fisher-Yates shuffle (same seeded stream) of opponent→seat so neither group binds to fixed
+turn-order seats. **Empty pool still returns the byte-identical task-A field** — fixed-field stays the
+empty-pool mode of this one pipeline.
+
+- **Knobs as CLI flags.** Env-server `--reserve-baselines`/`--pfsp-epsilon`/`--pfsp-k` → `makeLeague`;
+  `train_tracer.py` args + `_validate_args` bounds (ε∈(0,1], k≥0, R≥0, mirroring the Node guards) +
+  `EnvServerProcess` argv forwarding. The PFSP knobs ride the `--snapshot-dir`/`snapshot_manifest`
+  branch since they only bite a non-empty pool; Node↔Python defaults agree (R=3, ε=0.05, k=2).
+- **Tests.** NEW `tests/ml/ppo-league-pfsp.test.js` (17 tests: field shape, reserve rules incl. the
+  cap and the empty-reserve `ai_bc`-only case, seeded determinism, win-rate-monotone weighting +
+  the higher-k-sharpens check, the ε floor / all-mastered pool, draw→record→winRate loop, new-knob
+  validation). NEW `ml/tests/test_env_server_argv.py` (the Python→Node flag bridge — the only
+  automated guard on argv forwarding, runs torch-free). Updated the one B3 test that asserted "B4
+  hasn't happened yet" to assert snapshots ARE now seated.
+
+**Learned / decided:**
+
+- **Extracted `mulberry32` to its own module** (`scripts/lib/mulberry32.mjs`, re-exported from
+  `ppo-probe-core.mjs`) rather than importing it from the probe tool as [D-23]'s file manifest said:
+  the league is runtime code and shouldn't pull the throughput-benchmark tool (→ the env runner) into
+  its module graph just to borrow an 8-line PRNG. Re-export keeps the existing probe test/imports green.
+- **Shuffle opponent→seat** (a [D-23]-unstated addition): without it, reserve baselines would always
+  occupy the low array indices and thus the early (first-to-move) board seats — a systematic
+  turn-order pattern the learner could overfit. The shuffle is seeded, so determinism holds.
+- **Reserve baselines without replacement, capped at the distinct count** (`min(R, count, #reserve)`):
+  guarantees R _distinct_ aggressive opponents when enough exist, and degrades gracefully (more PFSP
+  seats) when the CSV has fewer than R aggressive bots or is `ai_bc`-only (→ 0 reserved, all PFSP).
+
+**Post-review hardening (5-dimension adversarial workflow → 12 confirmed findings, all minor):**
+
+- **Reserve lookup now guarded.** `resolveBaselineField` only validates the first `count` _cycled_
+  positions, so a typo'd opponent id PAST position `count−1` slipped past it and crashed the new
+  reserve-pool build with a cryptic `undefined.name`. Added the same clear `Unknown opponent bot id`
+  throw + corrected the false "cannot miss" comment.
+- **ε^k FP-underflow fallback.** At a pathological `k` (≥~249 for ε=0.05), `ε^k` underflows to 0.0 in
+  IEEE-754; with an all-mastered pool that zeroes the roulette total and `sampleByWeight` would
+  degenerate to "always the last entry". Added a `total === 0 → uniform` fallback (and scoped the
+  "never 0" claims to non-underflowing k).
+- **Python validation tightened.** Moved the three PFSP guards OUT of the `--snapshot-dir` branch so
+  they validate unconditionally (matching Node's always-on `makeLeague`), and added `math.isfinite`
+  for `--pfsp-k` (was accepting inf/nan).
+- **Test gaps closed.** Added: a shuffle anti-coupling test (a snapshot reaches the earliest seat and
+  a baseline the latest — disabling the shuffle now fails); a default-pin test (default field sequence
+  == explicit `{ε:0.05,k:2}`, ≠ other ε); the underflow-fallback test; the reserve-typo guard test;
+  and a torch-gated `test_train_tracer_args.py` (parser defaults, `_validate_args` rejections, the
+  `_make_env_thunk → server_kwargs` forwarding hop). Final: 1064 JS tests + ruff/lint/build all green.
+
+**Dead ends / surprises:**
+
+- Local `ml` pytest shows 6 pre-existing failures in `test_export_onnx.py` (`zip(strict=True)` needs
+  Python 3.10+; this box has 3.9) — unrelated to B4, untouched files. The B4 Python (`train_tracer`
+  imports SB3) is validated by `py_compile` + the torch-free argv test, per the B3 precedent.
+- Several review agents initially read a stale/phantom `ppo-league.mjs` and "found" that B4 was
+  unimplemented; the adversarial verify pass caught and rejected all of those against ground truth.
+
+**Next:**
+
+- **B5** — throughput / decisive-rate re-probe on a snapshot-heavy field (BC-forward snapshot seats
+  cost ~0.8 ms/move vs ~0.02–0.4 ms heuristic); re-validate `R` against the real `count`, then lock
+  the env-step budget. First live exercise of the sampler runs on shodan here.
+
 ## 2026-06-27 — Task B step B3: the snapshot pipeline (Python producer → Node hot-load)
 
 **Phase:** 3 · **Who:** Ivan + Claude

--- a/docs/ml-bot/LOG.md
+++ b/docs/ml-bot/LOG.md
@@ -45,7 +45,7 @@ empty-pool mode of this one pipeline.
   `train_tracer.py` args + `_validate_args` bounds (ε∈(0,1], k≥0, R≥0, mirroring the Node guards) +
   `EnvServerProcess` argv forwarding. The PFSP knobs ride the `--snapshot-dir`/`snapshot_manifest`
   branch since they only bite a non-empty pool; Node↔Python defaults agree (R=3, ε=0.05, k=2).
-- **Tests.** NEW `tests/ml/ppo-league-pfsp.test.js` (17 tests: field shape, reserve rules incl. the
+- **Tests.** NEW `tests/ml/ppo-league-pfsp.test.js` (21 tests: field shape, reserve rules incl. the
   cap and the empty-reserve `ai_bc`-only case, seeded determinism, win-rate-monotone weighting +
   the higher-k-sharpens check, the ε floor / all-mastered pool, draw→record→winRate loop, new-knob
   validation). NEW `ml/tests/test_env_server_argv.py` (the Python→Node flag bridge — the only
@@ -83,6 +83,31 @@ empty-pool mode of this one pipeline.
   == explicit `{ε:0.05,k:2}`, ≠ other ε); the underflow-fallback test; the reserve-typo guard test;
   and a torch-gated `test_train_tracer_args.py` (parser defaults, `_validate_args` rejections, the
   `_make_env_thunk → server_kwargs` forwarding hop). Final: 1064 JS tests + ruff/lint/build all green.
+
+**Second-pass review hardening (multi-agent `/review-pr`, follow-up commit).** A 5-agent review (code /
+tests / silent-failure / comments / type-design) found no correctness bug in the production path but
+flagged four silent-degradation footguns, all fixed:
+
+- **Dead-PFSP guard (was: silent no-op).** When reserved baselines fill every seat
+  (`min(R, #reserveBaselinePool) >= count`, e.g. default `R=3` on a 4-player game ⇒ `count=3`),
+  `draw()` seated ZERO snapshots despite a loaded pool — PFSP silently off, `stats()` still healthy.
+  `makeLeague` now throws at construction when a manifest is configured (decidable from config alone;
+  fixed-field mode is exempt). The production 7-player path (`count=6`) is unaffected.
+- **Persistent no-seatBeat now fails loud.** A one-off missing `seatBeat[]` stays warn-once, but past
+  `MAX_NO_SEATBEAT_GAMES` (10) `recordResult` throws — a persistent contract break leaves the win-rate
+  book uncredited and collapses PFSP to uniform, which the warn-once alone let run silently for hours.
+  The cumulative count is exposed on `stats()` and the `PPO_ENV_SERVER DONE` line (`noSeatBeatGames=`).
+- **Node-side flag bridge now tested.** NEW `tests/ml/ppo-env-server-args.test.js` covers the middle
+  hop the Python argv test couldn't reach: `parseArgs`/`numArg` actually parse `--reserve-baselines`/
+  `--pfsp-epsilon`/`--pfsp-k` and default them to the B4 values. `ppo-env-server.mjs` now guards its
+  `main()` behind an `isEntryPoint` check and exports `parseArgs`/`numArg` so a test can import without
+  spawning the server.
+- **Doc fixes.** Corrected the misleading `train_tracer._validate_args` comment (in fixed-field mode the
+  knobs are NOT forwarded, so the Python guard is the _sole_ check — not "Node validates anyway");
+  retired the stale "until B4 wires the book into `draw()`" note on `stats()`; relabelled "aggressive
+  baselines" → "non-`ai_bc` baselines" (the reserve set includes `ai_defensive`); fixed the "17 tests"
+  count above to 21. New tests: 3 dead-PFSP-guard cases + 1 persistent-no-seatBeat case + the 4 Node
+  flag-bridge cases.
 
 **Dead ends / surprises:**
 

--- a/docs/ml-bot/PLAN.md
+++ b/docs/ml-bot/PLAN.md
@@ -479,7 +479,7 @@ ppo:gate` over **3040 seat-fair games**: PPO **11.5 ± 1.3%** vs Lookahead **15.
       the 7 gate opponents (incl. all 3 strong ones) were training opponents → partly fixed-field
       _exploitation_ (also beats the 3 held-out bots → partial generalization); this green-lights task
       B. Full record: RESULTS.md + LOG.md + [D-23].
-- [~] **(B) PFSP opponent league ([D-22]) — Node-resident. 🔵 B1–B3 DONE 2026-06-27 (PRs #62/#64 + win-rate book + snapshot pipeline); B4 next → [D-23].** New `scripts/lib/ppo-league.mjs` (pool +
+- [~] **(B) PFSP opponent league ([D-22]) — Node-resident. 🔵 B1–B4 DONE 2026-06-27 (PRs #62/#64/#65 + PFSP sampling on); B5 next → [D-23].** New `scripts/lib/ppo-league.mjs` (pool +
   seeded `mulberry32` sampler + win-rate book) inside the env-server; the loop draws
   `league.draw(seed)` per episode (replaces the static `opponents` const at `ppo-env-server.mjs:259`).
   **Fixed-field is the empty-pool degenerate mode of this same pipeline** — so (A) and (B) share
@@ -508,10 +508,20 @@ ppo:gate` over **3040 seat-fair games**: PPO **11.5 ± 1.3%** vs Lookahead **15.
   deviations from [D-23]: `--snapshot-store` deferred to B6 with `SharedDiskStore`, not a dead flag
   now; `--snapshot-pool-cap` added/forwarded since the pool cap is the consumer setting; the producer
   manifest is append-only — entries are tiny, prune later if needed. `draw()` does NOT sample the pool
-  yet — that is B4 — so B3 is behavior-preserving for episode outcomes.)_ → **B4** PFSP weighting `w(S)=max(ε,1−winRate)^k` + R
-  reserved baselines (seeded `mulberry32`) → **B5** throughput/decisive-rate re-probe on a
-  snapshot-heavy field → **then** lock the env-step budget → **B6** persistence
-  (`toJSON()/restore()`) + `SharedDiskStore` (with task E).
+  yet — that is B4 — so B3 is behavior-preserving for episode outcomes.)_ → **B4 ✅** PFSP weighting
+  **on**: non-empty-pool `draw(seed)` seeds a `mulberry32` (extracted to NEW `scripts/lib/mulberry32.mjs`,
+  re-exported from `ppo-probe-core.mjs`) and seats `count−R` snapshots by `w(S)=max(ε,1−winRate)^k`
+  (`ε=0.05`,`k=2`; cold-start `winRate=0`→max weight; ε-floor keeps total>0 so a mastered snapshot is
+  never starved) **with** replacement + `R=3` DISTINCT aggressive baselines (CSV ids minus `ai_bc`)
+  **without** replacement, then Fisher-Yates shuffles opponent→seat so neither group binds to fixed
+  turn-order seats. **Empty pool stays byte-identical to task A.** Env-server
+  `--reserve-baselines`/`--pfsp-epsilon`/`--pfsp-k`; `train_tracer`/`EnvServerProcess` forward them
+  (only with `--snapshot-dir`, since the knobs only bite a non-empty pool). _(B4 deviation from [D-23]:
+  `mulberry32` extracted to its own module instead of imported from `ppo-probe-core.mjs`, so the league
+  doesn't pull the benchmark tool/env runner into its module graph — probe-core re-exports it, so its
+  test is unchanged.)_ First live exercise on shodan at B5. → **B5** throughput/decisive-rate re-probe
+  on a snapshot-heavy field; re-validate `R` against the real `count` → **then** lock the env-step
+  budget → **B6** persistence (`toJSON()/restore()`) + `SharedDiskStore` (with task E).
 - [ ] **(C)** Scale envs across cores; add the short **from-scratch control** run ([D-19] decision 1).
 - [ ] **(D)** Add **annealed potential-based reward shaping** (Δlargest-group/territory/dice/elims,
       `F = γΦ(s′)−Φ(s)`, env-side in JS) only if terminal-only learning is too slow.

--- a/ml/dicewars_ppo/env_server.py
+++ b/ml/dicewars_ppo/env_server.py
@@ -82,6 +82,9 @@ class EnvServerProcess:
         decision_timeout_ms: int = 120_000,
         snapshot_manifest: str | None = None,
         snapshot_pool_cap: int = 40,
+        reserve_baselines: int = 3,
+        pfsp_epsilon: float = 0.05,
+        pfsp_k: float = 2.0,
         host: str = "127.0.0.1",
         node_bin: str | None = None,
         start_timeout_s: float = 30.0,
@@ -120,9 +123,14 @@ class EnvServerProcess:
             argv.append(f"--max-areas={max_areas}")
         # PFSP snapshot pool (B3): point the server's league at the producer manifest and bound its
         # live pool. Absent ⇒ the server runs in empty-pool fixed-field mode (task A / B1 / B2).
+        # The PFSP sampler knobs (B4) only bite once that pool is non-empty, so they ride the same
+        # branch — in fixed-field mode `draw()` ignores them and the env-server defaults suffice.
         if snapshot_manifest is not None:
             argv.append(f"--snapshot-manifest={snapshot_manifest}")
             argv.append(f"--snapshot-pool-cap={snapshot_pool_cap}")
+            argv.append(f"--reserve-baselines={reserve_baselines}")
+            argv.append(f"--pfsp-epsilon={pfsp_epsilon}")
+            argv.append(f"--pfsp-k={pfsp_k}")
         self._argv = argv
 
     def start(self) -> EnvServerProcess:

--- a/ml/dicewars_ppo/train_tracer.py
+++ b/ml/dicewars_ppo/train_tracer.py
@@ -270,8 +270,8 @@ def build_parser() -> argparse.ArgumentParser:
         "--reserve-baselines",
         type=int,
         default=3,
-        help="R aggressive baselines reserved per drawn field (turtle-equilibrium defense; "
-        "distinct, no-replacement). Only used with --snapshot-dir.",
+        help="R baselines reserved per drawn field (turtle-equilibrium defense; distinct non-ai_bc "
+        "ids, no-replacement). Only used with --snapshot-dir.",
     )
     p.add_argument(
         "--pfsp-epsilon",
@@ -301,10 +301,12 @@ def _validate_args(args: argparse.Namespace) -> None:
         raise SystemExit("--n-envs must be >= 1.")
     if not Path(args.checkpoint).is_file():
         raise SystemExit(f"--checkpoint not found: {args.checkpoint}")
-    # PFSP knobs (B4): validate UNCONDITIONALLY — the Node-side makeLeague guards (ppo-league.mjs)
-    # run on every launch regardless of the pool, so a bad value is rejected even in fixed-field
-    # mode (where the knob is forwarded as a no-op) rather than silently swallowed. math.isfinite
-    # mirrors Node's Number.isFinite so inf/nan fail here, not later at server spawn.
+    # PFSP knobs (B4): validate UNCONDITIONALLY. In fixed-field mode (no --snapshot-dir) these
+    # knobs are NOT forwarded to the env-server — env_server.py only appends them on the snapshot
+    # branch — so Node never sees or validates the Python-supplied value. That makes THIS check the
+    # sole guard there; without it a bad value would be silently dropped (Node falls back to its own
+    # defaults). The bounds mirror the Node makeLeague guards so the two layers stay consistent when
+    # the knobs ARE forwarded; math.isfinite mirrors Number.isFinite so inf/nan fail here.
     if args.reserve_baselines < 0:
         raise SystemExit("--reserve-baselines must be >= 0.")
     if not 0.0 < args.pfsp_epsilon <= 1.0:

--- a/ml/dicewars_ppo/train_tracer.py
+++ b/ml/dicewars_ppo/train_tracer.py
@@ -30,6 +30,7 @@ byte-identical to the warm-start, a useful sanity floor.
 from __future__ import annotations
 
 import argparse
+import math
 import sys
 from pathlib import Path
 
@@ -81,6 +82,9 @@ def _make_env_thunk(cfg: ModelConfig, args: argparse.Namespace, env_index: int):
                 "seed_base": args.seed_base + env_index * 1_000_000,
                 "snapshot_manifest": snapshot_manifest,
                 "snapshot_pool_cap": args.snapshot_pool_cap,
+                "reserve_baselines": args.reserve_baselines,
+                "pfsp_epsilon": args.pfsp_epsilon,
+                "pfsp_k": args.pfsp_k,
             },
         )
 
@@ -260,6 +264,29 @@ def build_parser() -> argparse.ArgumentParser:
         default=40,
         help="Max snapshots the env-server league holds live (FIFO-by-step; forwarded).",
     )
+    # PFSP sampler knobs (B4 / [D-23]). Only bite with --snapshot-dir (a non-empty pool); forwarded
+    # to the env-server league's draw(). w(S) = max(eps, 1 - learnerWinRate(S)) ** k.
+    p.add_argument(
+        "--reserve-baselines",
+        type=int,
+        default=3,
+        help="R aggressive baselines reserved per drawn field (turtle-equilibrium defense; "
+        "distinct, no-replacement). Only used with --snapshot-dir.",
+    )
+    p.add_argument(
+        "--pfsp-epsilon",
+        type=float,
+        default=0.05,
+        help="PFSP weight floor eps in (0, 1] for w(S)=max(eps,1-winRate)**k. Only used with "
+        "--snapshot-dir.",
+    )
+    p.add_argument(
+        "--pfsp-k",
+        type=float,
+        default=2.0,
+        help="PFSP weight exponent k (>= 0) for w(S)=max(eps,1-winRate)**k. Only used with "
+        "--snapshot-dir.",
+    )
     return p
 
 
@@ -274,6 +301,16 @@ def _validate_args(args: argparse.Namespace) -> None:
         raise SystemExit("--n-envs must be >= 1.")
     if not Path(args.checkpoint).is_file():
         raise SystemExit(f"--checkpoint not found: {args.checkpoint}")
+    # PFSP knobs (B4): validate UNCONDITIONALLY — the Node-side makeLeague guards (ppo-league.mjs)
+    # run on every launch regardless of the pool, so a bad value is rejected even in fixed-field
+    # mode (where the knob is forwarded as a no-op) rather than silently swallowed. math.isfinite
+    # mirrors Node's Number.isFinite so inf/nan fail here, not later at server spawn.
+    if args.reserve_baselines < 0:
+        raise SystemExit("--reserve-baselines must be >= 0.")
+    if not 0.0 < args.pfsp_epsilon <= 1.0:
+        raise SystemExit("--pfsp-epsilon must be in (0, 1].")
+    if not math.isfinite(args.pfsp_k) or args.pfsp_k < 0:
+        raise SystemExit("--pfsp-k must be a finite number >= 0.")
     if args.snapshot_dir is not None:
         if args.snapshot_every <= 0:
             raise SystemExit("--snapshot-every must be > 0 when --snapshot-dir is set.")

--- a/ml/tests/test_env_server_argv.py
+++ b/ml/tests/test_env_server_argv.py
@@ -1,0 +1,53 @@
+"""EnvServerProcess argv construction — the Python→Node flag bridge (Phase 3, task B — [D-23]).
+
+``EnvServerProcess.__init__`` builds the ``ppo-env-server.mjs`` argv eagerly (before any spawn), so
+the league/PFSP flags it forwards can be asserted without a live Node process. This is the only
+automated guard on that bridge: a forwarding typo (e.g. piping ``pfsp_k`` into ``--pfsp-epsilon``)
+would otherwise surface only on a multi-hour shodan run. ``node_bin="node"`` skips the PATH lookup
+so the test needs no Node install; the constructor still verifies ``SERVER_SCRIPT`` exists.
+
+No torch/SB3 import here — ``env_server`` is stdlib-only, so this runs in the lean ``ml-test`` job.
+"""
+
+from __future__ import annotations
+
+from dicewars_ppo.env_server import EnvServerProcess
+
+
+def _argv(**kwargs) -> list[str]:
+    return EnvServerProcess(node_bin="node", **kwargs)._argv
+
+
+def test_pfsp_flags_forwarded_with_snapshot_manifest():
+    argv = _argv(
+        snapshot_manifest="/tmp/snap/manifest.json",
+        snapshot_pool_cap=12,
+        reserve_baselines=4,
+        pfsp_epsilon=0.1,
+        pfsp_k=3.0,
+    )
+    assert "--snapshot-manifest=/tmp/snap/manifest.json" in argv
+    assert "--snapshot-pool-cap=12" in argv
+    assert "--reserve-baselines=4" in argv
+    assert "--pfsp-epsilon=0.1" in argv
+    assert "--pfsp-k=3.0" in argv
+
+
+def test_pfsp_flags_use_b4_defaults():
+    argv = _argv(snapshot_manifest="/tmp/snap/manifest.json")
+    # B4 defaults must match makeLeague's (R=3, eps=0.05, k=2); drift here silently retunes runs.
+    assert "--reserve-baselines=3" in argv
+    assert "--pfsp-epsilon=0.05" in argv
+    assert "--pfsp-k=2.0" in argv
+
+
+def test_no_league_flags_without_snapshot_manifest():
+    # Empty-pool fixed-field mode (task A): the league/PFSP flags must NOT appear, so draw() keeps
+    # returning the cycled --opponents field and the server's own defaults govern.
+    argv = _argv(reserve_baselines=9, pfsp_epsilon=0.5, pfsp_k=1.0)
+    joined = " ".join(argv)
+    assert "--snapshot-manifest" not in joined
+    assert "--snapshot-pool-cap" not in joined
+    assert "--reserve-baselines" not in joined
+    assert "--pfsp-epsilon" not in joined
+    assert "--pfsp-k" not in joined

--- a/ml/tests/test_train_tracer_args.py
+++ b/ml/tests/test_train_tracer_args.py
@@ -1,0 +1,85 @@
+"""train_tracer PFSP arg plumbing: parser defaults, _validate_args bounds, server_kwargs forwarding.
+
+Torch/SB3-gated (``train_tracer`` imports them at module scope), so this runs on shodan and skips in
+the lean ``ml-test`` CI job — same pattern as test_snapshot_callback.py / test_ppo_policy.py. It
+covers the layers the torch-free test_env_server_argv.py cannot reach:
+  - the argparse defaults that ACTUALLY govern production runs (a separate copy from the
+    EnvServerProcess constructor defaults), which must agree with the Node makeLeague defaults;
+  - the unconditional PFSP range guards in _validate_args (mirroring the always-on Node guards); and
+  - the args -> server_kwargs hop inside _make_env_thunk (a typo there would pass the argv test but
+    silently mis-tune a multi-env run).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("sb3_contrib")
+
+import dicewars_ppo.train_tracer as tt  # noqa: E402
+
+
+def _args(tmp_path, **overrides):
+    """Parse a minimal valid argv (real checkpoint file) with optional knob overrides."""
+    ckpt = tmp_path / "ckpt.pt"
+    ckpt.write_bytes(b"x")
+    argv = ["--checkpoint", str(ckpt)]
+    for key, val in overrides.items():
+        argv += [f"--{key.replace('_', '-')}", str(val)]
+    return tt.build_parser().parse_args(argv)
+
+
+def test_parser_pfsp_defaults_match_makeleague(tmp_path):
+    # These argparse defaults govern production; drift here silently retunes runs and diverges from
+    # the Node makeLeague defaults (scripts/lib/ppo-league.mjs).
+    a = _args(tmp_path)
+    assert a.reserve_baselines == 3
+    assert a.pfsp_epsilon == 0.05
+    assert a.pfsp_k == 2.0
+
+
+@pytest.mark.parametrize(
+    "overrides,needle",
+    [
+        ({"reserve_baselines": -1}, "reserve-baselines"),
+        ({"pfsp_epsilon": 0}, "pfsp-epsilon"),
+        ({"pfsp_epsilon": 1.5}, "pfsp-epsilon"),
+        ({"pfsp_k": -1}, "pfsp-k"),
+        ({"pfsp_k": "nan"}, "pfsp-k"),  # math.isfinite mirrors Node's Number.isFinite
+        ({"pfsp_k": "inf"}, "pfsp-k"),
+    ],
+)
+def test_validate_args_rejects_bad_pfsp_knobs(tmp_path, overrides, needle):
+    a = _args(tmp_path, **overrides)
+    with pytest.raises(SystemExit, match=needle):
+        tt._validate_args(a)
+
+
+def test_validate_args_validates_pfsp_even_without_snapshot_dir(tmp_path):
+    # No --snapshot-dir (fixed-field mode): the PFSP guards still run (unconditional, like Node), so
+    # a bad value is rejected rather than silently swallowed; valid values pass cleanly.
+    bad = _args(tmp_path, pfsp_epsilon=5)
+    with pytest.raises(SystemExit, match="pfsp-epsilon"):
+        tt._validate_args(bad)
+    tt._validate_args(_args(tmp_path, reserve_baselines=2, pfsp_epsilon=0.1, pfsp_k=3))  # no raise
+
+
+def test_make_env_thunk_forwards_pfsp_into_server_kwargs(tmp_path, monkeypatch):
+    captured = {}
+
+    class FakeEnv:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(tt, "DiceWarsEnv", FakeEnv)
+    a = _args(tmp_path, reserve_baselines=4, pfsp_epsilon=0.2, pfsp_k=1.5)
+    cfg = SimpleNamespace(max_areas=32, player_count=7)
+    tt._make_env_thunk(cfg, a, 0)()  # invoke the zero-arg env factory
+
+    server_kwargs = captured["server_kwargs"]
+    assert server_kwargs["reserve_baselines"] == 4
+    assert server_kwargs["pfsp_epsilon"] == 0.2
+    assert server_kwargs["pfsp_k"] == 1.5

--- a/scripts/lib/mulberry32.mjs
+++ b/scripts/lib/mulberry32.mjs
@@ -1,0 +1,28 @@
+/**
+ * Deterministic 32-bit PRNG (mulberry32) — a tiny, dependency-free seeded random source.
+ *
+ * Shared by the PPO throughput probe (`ppo-probe-core.mjs`, the `random` learner) and the PFSP
+ * opponent league (`ppo-league.mjs`, the per-episode opponent sampler). Lives in its own module so
+ * the league does not have to import the benchmark tool (and, through it, the env runner) just to
+ * borrow a PRNG — `ppo-probe-core.mjs` re-exports it for backward compatibility.
+ *
+ * Identical-seed → identical stream, so any consumer that seeds from the episode seed is fully
+ * reproducible (no `Math.random`, which would make outcomes machine- and run-dependent).
+ *
+ * @module scripts/lib/mulberry32
+ */
+
+/**
+ * @param {number} seed coerced to a uint32 (`seed >>> 0`).
+ * @returns {() => number} next double in [0, 1)
+ */
+export function mulberry32(seed) {
+  let a = seed >>> 0;
+  return function next() {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}

--- a/scripts/lib/ppo-league.mjs
+++ b/scripts/lib/ppo-league.mjs
@@ -4,19 +4,25 @@
  * The env-server draws its per-episode opponent field from this league instead of a
  * static const. The league will own the opponent pool (built-in baselines + hot-loaded
  * self-play snapshots), a seeded sampler, and a per-opponent win-rate book — but step
- * **B1** ships only the empty-pool baselines (no snapshots, sampler, or win-rate book yet).
+ * built incrementally across steps **B1–B4** (see the build sequence at the bottom of this header).
  *
  * **Fixed-field (task A) is the empty-pool degenerate mode of this module:** with no
  * snapshots, `draw()` returns exactly the cycled baseline field the env-server used
  * before — content-identical (same names + fn refs), so task A's outcomes reproduce.
- * This file (step **B1**)
- * ships that empty-pool path plus a decisive/truncated telemetry tally; **step B2 adds the
- * per-opponent win-rate book** (`recordResult` crediting + `winRate(id)`); **step B3 adds the
- * snapshot pool + `refresh()`** — poll the producer's `manifest.json`, hot-load each new self-play
- * snapshot via `makeBC` (fresh filename per snapshot → ESM URL cache), FIFO-evict past `poolCap` and
- * GC the evicted `.js`. PFSP weighting (B4, samples the pool in `draw()`) and persistence (B6) extend
- * the same object. See docs/ml-bot/DECISIONS.md D-23 for the full B0–B6 build sequence (D-22 for the
- * league architecture + the win-rate-attribution decision).
+ *
+ * Build sequence (docs/ml-bot/DECISIONS.md D-23; D-22 for the league architecture + the win-rate-
+ * attribution decision):
+ *   - **B1** — the empty-pool path (== task A) plus a decisive/truncated telemetry tally.
+ *   - **B2** — the per-opponent win-rate book (`recordResult` pairwise crediting + `winRate(id)`).
+ *   - **B3** — the snapshot pool + `refresh()`: poll the producer's `manifest.json`, hot-load each
+ *     new self-play snapshot via `makeBC` (fresh filename per snapshot → ESM URL cache), FIFO-evict
+ *     past `poolCap`, GC the evicted `.js`. B3 only *loads* the pool — `draw()` does not seat it yet.
+ *   - **B4** — PFSP weighting **on**: when the pool is non-empty, `draw(seed)` seeds a `mulberry32`
+ *     sampler and seats `count − R` snapshots drawn by `w(S) = max(ε, 1 − learnerWinRate(S))^k`
+ *     (lower learner win-rate → higher weight) plus `R` reserved aggressive baselines (the [D-15]
+ *     turtle-equilibrium defense), then shuffles opponent→seat so neither group binds to fixed
+ *     turn-order seats. **Empty pool still returns the byte-identical task-A field** (fixed-field
+ *     stays the empty-pool mode of this one pipeline). Persistence (B6) extends the same object.
  *
  * @module scripts/lib/ppo-league
  */
@@ -28,6 +34,7 @@ import { pathToFileURL } from 'node:url';
 import { makeBC } from '../../src/ai/ai_bc.js';
 import { BUILT_IN_BOTS } from '../../src/arena/builtInBots.js';
 import { ENCODING_VERSION } from '../../src/arena/encodeObservation.js';
+import { mulberry32 } from './mulberry32.mjs';
 
 /*
  * `makeBC` (snapshot loader, B3) and `ENCODING_VERSION` (manifest compat gate) are imported
@@ -74,9 +81,9 @@ export function resolveBaselineField(idCsv, count) {
 /**
  * Construct a league. Step **B1** ships the empty-pool path (== task A's fixed field) plus a
  * decisive/truncated telemetry tally; step **B2** adds the per-opponent win-rate book
- * (`recordResult` pairwise crediting + `winRate(id)`); later steps extend the returned object
- * (B3 `refresh`/`addSnapshot`, B4 PFSP `w(S)=max(ε,1−learnerWinRate(S))^k` weighting, B6
- * `toJSON`/`restore`).
+ * (`recordResult` pairwise crediting + `winRate(id)`); step **B3** adds the snapshot pool +
+ * `refresh()`; step **B4** turns PFSP weighting on in `draw()` (samples the pool by
+ * `w(S)=max(ε,1−learnerWinRate(S))^k` + R reserved baselines); B6 adds `toJSON`/`restore`.
  *
  * @param {object} opts
  * @param {string} opts.baselineCsv the resolved `--opponents` CSV. The trainer passes
@@ -96,7 +103,19 @@ export function resolveBaselineField(idCsv, count) {
  *   module registry retains every dynamic-`import()`ed snapshot module for the process lifetime (each
  *   fresh filename is a distinct, permanently-cached module), so resident weights grow with the total
  *   number of snapshots ever loaded, not `poolCap`. Modest at realistic cadences (~2 MB each); if a
- *   long run needs a hard memory bound, load weights without `import()` caching (B4/B5 concern).
+ *   long run needs a hard memory bound, load weights without `import()` caching (B5 concern).
+ * @param {number} [opts.reserveBaselines=3] **R** — aggressive baselines reserved in every drawn
+ *   field while the pool is non-empty (the [D-15] turtle-equilibrium defense). The reserve pool is
+ *   the DISTINCT baseline ids minus `ai_bc` (the STOP/turtle lineage); reserved seats are sampled
+ *   WITHOUT replacement, so at most `min(R, count, #distinctReserveBaselines)` seats are reserved and
+ *   the remainder go to PFSP snapshots ([D-23]). 0 disables reservation. Empty-pool mode ignores it.
+ * @param {number} [opts.pfspEpsilon=0.05] **ε** — the PFSP weight floor in `w(S)=max(ε,1−winRate)^k`.
+ *   Must be in (0, 1]: ε>0 floors every snapshot weight at ε^k > 0 (a fully-mastered snapshot is still
+ *   drawn occasionally) for any sane k. (At a pathological k, ε^k can underflow to 0.0 in floating
+ *   point; `draw()` then falls back to uniform sampling so the wheel still selects.) Empty pool ignores it.
+ * @param {number} [opts.pfspK=2] **k** — the PFSP weight exponent in `w(S)=max(ε,1−winRate)^k`.
+ *   Must be ≥ 0; higher k sharpens the bias toward snapshots that beat the learner (k=0 → uniform).
+ *   Empty-pool mode ignores it.
  * @returns {{draw: Function, recordResult: Function, winRate: Function, refresh: Function,
  *   stats: Function}}
  */
@@ -106,6 +125,9 @@ export function makeLeague({
   learnerSeat,
   snapshotManifest = null,
   poolCap = 40,
+  reserveBaselines = 3,
+  pfspEpsilon = 0.05,
+  pfspK = 2,
 }) {
   /*
    * Fail loud at construction — both inputs are in scope here, so a bad value is caught at the
@@ -125,7 +147,50 @@ export function makeLeague({
   if (!Number.isInteger(poolCap) || poolCap <= 0) {
     throw new Error(`makeLeague: poolCap must be a positive integer, got ${poolCap}.`);
   }
+  /*
+   * PFSP sampler knobs (B4). Validate at construction so a typo'd CLI flag fails the launch, not a
+   * mid-run draw: ε must be a positive fraction (ε>0 floors every weight at ε^k > 0 mathematically, so
+   * a mastered snapshot is not starved; ε≤1 since 1−winRate ∈ [0,1]); k must be a finite non-negative
+   * exponent; R a non-negative integer count of reserved seats. (At a pathological k, ε^k can still
+   * underflow to 0.0 in IEEE-754 — `draw()` guards that with a uniform fallback, see below.)
+   */
+  if (!Number.isFinite(pfspEpsilon) || pfspEpsilon <= 0 || pfspEpsilon > 1) {
+    throw new Error(`makeLeague: pfspEpsilon must be in (0, 1], got ${pfspEpsilon}.`);
+  }
+  if (!Number.isFinite(pfspK) || pfspK < 0) {
+    throw new Error(`makeLeague: pfspK must be a finite number >= 0, got ${pfspK}.`);
+  }
+  if (!Number.isInteger(reserveBaselines) || reserveBaselines < 0) {
+    throw new Error(
+      `makeLeague: reserveBaselines must be a non-negative integer, got ${reserveBaselines}.`
+    );
+  }
   const baselineField = resolveBaselineField(baselineCsv, count);
+
+  /*
+   * Reserve pool (B4): the DISTINCT baseline bots minus `ai_bc` (the STOP/turtle lineage — reserving
+   * it would defeat the [D-15] turtle defense it exists to counter). Derived from the full
+   * `baselineCsv`, NOT `baselineField`, so a CSV with more distinct ids than `count` still surfaces
+   * all of them (the count-length cycle would hide the tail). We must re-validate here: above,
+   * `resolveBaselineField` only checks the first `count` CYCLED positions (`ids[i % ids.length]`), so a
+   * typo'd id PAST position `count−1` slips through it and would otherwise crash this `.map` with a
+   * cryptic `undefined.name`. Guard with the same clear message. Bare bot name (the `@i` disambiguator
+   * is appended per draw, mirroring the baseline field). When this is empty (e.g. the env-server bare
+   * default `--opponents=ai_bc`), `draw()` reserves nothing and all seats go to PFSP.
+   */
+  const reserveById = new Map(BUILT_IN_BOTS.map(b => [b.id, b]));
+  const reserveBaselinePool = [...new Set(parseIds(baselineCsv))]
+    .filter(id => id !== 'ai_bc')
+    .map(id => {
+      const bot = reserveById.get(id);
+      if (!bot) {
+        throw new Error(
+          `Unknown opponent bot id "${id}". Known: ${[...reserveById.keys()].join(', ')}.`
+        );
+      }
+      return { id, name: bot.name, fn: bot.fn };
+    });
+  Object.freeze(reserveBaselinePool);
   /*
    * `draw()` hands out this same array reference every episode, so freeze it (and its entries):
    * a future in-place reorder/mutation throws loudly under ESM strict mode instead of silently
@@ -167,19 +232,112 @@ export function makeLeague({
    */
   const seatOf = k => (k < learnerSeat ? k : k + 1);
 
+  /*
+   * The LEARNER's win-rate against opponent `id` — the B2 book read shared by the public `winRate()`
+   * method and B4's PFSP sampler. Unseen / zero-game id → 0 (cold-start ⇒ max PFSP weight; an
+   * opponent the learner has never beaten and one it has never met are deliberately indistinguishable,
+   * both prioritised). Defined as a closure (not via the returned method) so `draw()` can read it
+   * without an extra object hop.
+   */
+  const learnerWinRate = id => {
+    const rec = book.get(id);
+    return rec && rec.games > 0 ? rec.wins / rec.games : 0;
+  };
+
+  /*
+   * Roulette-wheel pick from `items` with parallel non-negative `weights` summing to `total > 0`,
+   * consuming one `rng()` draw. The caller precomputes weights/total once per draw (they are constant
+   * within a draw) and samples WITH replacement, so a small pool can still fill every PFSP seat. The
+   * trailing return covers the float-rounding corner where `r` never quite goes negative.
+   */
+  const sampleByWeight = (rng, items, weights, total) => {
+    let r = rng() * total;
+    for (let i = 0; i < items.length; i++) {
+      r -= weights[i];
+      if (r < 0) return items[i];
+    }
+    return items[items.length - 1];
+  };
+
   return {
     /*
-     * Draw the per-episode opponent field. B1: the pool is empty, so this is the cycled baseline
-     * field — identical for every seed (the episode outcome depends on the ordered fns × the seed,
-     * which the env-server passes to `runSelfPlayEpisode` separately). B4 adds snapshot seats
-     * sampled by `w(S) = max(ε, 1 - learnerWinRate(S))^k`, reserving R aggressive baselines per game.
+     * Draw the per-episode opponent field (length `count`, opponents/drawn index-parallel).
+     *
+     * **Empty pool → byte-identical task-A field.** With no snapshots this returns the cycled
+     * baseline field, seed-invariant (the episode outcome depends on the ordered fns × the seed, which
+     * the env-server passes to `runSelfPlayEpisode` separately). This is the load-bearing fixed-field
+     * parity guarantee — it must stay identical to B1/B2/B3.
+     *
+     * **Non-empty pool → PFSP (B4).** Seed a `mulberry32(seed)` stream and fill `count` seats with:
+     *   1. up to `min(R, count, #reserveBaselinePool)` aggressive baselines, sampled WITHOUT
+     *      replacement (distinct aggressive opponents — the [D-15] turtle defense), then
+     *   2. the remaining seats with snapshots sampled WITH replacement by
+     *      `w(S) = max(ε, 1 − learnerWinRate(S))^k` (lower learner win-rate → higher weight).
+     * The combined field is then Fisher-Yates shuffled (same rng stream) so the reserve/PFSP split
+     * does not bind to fixed board seats — i.e. snapshots don't systematically inherit the early
+     * (first-to-move) seats. Deterministic given (seed, current pool, current win-rate book).
      */
     draw(seed) {
-      void seed; // unused until B4 (empty-pool draw is deterministic); kept for API stability.
-      return {
-        opponents: baselineField,
-        drawn: baselineField.map((bot, i) => ({ id: bot.id, kind: 'baseline', seat: seatOf(i) })),
-      };
+      if (pool.length === 0) {
+        return {
+          opponents: baselineField,
+          drawn: baselineField.map((bot, i) => ({ id: bot.id, kind: 'baseline', seat: seatOf(i) })),
+        };
+      }
+
+      const rng = mulberry32(seed >>> 0);
+      const field = []; // { id, kind, name, fn } entries, length `count`
+
+      // (1) Reserved aggressive baselines — at most as many distinct ones as exist, no replacement.
+      const reserveCount = Math.min(reserveBaselines, count, reserveBaselinePool.length);
+      const reservePick = reserveBaselinePool.slice();
+      for (let i = 0; i < reserveCount; i++) {
+        const j = i + Math.floor(rng() * (reservePick.length - i)); // partial Fisher-Yates
+        const picked = reservePick[j];
+        reservePick[j] = reservePick[i];
+        reservePick[i] = picked;
+        field.push({ id: picked.id, kind: 'baseline', name: picked.name, fn: picked.fn });
+      }
+
+      /*
+       * (2) PFSP snapshots — weighted by w(S), with replacement. Weights are constant within a draw,
+       * so compute them once. ε>0 floors each weight at ε^k, which is > 0 for any sane k — but at a
+       * pathological k (large enough that ε^k underflows to 0.0 in IEEE-754) AND an all-mastered pool,
+       * every weight can collapse to 0. Fall back to UNIFORM there so the wheel still selects
+       * meaningfully (and deterministically) instead of always degenerating to the last entry.
+       */
+      const pfspCount = count - reserveCount;
+      if (pfspCount > 0) {
+        const weights = pool.map(s =>
+          Math.pow(Math.max(pfspEpsilon, 1 - learnerWinRate(s.id)), pfspK)
+        );
+        let total = 0;
+        for (const w of weights) total += w;
+        if (total === 0) {
+          weights.fill(1);
+          total = pool.length;
+        }
+        for (let i = 0; i < pfspCount; i++) {
+          const snap = sampleByWeight(rng, pool, weights, total);
+          field.push({ id: snap.id, kind: 'snapshot', name: snap.id, fn: snap.fn });
+        }
+      }
+
+      // Shuffle opponent→seat so neither group binds to fixed turn-order seats (still seeded).
+      for (let i = field.length - 1; i > 0; i--) {
+        const j = Math.floor(rng() * (i + 1));
+        const tmp = field[i];
+        field[i] = field[j];
+        field[j] = tmp;
+      }
+
+      /*
+       * `@i` disambiguates duplicates (a snapshot/baseline drawn for multiple seats) for runMatch's
+       * unique-name rule, matching the baseline field convention. `drawn[i]` describes `opponents[i]`.
+       */
+      const opponents = field.map((e, i) => ({ id: e.id, name: `${e.name}@${i}`, fn: e.fn }));
+      const drawn = field.map((e, i) => ({ id: e.id, kind: e.kind, seat: seatOf(i) }));
+      return { opponents, drawn };
     },
 
     /*
@@ -244,8 +402,7 @@ export function makeLeague({
      * game", which is intentional: both should be prioritised by the sampler.
      */
     winRate(id) {
-      const rec = book.get(id);
-      return rec && rec.games > 0 ? rec.wins / rec.games : 0;
+      return learnerWinRate(id);
     },
 
     /**

--- a/scripts/lib/ppo-league.mjs
+++ b/scripts/lib/ppo-league.mjs
@@ -19,7 +19,7 @@
  *     past `poolCap`, GC the evicted `.js`. B3 only *loads* the pool — `draw()` does not seat it yet.
  *   - **B4** — PFSP weighting **on**: when the pool is non-empty, `draw(seed)` seeds a `mulberry32`
  *     sampler and seats `count − R` snapshots drawn by `w(S) = max(ε, 1 − learnerWinRate(S))^k`
- *     (lower learner win-rate → higher weight) plus `R` reserved aggressive baselines (the [D-15]
+ *     (lower learner win-rate → higher weight) plus `R` reserved baselines (the [D-15]
  *     turtle-equilibrium defense), then shuffles opponent→seat so neither group binds to fixed
  *     turn-order seats. **Empty pool still returns the byte-identical task-A field** (fixed-field
  *     stays the empty-pool mode of this one pipeline). Persistence (B6) extends the same object.
@@ -42,6 +42,15 @@ import { mulberry32 } from './mulberry32.mjs';
  * loaded eagerly via the `BUILT_IN_BOTS` import below (→ `ai_bc.js` → `bcPolicyWeights.js`), and
  * `ENCODING_VERSION` rides the far lighter `encodeObservation.js`.
  */
+
+/*
+ * A decisive game must carry a `seatBeat[]` (both shapers guarantee one for a decided placement). A
+ * single missing vector is tolerated and warned once; this many CUMULATIVELY means a persistent
+ * shaper/contract regression — `recordResult` then throws, because an uncredited win-rate book
+ * silently collapses B4's PFSP sampler to ~uniform (every snapshot stuck at cold-start weight) and
+ * would waste a whole multi-hour training run with no other loud signal.
+ */
+const MAX_NO_SEATBEAT_GAMES = 10;
 
 /** Split + trim the opponent id CSV, dropping blanks; throws if it resolves to nothing. */
 function parseIds(idCsv) {
@@ -104,11 +113,14 @@ export function resolveBaselineField(idCsv, count) {
  *   fresh filename is a distinct, permanently-cached module), so resident weights grow with the total
  *   number of snapshots ever loaded, not `poolCap`. Modest at realistic cadences (~2 MB each); if a
  *   long run needs a hard memory bound, load weights without `import()` caching (B5 concern).
- * @param {number} [opts.reserveBaselines=3] **R** — aggressive baselines reserved in every drawn
- *   field while the pool is non-empty (the [D-15] turtle-equilibrium defense). The reserve pool is
- *   the DISTINCT baseline ids minus `ai_bc` (the STOP/turtle lineage); reserved seats are sampled
- *   WITHOUT replacement, so at most `min(R, count, #distinctReserveBaselines)` seats are reserved and
- *   the remainder go to PFSP snapshots ([D-23]). 0 disables reservation. Empty-pool mode ignores it.
+ * @param {number} [opts.reserveBaselines=3] **R** — baselines reserved in every drawn field while
+ *   the pool is non-empty (the [D-15] turtle-equilibrium defense). The reserve pool is the DISTINCT
+ *   baseline ids minus `ai_bc` (the STOP/turtle lineage is the ONLY excluded one — so the reserve set
+ *   can include a defensive bot such as `ai_defensive`, not just aggressive ones). Reserved seats are
+ *   sampled WITHOUT replacement, so at most `min(R, count, #distinctReserveBaselines)` seats are
+ *   reserved and the remainder go to PFSP snapshots ([D-23]). 0 disables reservation. Empty-pool mode
+ *   ignores it. With a snapshot manifest configured, a config that reserves ALL `count` seats (so no
+ *   snapshot could ever be drawn) is rejected at construction — see the dead-PFSP guard below.
  * @param {number} [opts.pfspEpsilon=0.05] **ε** — the PFSP weight floor in `w(S)=max(ε,1−winRate)^k`.
  *   Must be in (0, 1]: ε>0 floors every snapshot weight at ε^k > 0 (a fully-mastered snapshot is still
  *   drawn occasionally) for any sane k. (At a pathological k, ε^k can underflow to 0.0 in floating
@@ -192,6 +204,22 @@ export function makeLeague({
     });
   Object.freeze(reserveBaselinePool);
   /*
+   * Dead-PFSP guard (B4): `draw()` computes `pfspCount = count − min(R, count, #reserveBaselinePool)`,
+   * so when the reserve baselines alone fill every seat (`min(R, #reserveBaselinePool) >= count`) it
+   * seats ZERO snapshots — PFSP is silently a no-op even with a fully-loaded pool. That is only ever a
+   * misconfiguration when a manifest is configured (the operator clearly intends PFSP), and it is
+   * decidable here at construction (the condition is independent of pool contents). Fail the launch
+   * with an actionable message rather than burn a multi-hour run training against baselines only.
+   * Empty-pool fixed-field mode (no manifest) never seats snapshots anyway, so it is exempt.
+   */
+  if (snapshotManifest && Math.min(reserveBaselines, reserveBaselinePool.length) >= count) {
+    throw new Error(
+      `makeLeague: reserveBaselines=${reserveBaselines} with ${reserveBaselinePool.length} distinct ` +
+        `reserve baseline(s) fills all ${count} opponent seat(s), so draw() can never seat a PFSP ` +
+        `snapshot despite a configured snapshot manifest. Lower reserveBaselines or raise the player count.`
+    );
+  }
+  /*
    * `draw()` hands out this same array reference every episode, so freeze it (and its entries):
    * a future in-place reorder/mutation throws loudly under ESM strict mode instead of silently
    * poisoning every later draw. Near-zero cost — the fns are shared from BUILT_IN_BOTS anyway.
@@ -212,6 +240,13 @@ export function makeLeague({
   const book = new Map();
   // One-shot guard so a broken-contract decisive game (no seatBeat[]) warns once, not per-episode.
   let warnedNoSeatBeat = false;
+  /*
+   * Cumulative count of decisive games that arrived without a `seatBeat[]`. One-off is tolerated
+   * (warn-once above); past `MAX_NO_SEATBEAT_GAMES` it is a persistent contract break that has left
+   * the win-rate book uncredited — `recordResult` throws so PFSP can't quietly run on a ~uniform book.
+   * Surfaced on `stats()` for the DONE-line health window; should always read 0 on a healthy run.
+   */
+  let noSeatBeatGames = 0;
 
   /*
    * Snapshot pool (B3): hot-loaded self-play snapshots the trainer published, FIFO-capped at
@@ -269,8 +304,8 @@ export function makeLeague({
      * parity guarantee — it must stay identical to B1/B2/B3.
      *
      * **Non-empty pool → PFSP (B4).** Seed a `mulberry32(seed)` stream and fill `count` seats with:
-     *   1. up to `min(R, count, #reserveBaselinePool)` aggressive baselines, sampled WITHOUT
-     *      replacement (distinct aggressive opponents — the [D-15] turtle defense), then
+     *   1. up to `min(R, count, #reserveBaselinePool)` reserved baselines, sampled WITHOUT
+     *      replacement (distinct non-`ai_bc` opponents — the [D-15] turtle defense), then
      *   2. the remaining seats with snapshots sampled WITH replacement by
      *      `w(S) = max(ε, 1 − learnerWinRate(S))^k` (lower learner win-rate → higher weight).
      * The combined field is then Fisher-Yates shuffled (same rng stream) so the reserve/PFSP split
@@ -288,7 +323,7 @@ export function makeLeague({
       const rng = mulberry32(seed >>> 0);
       const field = []; // { id, kind, name, fn } entries, length `count`
 
-      // (1) Reserved aggressive baselines — at most as many distinct ones as exist, no replacement.
+      // (1) Reserved baselines (distinct, non-ai_bc) — at most as many distinct ones as exist, no replacement.
       const reserveCount = Math.min(reserveBaselines, count, reserveBaselinePool.length);
       const reservePick = reserveBaselinePool.slice();
       for (let i = 0; i < reserveCount; i++) {
@@ -361,13 +396,23 @@ export function makeLeague({
          * Both shapers always return a seatBeat[] for a decisive game (ppo-env.mjs), so a missing one
          * means an upstream shaper/contract break. Don't crash a long training run over a single bad
          * outcome — but don't let it silently empty the book either (the failure mode that would make
-         * B4's PFSP sampler quietly collapse to ~uniform). Warn ONCE so the regression is visible.
+         * B4's PFSP sampler quietly collapse to ~uniform). Warn ONCE so the regression is visible, and
+         * fail loud once it is clearly PERSISTENT (past MAX_NO_SEATBEAT_GAMES): a run that never credits
+         * the book is training against an effectively uniform sampler and should stop, not spin on.
          */
+        noSeatBeatGames++;
         if (!warnedNoSeatBeat) {
           warnedNoSeatBeat = true;
           process.stderr.write(
             '[ppo-league] decisive game had no seatBeat[] — win-rate book not credited; check the ' +
               'runSelfPlayEpisode/runMatch placement contract.\n'
+          );
+        }
+        if (noSeatBeatGames >= MAX_NO_SEATBEAT_GAMES) {
+          throw new Error(
+            `ppo-league.recordResult: ${noSeatBeatGames} decisive games had no seatBeat[] — the ` +
+              `win-rate book is not being credited and B4's PFSP sampler has collapsed to uniform. ` +
+              `Fix the runSelfPlayEpisode/runMatch placement contract.`
           );
         }
         return;
@@ -484,10 +529,12 @@ export function makeLeague({
 
     /**
      * League health snapshot. The env-server emits this on its `PPO_ENV_SERVER DONE` line (the B5
-     * throughput/decisive-rate re-probe reads it; until B4 wires the book into `draw()` it is the
-     * only external window onto the win-rate book). `decisiveGames` counts every booked decisive
-     * episode incl. zero-decision skips, so `decisiveGames > <wire terminals>` evidences the B2
-     * "book before the zero-decision wire gate" reordering.
+     * throughput/decisive-rate re-probe reads it). `winRate(id)` and `draw()` (which now samples the
+     * book for PFSP weighting, B4) are the other windows onto the win-rate book. `decisiveGames`
+     * counts every booked decisive episode incl. zero-decision skips, so `decisiveGames > <wire
+     * terminals>` evidences the B2 "book before the zero-decision wire gate" reordering.
+     * `noSeatBeatGames` should read 0 on a healthy run — a nonzero value means decisive games whose
+     * placement contract broke (book under-credited; PFSP drifting toward uniform).
      */
     stats() {
       const total = decisiveGames + truncatedGames;
@@ -498,6 +545,7 @@ export function makeLeague({
         decisiveGames,
         truncatedGames,
         decisiveRate: total > 0 ? decisiveGames / total : 0,
+        noSeatBeatGames,
       };
     },
   };

--- a/scripts/lib/ppo-probe-core.mjs
+++ b/scripts/lib/ppo-probe-core.mjs
@@ -17,26 +17,15 @@
  * @module scripts/lib/ppo-probe-core
  */
 
+import { mulberry32 } from './mulberry32.mjs';
 import { runSelfPlayEpisode } from './ppo-env.mjs';
 
-/**
- * Deterministic 32-bit PRNG (mulberry32). Used for the `random` learner so the probe is
- * reproducible (no `Math.random`, which would make the numEdges distribution machine- and
- * run-dependent).
- *
- * @param {number} seed
- * @returns {() => number} next double in [0, 1)
+/*
+ * `mulberry32` (the `random` learner's reproducible PRNG) moved to its own dependency-free module so
+ * the PFSP league can borrow it without importing this benchmark tool. Re-exported here so existing
+ * consumers (and the throughput-probe test) keep importing it from `ppo-probe-core.mjs` unchanged.
  */
-export function mulberry32(seed) {
-  let a = seed >>> 0;
-  return function next() {
-    a |= 0;
-    a = (a + 0x6d2b79f5) | 0;
-    let t = Math.imul(a ^ (a >>> 15), 1 | a);
-    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
+export { mulberry32 };
 
 /**
  * Build a synchronous stub action selector for the learner seat.

--- a/scripts/ppo-env-server.mjs
+++ b/scripts/ppo-env-server.mjs
@@ -38,6 +38,7 @@
  */
 
 import { Worker } from 'node:worker_threads';
+import { pathToFileURL } from 'node:url';
 
 import { createBotState } from '../src/arena/botState.js';
 import { encodeObservationForInference } from '../src/arena/encodeObservation.js';
@@ -75,16 +76,17 @@ const KNOWN_FLAGS = new Set([
   'snapshot-manifest',
   'snapshot-pool-cap',
   /*
-   * PFSP sampler knobs (B4 / [D-23]). Only take effect with a non-empty pool (i.e. alongside
-   * `--snapshot-manifest`): `reserve-baselines` = R aggressive baselines reserved per game (turtle
-   * defense); `pfsp-epsilon`/`pfsp-k` parameterise the snapshot weight `w(S)=max(ε,1−winRate)^k`.
+   * PFSP sampler knobs (B4 / [D-23]). Their draw-time EFFECT needs a non-empty pool (i.e. alongside
+   * `--snapshot-manifest`), but the values are range-validated at launch regardless (makeLeague):
+   * `reserve-baselines` = R baselines reserved per game (turtle defense — distinct, non-`ai_bc`);
+   * `pfsp-epsilon`/`pfsp-k` parameterise the snapshot weight `w(S)=max(ε,1−winRate)^k`.
    */
   'reserve-baselines',
   'pfsp-epsilon',
   'pfsp-k',
 ]);
 
-function parseArgs(argv) {
+export function parseArgs(argv) {
   const opts = {};
   for (const arg of argv) {
     const m = /^--([^=]+)=(.*)$/.exec(arg);
@@ -98,7 +100,7 @@ function parseArgs(argv) {
 }
 
 /** Parse a numeric flag, defaulting when absent and rejecting a non-finite value loudly. */
-function numArg(opts, key, fallback) {
+export function numArg(opts, key, fallback) {
   if (opts[key] === undefined) return fallback;
   const v = Number(opts[key]);
   if (!Number.isFinite(v)) throw new Error(`--${key}=${opts[key]} is not a finite number.`);
@@ -388,18 +390,19 @@ async function main() {
 
     /*
      * Emit the league health snapshot on the DONE line (the B5 throughput/decisive-rate re-probe
-     * reads this; it is the only window onto the otherwise-internal win-rate book until B4 wires it
-     * into `draw()`). `played` counts surfaced wire terminals; `decisiveGames` counts every booked
+     * reads this). `played` counts surfaced wire terminals; `decisiveGames` counts every booked
      * decisive episode INCLUDING zero-decision skips — so `episodes < decisiveGames` is the visible
      * signature of a zero-decision episode that was booked but surfaced no frame (the B2 reordering).
-     * env.py drains and drops this line (only the anchored LISTENING line is parsed), so appending
-     * fields is safe.
+     * `noSeatBeatGames` should be 0 — a nonzero value flags a placement-contract break that left the
+     * win-rate book under-credited (PFSP drifting toward uniform). env.py drains and drops this line
+     * (only the anchored LISTENING line is parsed), so appending fields is safe.
      */
     const s = league.stats();
     process.stdout.write(
       `PPO_ENV_SERVER DONE episodes=${played} decisiveGames=${s.decisiveGames} ` +
         `truncatedGames=${s.truncatedGames} decisiveRate=${s.decisiveRate.toFixed(4)} ` +
-        `poolSize=${s.poolSize} loadedSnapshots=${s.loadedSnapshots} bookSize=${s.bookSize}\n`
+        `poolSize=${s.poolSize} loadedSnapshots=${s.loadedSnapshots} bookSize=${s.bookSize} ` +
+        `noSeatBeatGames=${s.noSeatBeatGames}\n`
     );
   } finally {
     /*
@@ -431,7 +434,17 @@ async function shutdownWorker(worker) {
   await worker.terminate();
 }
 
-main().catch(err => {
-  process.stderr.write(`[ppo-env-server] fatal: ${err.stack || err.message}\n`);
-  process.exitCode = 1;
-});
+/*
+ * Run the server only when this file is the process entry point (the Python `EnvServerProcess`
+ * spawns it via `node scripts/ppo-env-server.mjs`). Guarding the launch lets a test `import` the
+ * module to exercise `parseArgs`/`numArg` — the Node side of the PFSP flag bridge — without spawning
+ * a Worker/socket. `pathToFileURL` normalises argv[1] so the compare is robust on every platform.
+ */
+const isEntryPoint =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isEntryPoint) {
+  main().catch(err => {
+    process.stderr.write(`[ppo-env-server] fatal: ${err.stack || err.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/ppo-env-server.mjs
+++ b/scripts/ppo-env-server.mjs
@@ -20,6 +20,12 @@
  *   node scripts/ppo-env-server.mjs [--port=0] [--host=127.0.0.1] [--players=7]
  *        [--learner-seat=0] [--opponents=ai_bc,ai_lookahead] [--max-areas=<N>]
  *        [--max-turns=500] [--episodes=0] [--seed-base=1] [--decision-timeout-ms=120000]
+ *        [--snapshot-manifest=<path>] [--snapshot-pool-cap=40]
+ *        [--reserve-baselines=3] [--pfsp-epsilon=0.05] [--pfsp-k=2]
+ *
+ * The PFSP league flags (`--snapshot-*`, `--reserve-baselines`, `--pfsp-*`) only matter once a
+ * snapshot pool exists; without `--snapshot-manifest` the league runs in empty-pool fixed-field mode
+ * and `draw()` returns the cycled `--opponents` field unchanged (task A). See docs/ml-bot D-22/D-23.
  *
  * `--decision-timeout-ms` is the per-decision watchdog: if the learner sends no action within it,
  * the server aborts loud instead of parking forever (covers a hung learner or a hard worker death).
@@ -68,6 +74,14 @@ const KNOWN_FLAGS = new Set([
    */
   'snapshot-manifest',
   'snapshot-pool-cap',
+  /*
+   * PFSP sampler knobs (B4 / [D-23]). Only take effect with a non-empty pool (i.e. alongside
+   * `--snapshot-manifest`): `reserve-baselines` = R aggressive baselines reserved per game (turtle
+   * defense); `pfsp-epsilon`/`pfsp-k` parameterise the snapshot weight `w(S)=max(ε,1−winRate)^k`.
+   */
+  'reserve-baselines',
+  'pfsp-epsilon',
+  'pfsp-k',
 ]);
 
 function parseArgs(argv) {
@@ -128,6 +142,9 @@ async function main() {
     learnerSeat,
     snapshotManifest: opts['snapshot-manifest'] ?? null,
     poolCap: numArg(opts, 'snapshot-pool-cap', 40),
+    reserveBaselines: numArg(opts, 'reserve-baselines', 3),
+    pfspEpsilon: numArg(opts, 'pfsp-epsilon', 0.05),
+    pfspK: numArg(opts, 'pfsp-k', 2),
   });
 
   const sab = new SharedArrayBuffer(8); // 2 × Int32

--- a/tests/ml/ppo-env-server-args.test.js
+++ b/tests/ml/ppo-env-server-args.test.js
@@ -1,0 +1,49 @@
+/**
+ * PPO env-server arg parsing — the NODE side of the PFSP flag bridge (Phase 3, task B — [D-23]).
+ *
+ * `ml/tests/test_env_server_argv.py` proves the Python EMITS `--reserve-baselines=…` etc., and
+ * `ppo-league-pfsp.test.js` proves `makeLeague` HONORS `reserveBaselines: …`. Nothing tested the
+ * middle hop: that `ppo-env-server.mjs` actually PARSES the flag (it is in `KNOWN_FLAGS`) and reads it
+ * back with the right key/default (`numArg`). A typo on this side — a missing `KNOWN_FLAGS` entry or a
+ * wrong `numArg` key/default — would otherwise surface only on a live shodan spawn: either a hard
+ * "Unknown flag" launch failure or, worse, a silent fall-back to the default = a mis-tuned multi-hour run.
+ *
+ * Importing the module is side-effect-free: `ppo-env-server.mjs` runs the server only when it is the
+ * process entry point (the `isEntryPoint` guard), so this exercises `parseArgs`/`numArg` without
+ * spawning a worker or binding a socket.
+ */
+
+import { numArg, parseArgs } from '../../scripts/ppo-env-server.mjs';
+
+describe('ppo-env-server — PFSP flag bridge (Node side)', () => {
+  it('parses the PFSP/snapshot knobs and reads them back round-trip', () => {
+    const opts = parseArgs([
+      '--reserve-baselines=4',
+      '--pfsp-epsilon=0.1',
+      '--pfsp-k=3',
+      '--snapshot-manifest=/tmp/snap/manifest.json',
+      '--snapshot-pool-cap=12',
+    ]);
+    expect(numArg(opts, 'reserve-baselines', 3)).toBe(4);
+    expect(numArg(opts, 'pfsp-epsilon', 0.05)).toBe(0.1);
+    expect(numArg(opts, 'pfsp-k', 2)).toBe(3);
+    expect(numArg(opts, 'snapshot-pool-cap', 40)).toBe(12);
+    expect(opts['snapshot-manifest']).toBe('/tmp/snap/manifest.json');
+  });
+
+  it('defaults the PFSP knobs to the B4 defaults when absent (must match makeLeague / Python)', () => {
+    const opts = parseArgs([]);
+    expect(numArg(opts, 'reserve-baselines', 3)).toBe(3);
+    expect(numArg(opts, 'pfsp-epsilon', 0.05)).toBe(0.05);
+    expect(numArg(opts, 'pfsp-k', 2)).toBe(2);
+  });
+
+  it('rejects an unknown / mistyped flag loudly (never silently ignored)', () => {
+    expect(() => parseArgs(['--pfsp-kk=3'])).toThrow(/Unknown flag --pfsp-kk/);
+    expect(() => parseArgs(['--reserve-baseline=3'])).toThrow(/Unknown flag --reserve-baseline/);
+  });
+
+  it('rejects a non-finite numeric knob', () => {
+    expect(() => numArg(parseArgs(['--pfsp-k=notnum']), 'pfsp-k', 2)).toThrow(/not a finite number/);
+  });
+});

--- a/tests/ml/ppo-league-pfsp.test.js
+++ b/tests/ml/ppo-league-pfsp.test.js
@@ -1,0 +1,372 @@
+/**
+ * PFSP opponent sampling — `draw()` weighting on (ml-bot Phase 3, task B step B4 — [D-22]/[D-23]).
+ *
+ * B3 only *loaded* snapshots into the pool; B4 turns the sampler on. With a non-empty pool,
+ * `draw(seed)` seeds a `mulberry32` stream and fills the `count` opponent seats with:
+ *   - up to `min(R, count, #reserveBaselines)` DISTINCT aggressive baselines (the [D-15] turtle
+ *     defense — never `ai_bc`), sampled without replacement, and
+ *   - the remaining seats with snapshots drawn by `w(S) = max(ε, 1 − learnerWinRate(S))^k`
+ *     (lower learner win-rate ⇒ higher weight), with replacement,
+ * then shuffles opponent→seat so neither group binds to fixed turn-order seats. The empty pool must
+ * STILL return the byte-identical task-A field. These tests pin the field shape, the reserve rules,
+ * seeded determinism, the win-rate-monotone weighting, and the ε floor (a mastered snapshot is never
+ * starved, and the roulette total is never 0).
+ *
+ * The pool is populated through the real `refresh()` path (temp-dir manifest + minimal weights
+ * modules, exactly as ppo-league-snapshots.test.js) — `draw()` only seats the loaded `fn`, never
+ * calls it, so tiny stand-in modules suffice.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync, utimesSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { makeLeague } from '../../scripts/lib/ppo-league.mjs';
+
+const DEFAULT_OPPONENTS = 'ai_lookahead,ai_strategist,ai_expectimax,ai_bc,ai_defensive';
+// Distinct reserve baselines = DEFAULT_OPPONENTS minus ai_bc = these 4 (the turtle-defense set).
+const RESERVE_IDS = ['ai_lookahead', 'ai_strategist', 'ai_expectimax', 'ai_defensive'];
+const COUNT = 6;
+
+let dir;
+let mtimeTick;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'ppo-pfsp-'));
+  mtimeTick = 1_700_000_000;
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function writeSnapshot(step, { encodingVersion = 2, maxAreas = 32 } = {}) {
+  const file = `snap-${String(step).padStart(6, '0')}.weights.js`;
+  writeFileSync(
+    join(dir, file),
+    `export const BC_POLICY = ${JSON.stringify({ encodingVersion, config: { maxAreas } })};\n`
+  );
+  return file;
+}
+
+function writeManifest(snapshots) {
+  const path = join(dir, 'manifest.json');
+  const latestStep = snapshots.reduce((m, s) => Math.max(m, s.step), 0);
+  writeFileSync(path, JSON.stringify({ encodingVersion: 2, snapshots, latestStep }));
+  const t = ++mtimeTick;
+  utimesSync(path, t, t);
+  return path;
+}
+
+const snap = step => ({ id: `snap-${step}`, step, weights: writeSnapshot(step), createdAt: 'x' });
+
+/** A league whose pool is preloaded with snapshots for `steps`; returns the started league. */
+async function leagueWithPool(steps, extra = {}) {
+  const lg = makeLeague({
+    baselineCsv: DEFAULT_OPPONENTS,
+    count: COUNT,
+    learnerSeat: 0,
+    snapshotManifest: writeManifest(steps.map(snap)),
+    ...extra,
+  });
+  await lg.refresh();
+  return lg;
+}
+
+describe('ppo-league PFSP — empty-pool parity preserved (B4 must not touch task A)', () => {
+  it('returns the byte-identical seed-invariant baseline field with no pool', () => {
+    const lg = makeLeague({ baselineCsv: DEFAULT_OPPONENTS, count: COUNT, learnerSeat: 0 });
+    const a = lg.draw(1);
+    const b = lg.draw(999_999);
+    expect(a.opponents.map(o => o.name)).toEqual(b.opponents.map(o => o.name));
+    expect(a.drawn.every(d => d.kind === 'baseline')).toBe(true);
+    expect(a.opponents.map(o => o.name)).toEqual([
+      'Lookahead@0',
+      'Strategist@1',
+      'Expectimax@2',
+      'BC@3',
+      'Defensive@4',
+      'Lookahead@5',
+    ]);
+  });
+});
+
+describe('ppo-league PFSP — field shape with a non-empty pool', () => {
+  it('fills count seats with R distinct reserve baselines + (count−R) snapshots', async () => {
+    const lg = await leagueWithPool([100, 200, 300, 400]); // R defaults to 3
+    const { opponents, drawn } = lg.draw(7);
+    expect(opponents).toHaveLength(COUNT);
+    expect(drawn).toHaveLength(COUNT);
+
+    const baselines = drawn.filter(d => d.kind === 'baseline');
+    const snapshots = drawn.filter(d => d.kind === 'snapshot');
+    expect(baselines).toHaveLength(3); // R = 3
+    expect(snapshots).toHaveLength(3); // count − R = 3
+
+    // Reserve baselines are DISTINCT and never ai_bc (the turtle-defense set).
+    const baseIds = baselines.map(d => d.id);
+    expect(new Set(baseIds).size).toBe(baseIds.length);
+    baseIds.forEach(id => expect(RESERVE_IDS).toContain(id));
+    expect(baseIds).not.toContain('ai_bc');
+  });
+
+  it('drawn seats are a permutation of the non-learner seats (player_count held constant)', async () => {
+    const lg = await leagueWithPool([100, 200], { learnerSeat: 3 });
+    const seats = lg.draw(7).drawn.map(d => d.seat).sort((a, b) => a - b);
+    expect(seats).toEqual([0, 1, 2, 4, 5, 6]); // learnerSeat 3 skipped, every other seat once
+  });
+
+  it('opponents/drawn stay index-parallel, names carry the @i slot suffix', async () => {
+    const lg = await leagueWithPool([100, 200]);
+    const { opponents, drawn } = lg.draw(7);
+    opponents.forEach((o, i) => {
+      expect(o.name).toBe(`${o.name.replace(/@\d+$/, '')}@${i}`);
+      expect(o.id).toBe(drawn[i].id);
+      expect(typeof o.fn).toBe('function');
+    });
+  });
+});
+
+describe('ppo-league PFSP — seeded determinism', () => {
+  it('same seed → identical field; pool state held', async () => {
+    const lg = await leagueWithPool([100, 200, 300]);
+    const a = lg.draw(42);
+    const b = lg.draw(42);
+    expect(a.opponents.map(o => o.name)).toEqual(b.opponents.map(o => o.name));
+    expect(a.drawn).toEqual(b.drawn);
+  });
+
+  it('different seeds vary the field (sampling actually depends on the seed)', async () => {
+    const lg = await leagueWithPool([100, 200, 300, 400, 500]);
+    const fields = [0, 1, 2, 3, 4].map(s =>
+      lg
+        .draw(s)
+        .drawn.map(d => `${d.kind}:${d.id}@${d.seat}`)
+        .join('|')
+    );
+    expect(new Set(fields).size).toBeGreaterThan(1);
+  });
+
+  it('shuffles opponent→seat so neither kind binds to fixed turn-order seats (D-23 guarantee)', async () => {
+    /*
+     * Without the Fisher-Yates shuffle, reserve baselines would always occupy the low field indices
+     * (→ the early, first-to-move board seats) and snapshots the high ones — a systematic turn-order
+     * pattern D-23 forbids and the learner could overfit. learnerSeat=0 → seats are 1..6; without the
+     * shuffle baselines (R=3) would be locked to seats {1,2,3} and snapshots to {4,5,6}. Assert the
+     * coupling is broken: across seeds, a snapshot reaches the earliest seat (1) AND a baseline reaches
+     * the latest seat (6). (Disabling the shuffle in draw() makes both of these impossible → fails.)
+     */
+    const lg = await leagueWithPool([100, 200, 300]); // R=3 baselines + 3 snapshots
+    let snapshotAtEarliest = false;
+    let baselineAtLatest = false;
+    for (let s = 0; s < 100 && !(snapshotAtEarliest && baselineAtLatest); s++) {
+      for (const d of lg.draw(s).drawn) {
+        if (d.kind === 'snapshot' && d.seat === 1) snapshotAtEarliest = true;
+        if (d.kind === 'baseline' && d.seat === 6) baselineAtLatest = true;
+      }
+    }
+    expect(snapshotAtEarliest).toBe(true);
+    expect(baselineAtLatest).toBe(true);
+  });
+});
+
+describe('ppo-league PFSP — reserve-baseline rules', () => {
+  it('reserveBaselines=0 → every seat is a PFSP snapshot', async () => {
+    const lg = await leagueWithPool([100, 200], { reserveBaselines: 0 });
+    const drawn = lg.draw(7).drawn;
+    expect(drawn.every(d => d.kind === 'snapshot')).toBe(true);
+  });
+
+  it('caps reserved seats at the number of DISTINCT reserve baselines (R > pool size)', async () => {
+    // R=10 but only 4 distinct aggressive baselines exist → 4 reserved, 2 PFSP.
+    const lg = await leagueWithPool([100, 200, 300], { reserveBaselines: 10 });
+    const drawn = lg.draw(7).drawn;
+    expect(drawn.filter(d => d.kind === 'baseline')).toHaveLength(4);
+    expect(drawn.filter(d => d.kind === 'snapshot')).toHaveLength(2);
+  });
+
+  it('empty reserve set (baselineCsv=ai_bc only) → all seats PFSP, never seats ai_bc', async () => {
+    const lg = makeLeague({
+      baselineCsv: 'ai_bc',
+      count: COUNT,
+      learnerSeat: 0,
+      snapshotManifest: writeManifest([100, 200].map(snap)),
+    });
+    await lg.refresh();
+    const drawn = lg.draw(7).drawn;
+    expect(drawn.every(d => d.kind === 'snapshot')).toBe(true);
+    expect(drawn.some(d => d.id === 'ai_bc')).toBe(false);
+  });
+});
+
+describe('ppo-league PFSP — win-rate-monotone weighting (the [D-19]/[D-22] signal)', () => {
+  it('samples a low-win-rate snapshot far more than a high-win-rate one (monotone in 1−winRate)', async () => {
+    /*
+     * Pool of two: snap-100 unrecorded (winRate 0 → weight max(ε,1)^k = 1); snap-200 recorded as a
+     * learner win (winRate 1 → weight max(ε,0)^k = ε^k ≈ 0.0025). reserveBaselines=0 ⇒ all 6 seats
+     * are snapshots, so every seat is one of the two and the counts isolate the weighting.
+     */
+    const lg = await leagueWithPool([100, 200], { reserveBaselines: 0 });
+    // Drive snap-200's win-rate to 1 (learner beat it) via a synthetic per-seat outcome.
+    lg.recordResult([{ id: 'snap-200', kind: 'snapshot', seat: 1 }], {
+      truncated: false,
+      seatBeat: [null, 1, null, null, null, null, null],
+    });
+    expect(lg.winRate('snap-200')).toBe(1);
+    expect(lg.winRate('snap-100')).toBe(0);
+
+    let lose = 0; // snap-100 (learner loses → up-weighted)
+    let won = 0; // snap-200 (learner wins → down-weighted)
+    const DRAWS = 400;
+    for (let s = 0; s < DRAWS; s++) {
+      for (const d of lg.draw(s).drawn) {
+        if (d.id === 'snap-100') lose++;
+        else if (d.id === 'snap-200') won++;
+      }
+    }
+    expect(lose + won).toBe(DRAWS * COUNT); // sanity: all seats accounted for
+    // ~400:1 expected weight ratio — assert a strong, unambiguous bias toward the loser.
+    expect(lose).toBeGreaterThan(won * 20);
+    // ε floor: the mastered snapshot is NOT starved — it still surfaces sometimes.
+    expect(won).toBeGreaterThan(0);
+  });
+
+  it('higher k sharpens the bias (k=4 starves the mastered snapshot harder than k=1)', async () => {
+    const countWonAtK = async k => {
+      const lg = await leagueWithPool([100, 200], { reserveBaselines: 0, pfspK: k });
+      lg.recordResult([{ id: 'snap-200', kind: 'snapshot', seat: 1 }], {
+        truncated: false,
+        seatBeat: [null, 1, null, null, null, null, null],
+      });
+      let won = 0;
+      for (let s = 0; s < 300; s++) for (const d of lg.draw(s).drawn) if (d.id === 'snap-200') won++;
+      return won;
+    };
+    expect(await countWonAtK(4)).toBeLessThan(await countWonAtK(1));
+  });
+
+  it('pins the makeLeague defaults at ε=0.05, k=2 (field sequence == explicit knobs, ≠ other ε)', async () => {
+    /*
+     * R=3/ε=0.05/k=2 are D-23-fixed defaults. R is pinned behaviorally above; ε and k are pinned here.
+     * With one mastered snapshot (snap-200) and one fresh (snap-100), the per-seat pick threshold is
+     * 1/(1+ε^k), which depends on BOTH ε and k — so the field SEQUENCE over a seed sweep is a
+     * fingerprint of the defaults. A default league must reproduce the explicit-{ε:0.05,k:2} sequence
+     * exactly, and a different ε must change it (proof the check has teeth, not a tautology).
+     */
+    const masteredPool = async extra => {
+      const lg = await leagueWithPool([100, 200], { reserveBaselines: 0, ...extra });
+      lg.recordResult([{ id: 'snap-200', kind: 'snapshot', seat: 1 }], {
+        truncated: false,
+        seatBeat: [null, 1, null, null, null, null, null],
+      });
+      return lg;
+    };
+    const seq = lg => Array.from({ length: 200 }, (_, s) => JSON.stringify(lg.draw(s).drawn)).join('|');
+
+    const dflt = await masteredPool({});
+    const explicit = await masteredPool({ pfspEpsilon: 0.05, pfspK: 2 });
+    const otherEps = await masteredPool({ pfspEpsilon: 0.5 });
+    expect(seq(dflt)).toBe(seq(explicit)); // defaults are exactly ε=0.05, k=2
+    expect(seq(dflt)).not.toBe(seq(otherEps)); // and the sequence genuinely depends on ε
+  });
+});
+
+describe('ppo-league PFSP — ε floor / no degenerate total', () => {
+  it('seats snapshots even when EVERY snapshot is fully mastered (weights all ε^k > 0)', async () => {
+    const lg = await leagueWithPool([100, 200], { reserveBaselines: 0 });
+    // Drive both snapshots to winRate 1 → both weights collapse to ε^k; total must stay > 0.
+    for (const id of ['snap-100', 'snap-200']) {
+      lg.recordResult([{ id, kind: 'snapshot', seat: 1 }], {
+        truncated: false,
+        seatBeat: [null, 1, null, null, null, null, null],
+      });
+    }
+    const seenIds = new Set();
+    for (let s = 0; s < 50; s++) {
+      const drawn = lg.draw(s).drawn;
+      expect(drawn).toHaveLength(COUNT);
+      expect(drawn.every(d => d.kind === 'snapshot')).toBe(true); // never empty / NaN seat
+      drawn.forEach(d => seenIds.add(d.id));
+    }
+    // Equal weights ⇒ both mastered snapshots still get drawn.
+    expect(seenIds).toEqual(new Set(['snap-100', 'snap-200']));
+  });
+
+  it('falls back to uniform when a pathological k underflows every weight to 0 (total===0 guard)', async () => {
+    /*
+     * At k high enough that ε^k underflows to exactly 0.0 in IEEE-754 (0.05^400 === 0) AND every
+     * snapshot mastered (base floored to ε), all weights are 0 and the roulette total is 0. Without
+     * the uniform fallback, sampleByWeight would degenerate to always returning the last pool entry;
+     * the guard keeps sampling meaningful (both snapshots surface) and crash-free.
+     */
+    const lg = await leagueWithPool([100, 200], { reserveBaselines: 0, pfspK: 400 });
+    for (const id of ['snap-100', 'snap-200']) {
+      lg.recordResult([{ id, kind: 'snapshot', seat: 1 }], {
+        truncated: false,
+        seatBeat: [null, 1, null, null, null, null, null],
+      });
+    }
+    const seenIds = new Set();
+    for (let s = 0; s < 50; s++) {
+      const drawn = lg.draw(s).drawn;
+      expect(drawn).toHaveLength(COUNT);
+      expect(drawn.every(d => d.kind === 'snapshot')).toBe(true);
+      drawn.forEach(d => seenIds.add(d.id));
+    }
+    expect(seenIds).toEqual(new Set(['snap-100', 'snap-200'])); // uniform fallback drew both
+  });
+});
+
+describe('ppo-league PFSP — draw → record → winRate loop credits sampled snapshots', () => {
+  it('records a snapshot drawn from the pool back into the win-rate book', async () => {
+    const lg = await leagueWithPool([100], { reserveBaselines: 0 });
+    const { drawn } = lg.draw(7); // every seat is snap-100
+    // Synthesize: the learner beat the snapshot at every seat.
+    const seatBeat = [null, null, null, null, null, null, null];
+    drawn.forEach(d => {
+      seatBeat[d.seat] = 1;
+    });
+    lg.recordResult(drawn, { truncated: false, seatBeat });
+    expect(lg.winRate('snap-100')).toBe(1); // beat at all (count) seats → 1.0
+    expect(lg.stats().bookSize).toBe(1);
+  });
+});
+
+describe('ppo-league PFSP — construction validation (B4 knobs)', () => {
+  const base = { baselineCsv: DEFAULT_OPPONENTS, count: COUNT, learnerSeat: 0 };
+
+  it('rejects pfspEpsilon outside (0, 1]', () => {
+    for (const pfspEpsilon of [0, -0.1, 1.5, NaN, Infinity]) {
+      expect(() => makeLeague({ ...base, pfspEpsilon })).toThrow(/pfspEpsilon must be in \(0, 1]/);
+    }
+  });
+
+  it('rejects a negative or non-finite pfspK', () => {
+    for (const pfspK of [-1, NaN, Infinity]) {
+      expect(() => makeLeague({ ...base, pfspK })).toThrow(/pfspK must be a finite number/);
+    }
+  });
+
+  it('rejects a negative or fractional reserveBaselines', () => {
+    for (const reserveBaselines of [-1, 2.5]) {
+      expect(() => makeLeague({ ...base, reserveBaselines })).toThrow(
+        /reserveBaselines must be a non-negative integer/
+      );
+    }
+  });
+
+  it('accepts the B4 defaults (R=3, ε=0.05, k=2) implicitly', () => {
+    expect(() => makeLeague(base)).not.toThrow();
+  });
+
+  it('rejects a typo\'d opponent id PAST position count with the clear "Unknown opponent bot id" error', () => {
+    /*
+     * The reserve pool is built from ALL distinct CSV ids, but resolveBaselineField only validates the
+     * first `count` cycled positions — so a bad id beyond position count−1 would slip past it and used
+     * to crash the reserve build with a cryptic `undefined.name` TypeError. The reserve lookup now
+     * guards it with the same clear message resolveBaselineField emits. (count=2, ai_not_a_bot at idx 2.)
+     */
+    expect(() =>
+      makeLeague({ baselineCsv: 'ai_lookahead,ai_bc,ai_not_a_bot', count: 2, learnerSeat: 0 })
+    ).toThrow(/Unknown opponent bot id "ai_not_a_bot"/);
+  });
+});

--- a/tests/ml/ppo-league-pfsp.test.js
+++ b/tests/ml/ppo-league-pfsp.test.js
@@ -370,3 +370,45 @@ describe('ppo-league PFSP — construction validation (B4 knobs)', () => {
     ).toThrow(/Unknown opponent bot id "ai_not_a_bot"/);
   });
 });
+
+describe('ppo-league PFSP — dead-PFSP guard (reserves must not crowd out every snapshot seat)', () => {
+  it('rejects a manifest config where reserved baselines fill EVERY seat (pfspCount would be 0)', () => {
+    /*
+     * count=3, default R=3, and DEFAULT_OPPONENTS carries 4 distinct non-ai_bc reserves, so
+     * reserveCount = min(3, 3, 4) = 3 = count ⇒ pfspCount = 0: draw() could never seat a PFSP snapshot
+     * even with a fully-loaded pool. With a snapshot manifest configured (PFSP clearly intended) that is
+     * a misconfiguration — fail the launch instead of silently training against baselines only.
+     */
+    expect(() =>
+      makeLeague({
+        baselineCsv: DEFAULT_OPPONENTS,
+        count: 3,
+        learnerSeat: 0,
+        snapshotManifest: join(dir, 'unused-manifest.json'),
+      })
+    ).toThrow(/can never seat a PFSP snapshot/);
+  });
+
+  it('does NOT apply the guard in fixed-field mode (no manifest) — that is a legitimate task-A config', () => {
+    /*
+     * Same starving R/count, but with no manifest the empty-pool path never seats snapshots anyway,
+     * so this is the ordinary fixed-field mode and must construct cleanly.
+     */
+    expect(() =>
+      makeLeague({ baselineCsv: DEFAULT_OPPONENTS, count: 3, learnerSeat: 0 })
+    ).not.toThrow();
+  });
+
+  it('allows a small-count manifest config that still leaves at least one PFSP seat', () => {
+    // count=3, R=2 ⇒ reserveCount=2, pfspCount=1: PFSP can still seat a snapshot, so it is allowed.
+    expect(() =>
+      makeLeague({
+        baselineCsv: DEFAULT_OPPONENTS,
+        count: 3,
+        learnerSeat: 0,
+        reserveBaselines: 2,
+        snapshotManifest: join(dir, 'unused-manifest.json'),
+      })
+    ).not.toThrow();
+  });
+});

--- a/tests/ml/ppo-league-snapshots.test.js
+++ b/tests/ml/ppo-league-snapshots.test.js
@@ -90,14 +90,16 @@ describe('ppo-league snapshots — hot-loading into the pool', () => {
     expect(lg.stats()).toMatchObject({ poolSize: 2, loadedSnapshots: 2 });
   });
 
-  it('does NOT seat snapshots in draw() yet (B3 only loads; B4 samples)', async () => {
+  it('seats snapshots in draw() once the pool is non-empty (B4 sampling on)', async () => {
     const lg = league(writeManifest([snap(100), snap(200)]));
-    const before = lg.draw(7).opponents.map(o => o.name);
+    // Before refresh the pool is empty → the pure task-A baseline field (no snapshot seats).
+    expect(lg.draw(7).drawn.every(d => d.kind === 'baseline')).toBe(true);
     await lg.refresh();
-    const after = lg.draw(7).opponents.map(o => o.name);
-    // The drawn field is byte-identical baselines before and after snapshots enter the pool.
-    expect(after).toEqual(before);
-    expect(after).not.toContain('snap-100');
+    // After refresh the pool is non-empty → PFSP now seats snapshots (player_count still held).
+    const after = lg.draw(7).drawn;
+    expect(after).toHaveLength(COUNT);
+    expect(after.some(d => d.kind === 'snapshot')).toBe(true);
+    // The detailed sampling/weighting behavior is pinned in ppo-league-pfsp.test.js.
   });
 
   it('re-refresh with an unchanged manifest loads nothing (mtime short-circuit)', async () => {

--- a/tests/ml/ppo-league.test.js
+++ b/tests/ml/ppo-league.test.js
@@ -254,6 +254,38 @@ describe('ppo-league — win-rate book (B2)', () => {
     }
   });
 
+  it('fails loud once no-seatBeat decisive games become PERSISTENT (PFSP-collapse guard)', () => {
+    /*
+     * A one-off missing seatBeat is tolerated (warn-once, above), but a PERSISTENT absence means the
+     * win-rate book is never credited and B4's PFSP sampler silently collapses to uniform — so
+     * recordResult must eventually throw rather than spin on and waste a whole training run.
+     */
+    const league = newLeague(0);
+    const { drawn } = league.draw(0);
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      let recorded = 0;
+      let thrown = null;
+      for (let i = 0; i < 100 && thrown === null; i++) {
+        try {
+          league.recordResult(drawn, { truncated: false }); // no seatBeat
+          recorded++;
+        } catch (err) {
+          thrown = err;
+        }
+      }
+      expect(thrown).toBeInstanceOf(Error);
+      expect(thrown.message).toMatch(/collapsed to uniform/);
+      // Tolerated a bounded handful before failing — not on the first call, and well before 100.
+      expect(recorded).toBeGreaterThan(0);
+      expect(recorded).toBeLessThan(100);
+      // The cumulative break count is surfaced for the DONE-line health window (recorded + the throwing call).
+      expect(league.stats().noSeatBeatGames).toBe(recorded + 1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
   it('throws on an out-of-domain seatBeat value (shaper/seat desync — never folds garbage into wins)', () => {
     const league = newLeague(0);
     const { drawn } = league.draw(0);


### PR DESCRIPTION
## Task B step B4 — PFSP weighting on ([D-22]/[D-23])

Turns the PFSP sampler **on** in `scripts/lib/ppo-league.mjs` `draw()`. B3 only *loaded* the snapshot pool; B4 seats it.

With a **non-empty pool**, `draw(seed)` seeds a `mulberry32` stream and fills the `count` opponent seats with:
- `R` **distinct aggressive baselines** (resolved `--opponents` ids minus `ai_bc`, the turtle lineage) — sampled *without* replacement, capped at `min(R, count, #distinct)`;
- `count − R` **snapshots** sampled *with* replacement by `w(S) = max(ε, 1 − learnerWinRate(S))^k` (ε=0.05, k=2; cold-start `winRate=0` → max weight → sampled hardest first);
- then a seeded **Fisher-Yates shuffle** of opponent→seat so neither group binds to fixed turn-order seats.

**The empty-pool path stays byte-identical to task A** — fixed-field remains the empty-pool mode of this one pipeline (pinned by tests). Deterministic given `(seed, pool, win-rate book)`.

### Changes
- **`scripts/lib/ppo-league.mjs`** — PFSP sampling in `draw()`; new `reserveBaselines`/`pfspEpsilon`/`pfspK` opts with validation; reserve-pool build with id guard; `total===0 → uniform` fallback for the pathological-k IEEE-754 underflow case.
- **`scripts/lib/mulberry32.mjs`** (NEW) — extracted the PRNG; re-exported from `ppo-probe-core.mjs` so the league doesn't pull the benchmark tool/env runner into its module graph. *(Documented deviation from D-23's "import from probe-core".)*
- **`scripts/ppo-env-server.mjs`** — `--reserve-baselines` / `--pfsp-epsilon` / `--pfsp-k` flags.
- **`ml/dicewars_ppo/{env_server,train_tracer}.py`** — argv forwarding, parser args, and `_validate_args` bounds (unconditional, mirroring the Node guards; `math.isfinite` for `k`).

### Tests
- NEW `tests/ml/ppo-league-pfsp.test.js` (21): field shape, reserve rules, seeded determinism, the shuffle anti-coupling, win-rate-monotone weighting, the ε floor + underflow fallback, default-knob pin, the draw→record→winRate loop, new-knob validation.
- NEW `ml/tests/test_env_server_argv.py` (torch-free flag bridge) and `ml/tests/test_train_tracer_args.py` (torch-gated parser/validation/forwarding — runs on shodan).
- Updated the one B3 test that asserted "B4 hasn't happened yet".

### Quality
Hardened against a **5-dimension adversarial review** (12 confirmed minor findings, all fixed: reserve-id guard, ε^k underflow fallback, unconditional Python validation, and closed test gaps).

- `npm test` → **1064/1064 pass** · `npm run lint` → 0 errors · `npm run build` → success · ruff clean.
- Pre-existing `test_export_onnx.py` failures locally are environmental (`zip(strict=True)` needs Py3.10) and untouched by B4.

**Next:** B5 — throughput/decisive-rate re-probe on a snapshot-heavy field; re-validate `R`; then lock the env-step budget. (B5 is also the sampler's first live exercise on shodan.)