### PR TITLE
feat(ml): Phase-3 task C/E foundation — league resume hardening, B6 flag forwarding, single-writer snapshot GC

### DIFF
--- a/docs/ml-bot/DECISIONS.md
+++ b/docs/ml-bot/DECISIONS.md
@@ -1462,3 +1462,72 @@ Phase-3 work is task C/E (cross-core + training-ops) → the long BEAT run.**
 **Grounding.** Two multi-agent workflows: a 12-agent design (4 code-readers → 3 design takes → synthesize
 → 3 adversarial-verify lenses → finalize) producing the vetted blueprint, and a 5-agent review
 (correctness / silent-failure / tests / grounding → verify-and-synthesize against ground truth).
+
+---
+
+## D-26 — Task C/E design: SubprocVecEnv + shodan training-ops; DROP VecNormalize; idempotent two-half resume · Accepted (2026-06-27) · closes Phase-3 tasks C/E design · follows [D-25](#d-25--b6-league-persistence-tojsonrestore--pluggable-shareddiskstore-as-a-standalone-node-pr--accepted-2026-06-27--closes-d-23-step-b6--feeds-task-e)
+
+**Context.** Tasks B0–B6 (the PFSP league) are feature-complete; the remaining Phase-3 work before the
+long BEAT run is task C (scale envs across cores + a from-scratch control) and task E (shodan
+training-ops: schtasks launch, idempotent checkpoint/resume, TensorBoard+CSV, `DummyVecEnv`→
+`SubprocVecEnv`). A 13-agent design workflow (4 code-readers → 3 design takes → synthesize → 4
+adversarial-verify lenses → finalize) produced a vetted, code-anchored blueprint, then Ivan confirmed
+the two genuine forks.
+
+**Decisions (Q1–Q6).**
+
+- **Q1 — new `ml/dicewars_ppo/train.py` + extract a torch-free `_train_common.py`** (shared env-thunk /
+  arg parser). Do NOT fork the tracer; one shared definition keeps the green CI tracer byte-identical.
+  `_train_common.py` must NOT import torch/sb3 at module top (SubprocVecEnv children import it).
+- **Q2 — DROP VecNormalize entirely** (`norm_obs=False, norm_reward=False`; don't wrap). _This reverses
+  the PLAN's literal "checkpoint/resume of policy + optimizer + VecNormalize + RNG" wording_ — the
+  adversarial verifier (grounded in `env.py:103-113`/`238-261`, `policy.py:108-136`, `model.py:113-161`,
+  `constants.py:30-68`, and the SB3 2.9.0 `VecNormalize` source) showed obs-normalization would
+  **corrupt the encoding contract**: it standardizes the int edge-index keys (`edge_from`/`edge_to`
+  → garbage after `.long()`), hard-`ValueError`s on the `edge_mask` `MultiBinary`, and breaks the
+  `present`-column masked-mean pool the warm-started trunk depends on. Reward-normalization only
+  manufactures a drifting scale on a clean `{0,1}` / `gamma=0.999` terminal return that PPO's own
+  advantage-normalization already handles. So there is **nothing VecNormalize-shaped to checkpoint**;
+  the resume state is policy + optimizer + `num_timesteps` + RNG + league pool/book only.
+- **Q3 — resume is TWO independent idempotent halves, no two-phase commit.** Python owns
+  policy/optimizer/`num_timesteps`/RNG/manifest/callback state; each Node worker owns its
+  `league-state-<seedBase>.json` + `book-shard-<seedBase>.json`. Atomic `latest.json` written LAST is
+  the Python crash-safety hinge. Resume is **"statistically consistent, bounded-skew," not bit-exact**
+  (Node can't replay trajectories; the RNG sidecar de-randomizes only the Python half) — documented, not
+  hidden.
+- **Q4 — `SubprocVecEnv(start_method="forkserver")` + `VecMonitor` in the PARENT.** forkserver because
+  CUDA inits at `MaskablePPO` construction (after the fork) so "venv built before CUDA" is not safe to
+  rely on; VecMonitor in the parent keeps children importing only the torch-free `dicewars_ppo.env` yet
+  still logs `rollout/ep_rew_mean`.
+- **Q5 — consumer ENOENT-tolerance FIRST (the required floor), then producer-single-writer GC.** A
+  lagging worker tolerates a peer-evicted snapshot file; the single Python producer owns disk deletion.
+- **Q6 — `--from-scratch` flag** (mutually exclusive with `--freeze-trunk`): skip warm-start, still load
+  the BC `cfg`, relax LR/ent-coef, stamp provenance. A SHORT control run before the long run proves the
+  gate win is real PPO learning, not fixed-field BC exploitation ([D-19] control).
+
+**Verifier-found resume bugs folded into the build (each with a regression test):** **HOLE-A** the
+env-server replayed seeds from 0 on resume and re-booked them (double-count) → persist an `episodeCount`
+seed-cursor; **HOLE-B** the league dump flushed the disk shard BEFORE the state file (a crash double-counts
+the book) → write state first, flush shard second (turns double-count into bounded loss); **HOLE-C** a
+resumed snapshot producer republished ids ahead of the resumed step → rehydrate the manifest filtered to
+`step <= num_timesteps`; **HOLE-D** `reset_num_timesteps=False` makes a fixed `--timesteps` additive (a
+crash-loop trains unbounded) → `remaining = max(timesteps − num_timesteps, 0)` (task-E).
+
+**Build sequence (PR slices).** PR-1 Node crash-safety + GC-race floor + resume hardening (DONE) · PR-2
+`EnvServerProcess` B6-flag forwarding (DONE) · PR-3 SnapshotCallback rehydration + single-writer producer
+GC, consumer `unlinkSync` removed (DONE) · PR-4 `_train_common.py` + `train.py` (SubprocVecEnv + VecMonitor
+
+- TB/CSV + `--from-scratch`) · PR-5 idempotent checkpoint/resume core · PR-6 committed shodan launcher +
+  schtasks runbook · PR-7 deferred test-hardening (env-server `main()` persistence integration test; live
+  cross-worker `SharedDiskStore`).
+
+**Status: IN PROGRESS — foundation PR-1→PR-3 landed locally (branch `ml-bot/task-ce-foundation`).** PR-1:
+`episodeCount` resume-cursor, `dumpLeagueState` state-then-flush order, `refresh()` ENOENT-tolerance +
+id-dedup + `refreshSkips` health counter (stderr DONE mirror), schema v1→v2. PR-2: `snapshot_store` /
+`league_state_dir` / `league_dump_every` forwarded by `EnvServerProcess` on their own gate (manifest-
+independent), byte-identical when unset. PR-3: NEW torch-free `snapshot_manifest.py` (`rehydrate_snapshots`
+
+- `gc_partition`); `SnapshotCallback` rehydrates on resume + GCs as the single disk writer; the consumer
+  no longer unlinks. Local verification: `tests/ml/` 196 green, the torch-free Python tiers green
+  (`test_snapshot_manifest.py` 12, `test_env_server_argv.py` 6), eslint + ruff clean. The torch-gated
+  callback tests + the live SubprocVecEnv/shodan paths are verified on shodan (PR-4+).

--- a/docs/ml-bot/LOG.md
+++ b/docs/ml-bot/LOG.md
@@ -21,6 +21,65 @@ Entry template:
 
 ---
 
+## 2026-06-27 — Task C/E design (D-26) + foundation PR-1→PR-3 landed locally
+
+**Phase:** 3 · **Who:** Ivan + Claude
+
+**Did:**
+
+- **Scoped task C/E (SubprocVecEnv + shodan training-ops) via a 13-agent design workflow** (4 code-readers
+  → 3 design takes [minimal / robustness / ops] → synthesize → 4 adversarial-verify lenses → finalize).
+  Produced a vetted, code-anchored plan of record; recorded as **[D-26]**.
+- **Resolved Q1–Q6** (two genuine forks confirmed with Ivan via AskUserQuestion): new `train.py` +
+  torch-free `_train_common.py`; **DROP VecNormalize** (reverses the PLAN wording); two-half idempotent
+  resume (bounded-skew); `SubprocVecEnv(forkserver)` + `VecMonitor` in the parent; consumer
+  ENOENT-tolerance then producer single-writer GC; `--from-scratch` control.
+- **Implemented + locally tested the foundation PR-1→PR-3** on branch `ml-bot/task-ce-foundation`:
+  - **PR-1 (Node crash-safety):** `episodeCount` resume seed-cursor (persisted/restored/in `stats()`;
+    env-server loop starts at it); `refresh()` GC-race floor (tolerate a peer-evicted file: warn + mark
+    loaded + `refreshSkips++`; dedup `fresh` by id; rethrow non-missing errors); `dumpLeagueState`
+    flipped to state-then-flush (HOLE-B); schema v1→v2; DONE health mirrored to stderr.
+  - **PR-2 (Python forwarding):** `EnvServerProcess` forwards `snapshot_store`/`league_state_dir`/
+    `league_dump_every` to argv on their own (manifest-independent) gate; byte-identical when unset.
+  - **PR-3 (snapshot GC ownership):** removed the consumer `unlinkSync`; NEW torch-free
+    `ml/dicewars_ppo/snapshot_manifest.py` (`rehydrate_snapshots` + `gc_partition`); `SnapshotCallback`
+    rehydrates on resume + GCs aged files after truncating the manifest (`pool_cap`/`gc_grace`).
+- **Verification GREEN:** full JS suite **1147** (+6 new league tests), build + eslint + prettier clean;
+  torch-free Python tiers (`test_snapshot_manifest.py` 12, `test_env_server_argv.py` 6) pass; ruff +
+  py_compile clean. Updated DECISIONS (D-26), PLAN (task C/E), and this LOG.
+
+**Learned / decided:**
+
+- **VecNormalize is a trap here, not a feature.** The verifier (grounded in `env.py`/`policy.py`/
+  `model.py`/`constants.py` + the SB3 2.9.0 source) showed obs-norm corrupts the int edge-index keys,
+  `ValueError`s on the `edge_mask` MultiBinary, and breaks the masked-mean pool; reward-norm is pointless
+  on a `{0,1}`/γ=0.999 return. So there is nothing VecNormalize-shaped to checkpoint — the PLAN wording
+  was wrong; resume state = policy + optimizer + `num_timesteps` + RNG + league pool/book.
+- **The adversarial pass earned its keep:** it found 4 concrete resume bugs (HOLE-A seed-replay double-
+  count, HOLE-B disk-book double-count, HOLE-C future-snapshot republish, HOLE-D additive `--timesteps`)
+  the naive design would have shipped. A→C are fixed in PR-1/PR-3; D lands in PR-5.
+- **PR-1 and PR-3 interact:** PR-3 moves disk deletion to the single producer, so the GC-race tests are
+  written for the final (consumer-never-unlinks) state — they delete the file directly to simulate the
+  producer/peer GC, surviving the PR-1→PR-3 boundary.
+
+**Dead ends / surprises:**
+
+- This Mac has **no torch/sb3** (system py 3.9; the ml venv is shodan-only), so the torch-gated
+  `test_snapshot_callback.py` (updated for the new GC/rehydration + `_write_manifest_atomic(entries)`
+  signature) can't run locally — its logic is mirrored in the torch-free `test_snapshot_manifest.py`,
+  and the wiring is verified on shodan at PR-4+. Extracting the pure helpers into `snapshot_manifest.py`
+  was specifically to keep the GC/rehydration math locally testable.
+
+**Next:**
+
+- **PR-4** `_train_common.py` + `train.py` (SubprocVecEnv(forkserver) + VecMonitor + TB/CSV +
+  `--from-scratch`; add `tensorboard` to `[rl]`) · **PR-5** idempotent checkpoint/resume core (RNG
+  sidecar + atomic `latest.json` last + HOLE-D budget) · **PR-6** committed `scripts/shodan/ppo-train.sh`
+  - schtasks runbook · **PR-7** deferred test-hardening. Then the long BEAT run at R=3.
+- Decide commit/PR mechanics for the foundation branch with Ivan (one PR vs the 3-slice split).
+
+---
+
 ## 2026-06-27 — Task B step B6: league persistence + SharedDiskStore (toJSON/restore; standalone PR #69, squash `d637a06`)
 
 **Phase:** 3 · **Who:** Ivan + Claude

--- a/docs/ml-bot/LOG.md
+++ b/docs/ml-bot/LOG.md
@@ -21,6 +21,57 @@ Entry template:
 
 ---
 
+## 2026-06-27 — Task C/E foundation — PR #70 review-hardening (4-agent review)
+
+**Phase:** 3 · **Who:** Ivan + Claude
+
+**Did:**
+
+- **Ran a 4-agent review of PR #70** (code-review, silent-failure-hunter, pr-test-analyzer,
+  comment-analyzer). The core logic (resume cursor, HOLE-B dump order, `gc_partition` math, rehydrate
+  `<=` cutoff) was independently traced correct by 3 agents — **no blocking bugs**. The review found two
+  real disk-related issues on the Python producer plus comment rot from the consumer→producer GC pivot.
+- **Fixed two functional issues (both surface only on the long shodan run):**
+  - **Grace-zone disk leak on resume + republish window:** `_on_training_start` rehydrated from the
+    _truncated manifest_ (`pool_cap` entries), so the `gc_grace` files on disk beyond it were never
+    re-tracked → leaked `gc_grace` files per resume. Rewrote it to **scan disk** (`_discover_on_disk_
+snapshots` + new torch-free `plan_resume`): re-adopt the whole retention set, drop+**delete** any
+    file ahead of the resumed step (closes the HOLE-C republish-divergence window at the producer), and
+    rewrite the manifest. Reading the manifest is dropped entirely, so a corrupt/torn manifest can no
+    longer mislead the producer (dissolves the prior start-fresh/encodingVersion/KeyError concerns).
+  - **Fatal GC unlink:** the `unlink(missing_ok=True)` GC loop only swallowed `FileNotFoundError`; any
+    other `OSError` (EIO / read-only remount / EBUSY) crashed `model.learn()` over pure disk hygiene.
+    New `_safe_unlink` logs and continues — a robustness regression vs the old best-effort eviction.
+- **Comment sweep (consumer no longer GCs):** corrected ~6 stale `ppo-league.mjs` comments that still
+  said the consumer "FIFO-evicts + `unlinkSync`s" / a "peer worker" deletes — re-attributed the GC race
+  to the single Python producer; fixed the `refresh()` JSDoc, the fingerprint/`restore` gate notes, and
+  the dead-code back-fill comment. Pointed the env-server stdout-drain comments at `env_server.py`.
+- **Test-seam extraction (the PR's guarantees were untested where they execute):** `main()` isn't
+  exported, so the HOLE-B write order and the resume-loop bounds had no coverage. Extracted + exported
+  `makeCheckpointDumper` (pins state-then-flush order + the consecutive-failure abort),
+  `formatDoneLine`, and `resumeStartEpisode`/`shouldRunEpisode` (pins `--episodes=N` as a run-total).
+  Also emit the health line with a `WARN` prefix and on the **abnormal-exit** path (S-3/S-4), and added
+  the `!existsSync` guard so a _present_ module's `ERR_MODULE_NOT_FOUND` (missing transitive import) is
+  rethrown, not masked as a benign GC-race skip (S-1).
+- **New tests:** torch-free `plan_resume` (4) + `makeCheckpointDumper`/`formatDoneLine`/loop-bounds (9) +
+  the ERR_MODULE_NOT_FOUND-while-present guard (1); torch-gated callback tests for disk-scan resume,
+  grace-zone re-adoption (the leak), and unlink resilience (run on shodan).
+
+**Learned / decided:**
+
+- **Disk-scan beats manifest-read for producer resume.** Rebuilding the tracked set from the directory
+  (not the truncated manifest) is what keeps the grace zone GC-eligible AND removes the manifest as a
+  trust dependency — one change closes the leak, the republish window, and the corrupt-manifest class.
+- **Extract the seam to test the guarantee.** The dump-order and run-total semantics were correct but a
+  silent revert would have passed CI; the fix was a small export, not a new integration harness.
+
+**Verification GREEN:** ruff + ruff-format clean; torch-free Python (`test_snapshot_manifest.py` 16,
+`test_env_server_argv.py` 6) pass; full ml JS suite **206** (+9 checkpoint/loop tests, +1 guard test);
+eslint + prettier clean. Torch-gated `test_snapshot_callback.py` (disk-scan resume / leak / unlink
+resilience) runs on shodan. Full repo suite + build run by the main agent.
+
+---
+
 ## 2026-06-27 — Task C/E design (D-26) + foundation PR-1→PR-3 landed locally
 
 **Phase:** 3 · **Who:** Ivan + Claude

--- a/docs/ml-bot/PLAN.md
+++ b/docs/ml-bot/PLAN.md
@@ -532,13 +532,26 @@ ppo:gate` over **3040 seat-fair games**: PPO **11.5 ± 1.3%** vs Lookahead **15.
       when absent). 12-agent design + 5-agent review (SHIP-AFTER-FIXES, no blockers); folded S1–S6. Deferred
       to task E: Python flag forwarding, the multi-worker `refresh()` snapshot-GC race, the `main()`
       persistence integration test, live cross-worker validation.
+- [~] **(C/E) Design fixed in [D-26]** (13-agent workflow: 4 readers → 3 design takes → synthesize → 4
+  adversarial verifiers → finalize). Q1–Q6 resolved: new `train.py` + torch-free `_train_common.py`;
+  **DROP VecNormalize** (it corrupts the Dict-obs encoding contract — see [D-26]; supersedes the
+  VecNormalize wording below); two-half idempotent resume (Python SB3 half + Node league half),
+  bounded-skew not bit-exact; `SubprocVecEnv(forkserver)` + `VecMonitor` in the parent; consumer
+  ENOENT-tolerance then producer-single-writer GC; `--from-scratch` control. **Foundation PR-1→PR-3
+  landed locally** (branch `ml-bot/task-ce-foundation`): Node crash-safety + GC-race floor +
+  `episodeCount` resume-cursor (PR-1); `EnvServerProcess` B6-flag forwarding (PR-2); SnapshotCallback
+  rehydration + single-writer producer GC, consumer `unlinkSync` removed (PR-3). `tests/ml/` 196 +
+  torch-free Python tiers green; eslint + ruff clean.
 - [ ] **(C)** Scale envs across cores; add the short **from-scratch control** run ([D-19] decision 1).
+      _Lands in PR-4/PR-5 (`train.py`: `SubprocVecEnv(forkserver)` + `--from-scratch`); see [D-26]._
 - [ ] **(D)** Add **annealed potential-based reward shaping** (Δlargest-group/territory/dice/elims,
       `F = γΦ(s′)−Φ(s)`, env-side in JS) only if terminal-only learning is too slow.
 - [ ] **(E) shodan training-ops (prerequisite for the long BEAT run):** schtasks-wrapped WSL launch
       (the only disconnect-surviving pattern); idempotent checkpoint/resume of policy + optimizer +
-      VecNormalize + RNG + step + pool; TensorBoard + a flat CSV that survives sessions; swap
-      `DummyVecEnv` → `SubprocVecEnv` for real cross-core parallelism.
+      RNG + step + league pool/book (**NOT VecNormalize** — dropped per [D-26]); TensorBoard + a flat
+      CSV that survives sessions; swap `DummyVecEnv` → `SubprocVecEnv` for real cross-core parallelism.
+      _Remaining slices: PR-4 (`train.py` + TB/CSV), PR-5 (checkpoint/resume core), PR-6 (committed
+      shodan launcher + schtasks runbook), PR-7 (deferred test-hardening). See [D-26]._
 
 **Acceptance criteria.**
 

--- a/ml/dicewars_ppo/env_server.py
+++ b/ml/dicewars_ppo/env_server.py
@@ -85,6 +85,9 @@ class EnvServerProcess:
         reserve_baselines: int = 3,
         pfsp_epsilon: float = 0.05,
         pfsp_k: float = 2.0,
+        snapshot_store: str | None = None,
+        league_state_dir: str | None = None,
+        league_dump_every: int | None = None,
         host: str = "127.0.0.1",
         node_bin: str | None = None,
         start_timeout_s: float = 30.0,
@@ -131,6 +134,19 @@ class EnvServerProcess:
             argv.append(f"--reserve-baselines={reserve_baselines}")
             argv.append(f"--pfsp-epsilon={pfsp_epsilon}")
             argv.append(f"--pfsp-k={pfsp_k}")
+        # League persistence (B6 / task E). Independent of the snapshot manifest: a fixed-field run
+        # (no manifest) still checkpoints/resumes via --league-state-dir, so these ride their OWN
+        # gate, not the snapshot branch above. Each is forwarded only when set, so an unset value
+        # yields byte-identical argv to B5 and the Node server falls back to its own defaults
+        # (snapshot-store=memory, league-dump-every=50, persistence off). The values themselves are
+        # range-validated on the Node side (resolveLeaguePersistence / the dump-every guard) and by
+        # the train CLI; EnvServerProcess stays a thin forwarder, mirroring the PFSP flags above.
+        if snapshot_store is not None:
+            argv.append(f"--snapshot-store={snapshot_store}")
+        if league_state_dir is not None:
+            argv.append(f"--league-state-dir={league_state_dir}")
+        if league_dump_every is not None:
+            argv.append(f"--league-dump-every={league_dump_every}")
         self._argv = argv
 
     def start(self) -> EnvServerProcess:

--- a/ml/dicewars_ppo/snapshot_callback.py
+++ b/ml/dicewars_ppo/snapshot_callback.py
@@ -18,9 +18,12 @@ forced by the bare-i32 learner-env wire). The producer keeps the newest ``pool_c
 manifest and ``pool_cap + gc_grace`` on disk (a grace buffer for a consumer mid-import during
 a manifest truncation), unlinking older files after the truncated manifest is durable.
 
-Resume (task E / PR-3): ``_on_training_start`` rehydrates the manifest from a prior run (minus
-entries published AHEAD of the resumed step), so a relaunched run does not republish ids the
-league already pooled nor restart numbering from zero.
+Resume (task E / PR-3): ``_on_training_start`` rebuilds the tracked set by SCANNING the snapshot
+dir (not by reading the truncated manifest — that would leave the ``gc_grace`` files beyond it
+untracked and so leak them every resume). It drops + deletes any file published AHEAD of the
+resumed step (the resumed run republishes those ids; a stale file is the republish-divergence
+window) and rewrites the manifest, so a relaunch neither double-publishes a pooled id nor orphans
+disk from the single-writer GC.
 
 Reuse, not reinvention: ``repack_to_bc_checkpoint`` + ``export`` are the exact step-7 gate
 path (PR #61), already proven to produce a module ``makeBC`` accepts — so a snapshot needs
@@ -42,6 +45,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
@@ -53,7 +57,13 @@ from dicewars_bc.export_weights import export
 from dicewars_bc.manifest import EXPECTED_ENCODING_VERSION
 
 from .policy import repack_to_bc_checkpoint
-from .snapshot_manifest import gc_partition, rehydrate_snapshots
+from .snapshot_manifest import gc_partition, plan_resume
+
+# A published weights file: ``snap-<zero-padded-step>.weights.js`` (see ``_publish``). The capture
+# group recovers the producer step so a resume can rebuild its tracked set from a directory scan
+# (the manifest lists only the newest ``pool_cap`` — globbing disk is what makes the grace zone and
+# any stale files GC-eligible again). Anchored so a stray/temp file can never pose as a snapshot.
+_SNAPSHOT_FILE_RE = re.compile(r"snap-(\d+)\.weights\.js\Z")
 
 
 class SnapshotCallback(BaseCallback):
@@ -105,29 +115,81 @@ class SnapshotCallback(BaseCallback):
 
     def _on_training_start(self) -> None:
         self.snapshot_dir.mkdir(parents=True, exist_ok=True)
-        # Resume rehydration (task E / PR-3): adopt a prior run's manifest (minus entries AHEAD of
-        # the resumed step) so we neither republish ids the league already pooled nor restart id
-        # numbering from zero. Without it, a resumed run re-writes `snap-<step>` ids it already
-        # published — duplicate manifest entries + a double-seated pool. `self.model.num_timesteps`
-        # is the resumed env-step count (SB3 restores it under `learn(reset_num_timesteps=False)`);
-        # the callback's own `self.num_timesteps` is not synced at training-start, so read model's.
-        manifest_path = self.snapshot_dir / "manifest.json"
-        if not manifest_path.is_file():
-            return
-        try:
-            prior = json.loads(manifest_path.read_text())
-        except (OSError, ValueError) as err:
-            # A corrupt/half-written manifest must not crash training start — log and start fresh
-            # (the league re-polls and rebuilds its pool from the persisted snapshots regardless).
-            print(f"[snapshot] ignoring unreadable manifest.json on resume ({err}); starting fresh")
-            return
-        resumed_step = self.model.num_timesteps
-        self._snapshots = rehydrate_snapshots(prior.get("snapshots", []), resumed_step)
+        # Resume rehydration (task E / PR-3, hardened): rebuild the tracked set from what is on
+        # disk (a scan of `snap-*.weights.js`), NOT from `manifest.json`. The manifest lists only
+        # the newest `pool_cap`, so adopting it would leave the `gc_grace` files on disk beyond the
+        # manifest untracked and therefore never GC-eligible — a `gc_grace`-file leak per resume.
+        # Scanning disk re-adopts the whole retention set, drops+deletes any file AHEAD of the
+        # resumed step (the resumed run republishes those ids — a stale file is the republish-
+        # divergence window and would orphan from this producer's GC), and rewrites the manifest to
+        # match. The manifest is never read, so a corrupt/torn manifest cannot mislead the producer.
+        #
+        # `self.model.num_timesteps` is the resumed env-step count (SB3 restores it under
+        # `learn(reset_num_timesteps=False)`); the callback's own `self.num_timesteps` is not synced
+        # at training-start, so read the model's. Set `_last_snapshot_step` to it so the first
+        # `_on_step` does not immediately re-publish steps 0..resumed.
+        resumed_step = int(self.model.num_timesteps)
         self._last_snapshot_step = resumed_step
-        if self._snapshots:
+        on_disk = self._discover_on_disk_snapshots()
+        if not on_disk:
+            return  # fresh run (or no snapshots published yet) — nothing to rehydrate or GC
+        manifest_entries, retained, deletable, future = plan_resume(
+            on_disk, resumed_step, self._pool_cap, self._gc_grace
+        )
+        # Delete future (republished) files first, then aged-out files, then rewrite the manifest so
+        # it never lists a file we removed. (Unlike a steady-state publish, here the manifest is
+        # rewritten AFTER deletion: every deleted entry is excluded from `manifest_entries` by
+        # construction, so no crash window references a missing file.)
+        for s in future:
+            self._safe_unlink(s["weights"])
+        for s in deletable:
+            self._safe_unlink(s["weights"])
+        self._snapshots = retained
+        self._write_manifest_atomic(manifest_entries)
+        print(
+            f"[snapshot] resumed: {len(retained)} on disk, {len(manifest_entries)} in manifest "
+            f"(step <= {resumed_step}); dropped {len(future)} future, GC'd {len(deletable)} aged"
+        )
+
+    def _discover_on_disk_snapshots(self) -> list[dict]:
+        """Scan ``snapshot_dir`` for published weights files → manifest entries, ascending by step.
+
+        The producer's tracked set is rebuilt from disk on resume (see ``_on_training_start``).
+        ``createdAt`` is recovered from each file's mtime (the original is only informational, not
+        persisted anywhere torch-free); a filename that does not match ``snap-<step>.weights.js`` is
+        skipped (a stray temp file or unrelated artifact must never enter the GC set).
+        """
+        entries: list[dict] = []
+        for path in self.snapshot_dir.glob("snap-*.weights.js"):
+            m = _SNAPSHOT_FILE_RE.match(path.name)
+            if m is None:
+                continue
+            step = int(m.group(1))
+            created = datetime.fromtimestamp(path.stat().st_mtime, timezone.utc).isoformat()
+            entries.append(
+                {
+                    "id": f"snap-{step:09d}",
+                    "step": step,
+                    "weights": path.name,
+                    "createdAt": created,
+                }
+            )
+        entries.sort(key=lambda s: s["step"])
+        return entries
+
+    def _safe_unlink(self, weights_name: str) -> None:
+        """Best-effort unlink of an aged-out/superseded weights file (single-writer GC, task E).
+
+        Deleting a file the manifest no longer references is pure disk hygiene — training is
+        unaffected — so a transient FS error (``EIO`` on a flaky disk, a read-only-remounted
+        share, ``EBUSY``) must NOT crash a multi-day run. ``FileNotFoundError`` is idempotent for
+        the single writer; any other ``OSError`` is logged and the file left for the next GC pass.
+        """
+        try:
+            (self.snapshot_dir / weights_name).unlink(missing_ok=True)
+        except OSError as err:
             print(
-                f"[snapshot] resumed manifest: kept {len(self._snapshots)} entries "
-                f"(step <= {resumed_step})"
+                f"[snapshot] GC: could not unlink aged-out {weights_name} ({err}); leaving on disk"
             )
 
     def _on_step(self) -> bool:
@@ -153,15 +215,23 @@ class SnapshotCallback(BaseCallback):
         tmp_fd, tmp_name = tempfile.mkstemp(suffix=".pt", dir=str(self.snapshot_dir))
         os.close(tmp_fd)
         tmp_pt = Path(tmp_name)
+        # 2) export the JS module to a temp path, fsync, then `os.replace` into final position — the
+        # same temp+atomic-rename discipline the manifest uses (`_write_manifest_atomic`). Writing
+        # the final `snap-*.weights.js` directly would leave a TORN file at that name on a crash
+        # (kill -9 / OOM / power loss) lands mid-write — and the resume disk-scan globs every
+        # `snap-*.weights.js`, so it would re-adopt the truncated module and a consumer would import
+        # a broken file. The `.tmp` suffix is outside the `snap-*.weights.js` glob (and the anchored
+        # discovery regex), so a leftover temp is never mistaken for a published snapshot.
+        tmp_js = weights_path.with_name(weights_path.name + ".tmp")
         try:
             torch.save(repacked, tmp_pt)
-            # 2) export the JS weights module — no parity fixture (makeBC needs weights only).
-            export(tmp_pt, weights_path, fixture_path=None)
+            export(tmp_pt, tmp_js, fixture_path=None)
+            _fsync_path(tmp_js)
+            os.replace(tmp_js, weights_path)  # atomic on POSIX; the final name is never torn
         finally:
             tmp_pt.unlink(missing_ok=True)
-
-        # Make the weights durable BEFORE the manifest references it (atomic-publish ordering).
-        _fsync_path(weights_path)
+            # No-op after a successful replace (tmp_js was renamed away); cleans a failed export.
+            tmp_js.unlink(missing_ok=True)
 
         # 3) append, then single-writer GC (task E / PR-3): the manifest lists the newest pool_cap;
         # disk keeps the newest pool_cap + gc_grace; older files are deleted. ORDER MATTERS: write
@@ -181,7 +251,7 @@ class SnapshotCallback(BaseCallback):
         )
         self._write_manifest_atomic(manifest_entries)
         for s in deletable:
-            (self.snapshot_dir / s["weights"]).unlink(missing_ok=True)
+            self._safe_unlink(s["weights"])
         # Bound the tracked history to what is still on disk so the next gc_partition is over the
         # live set (it would otherwise grow unbounded across a multi-day run).
         self._snapshots = retained

--- a/ml/dicewars_ppo/snapshot_callback.py
+++ b/ml/dicewars_ppo/snapshot_callback.py
@@ -3,15 +3,24 @@
 An SB3 :class:`~stable_baselines3.common.callbacks.BaseCallback` that, every
 ``snapshot_every`` env steps, repacks the live PPO actor back into BC-checkpoint format,
 exports it to a ``.weights.js`` module in ``snapshot_dir``, and atomically republishes
-``manifest.json`` listing every snapshot. The Node env-server's ``league.refresh()``
-(``scripts/lib/ppo-league.mjs``) polls that manifest at each episode boundary and hot-loads
-the new snapshots as in-process ``ai_bc`` opponents — the PFSP pool the learner trains on.
-See [D-22]/[D-23].
+``manifest.json`` listing the newest ``pool_cap`` snapshots. The Node env-server's
+``league.refresh()`` (``scripts/lib/ppo-league.mjs``) polls that manifest at each episode
+boundary and hot-loads the new snapshots as in-process ``ai_bc`` opponents — the PFSP pool
+the learner trains on. See [D-22]/[D-23].
 
-This is the **producer half** only: the pool, the seeded sampler, the win-rate book, and
-the ``poolCap`` FIFO/disk-GC are all Node-resident ([D-22], forced by the bare-i32
-learner-env wire — the trainer cannot select opponents per-episode over it). The producer
-just publishes artifacts.
+This is the **producer half**: it publishes artifacts and — as of task E / PR-3 — is the
+**single owner of disk GC**. Under ``SubprocVecEnv`` many Node env-server consumers share one
+``snapshot_dir``; if each consumer unlinked its own FIFO-evicted files they would race to
+delete each other's (and a lagging consumer would import a path a peer just removed), so
+deletion was pulled to this one producer. Consumers now only TRIM their in-memory pool and
+tolerate a missing file. The seeded sampler and win-rate book stay Node-resident ([D-22],
+forced by the bare-i32 learner-env wire). The producer keeps the newest ``pool_cap`` in the
+manifest and ``pool_cap + gc_grace`` on disk (a grace buffer for a consumer mid-import during
+a manifest truncation), unlinking older files after the truncated manifest is durable.
+
+Resume (task E / PR-3): ``_on_training_start`` rehydrates the manifest from a prior run (minus
+entries published AHEAD of the resumed step), so a relaunched run does not republish ids the
+league already pooled nor restart numbering from zero.
 
 Reuse, not reinvention: ``repack_to_bc_checkpoint`` + ``export`` are the exact step-7 gate
 path (PR #61), already proven to produce a module ``makeBC`` accepts — so a snapshot needs
@@ -44,6 +53,7 @@ from dicewars_bc.export_weights import export
 from dicewars_bc.manifest import EXPECTED_ENCODING_VERSION
 
 from .policy import repack_to_bc_checkpoint
+from .snapshot_manifest import gc_partition, rehydrate_snapshots
 
 
 class SnapshotCallback(BaseCallback):
@@ -52,6 +62,12 @@ class SnapshotCallback(BaseCallback):
     :param snapshot_dir: directory to write ``snap-*.weights.js`` + ``manifest.json`` into. The Node
         env-server is pointed at ``<snapshot_dir>/manifest.json`` via ``--snapshot-manifest``.
     :param snapshot_every: publish cadence in total env steps (across all vec-envs). Must be > 0.
+    :param pool_cap: max snapshots the manifest lists (the consumers' sampleable set). Match the
+        env-server league's ``--snapshot-pool-cap``. The manifest is truncated to the newest
+        ``pool_cap`` on each publish (task E / PR-3). Must be > 0.
+    :param gc_grace: extra snapshots kept ON DISK beyond the manifest (a buffer for a consumer
+        mid-import during a manifest truncation). Files older than ``pool_cap + gc_grace`` are
+        unlinked here by the single producer. Must be >= 0.
     :param teacher: provenance stamped into each exported module's header.
     """
 
@@ -60,20 +76,59 @@ class SnapshotCallback(BaseCallback):
         snapshot_dir: str | Path,
         snapshot_every: int,
         *,
+        pool_cap: int = 40,
+        gc_grace: int = 10,
         teacher: str = "ppo-snapshot",
         verbose: int = 0,
     ) -> None:
         super().__init__(verbose)
         if int(snapshot_every) <= 0:
             raise ValueError(f"snapshot_every must be a positive int, got {snapshot_every!r}")
+        if int(pool_cap) <= 0:
+            raise ValueError(f"pool_cap must be a positive int, got {pool_cap!r}")
+        if int(gc_grace) < 0:
+            raise ValueError(f"gc_grace must be a non-negative int, got {gc_grace!r}")
         self.snapshot_dir = Path(snapshot_dir)
         self.snapshot_every = int(snapshot_every)
+        # Single-writer GC (task E / PR-3): the manifest lists the newest `pool_cap` (match the
+        # env-server league's --snapshot-pool-cap so consumers see exactly the sampleable set);
+        # disk keeps `pool_cap + gc_grace` (a grace buffer for a consumer mid-import during a
+        # truncation — its ENOENT tolerance is the real backstop). Older files are unlinked here,
+        # by the single producer, so N SubprocVecEnv consumers never race to delete each other's.
+        self._pool_cap = int(pool_cap)
+        self._gc_grace = int(gc_grace)
         self.teacher = teacher
         self._last_snapshot_step = 0
-        self._snapshots: list[dict] = []  # manifest entries, ascending step (append-only)
+        # Tracked entries, ascending step; bounded to the newest `pool_cap + gc_grace` after each
+        # publish (the on-disk retention set), NOT append-only forever.
+        self._snapshots: list[dict] = []
 
     def _on_training_start(self) -> None:
         self.snapshot_dir.mkdir(parents=True, exist_ok=True)
+        # Resume rehydration (task E / PR-3): adopt a prior run's manifest (minus entries AHEAD of
+        # the resumed step) so we neither republish ids the league already pooled nor restart id
+        # numbering from zero. Without it, a resumed run re-writes `snap-<step>` ids it already
+        # published — duplicate manifest entries + a double-seated pool. `self.model.num_timesteps`
+        # is the resumed env-step count (SB3 restores it under `learn(reset_num_timesteps=False)`);
+        # the callback's own `self.num_timesteps` is not synced at training-start, so read model's.
+        manifest_path = self.snapshot_dir / "manifest.json"
+        if not manifest_path.is_file():
+            return
+        try:
+            prior = json.loads(manifest_path.read_text())
+        except (OSError, ValueError) as err:
+            # A corrupt/half-written manifest must not crash training start — log and start fresh
+            # (the league re-polls and rebuilds its pool from the persisted snapshots regardless).
+            print(f"[snapshot] ignoring unreadable manifest.json on resume ({err}); starting fresh")
+            return
+        resumed_step = self.model.num_timesteps
+        self._snapshots = rehydrate_snapshots(prior.get("snapshots", []), resumed_step)
+        self._last_snapshot_step = resumed_step
+        if self._snapshots:
+            print(
+                f"[snapshot] resumed manifest: kept {len(self._snapshots)} entries "
+                f"(step <= {resumed_step})"
+            )
 
     def _on_step(self) -> bool:
         # ``num_timesteps`` is SB3's total env steps (summed over vec-envs). Publish the first
@@ -108,7 +163,11 @@ class SnapshotCallback(BaseCallback):
         # Make the weights durable BEFORE the manifest references it (atomic-publish ordering).
         _fsync_path(weights_path)
 
-        # 3) append + atomically republish the manifest (weights already on disk).
+        # 3) append, then single-writer GC (task E / PR-3): the manifest lists the newest pool_cap;
+        # disk keeps the newest pool_cap + gc_grace; older files are deleted. ORDER MATTERS: write
+        # the TRUNCATED manifest FIRST (so a crash never leaves the manifest referencing a file we
+        # then delete), THEN unlink aged-out files. `gc_partition` keeps the deletable set disjoint
+        # from the manifest, so the producer never removes a referenced file.
         self._snapshots.append(
             {
                 "id": snap_id,
@@ -117,22 +176,34 @@ class SnapshotCallback(BaseCallback):
                 "createdAt": datetime.now(timezone.utc).isoformat(),
             }
         )
-        self._write_manifest_atomic()
+        manifest_entries, retained, deletable = gc_partition(
+            self._snapshots, self._pool_cap, self._gc_grace
+        )
+        self._write_manifest_atomic(manifest_entries)
+        for s in deletable:
+            (self.snapshot_dir / s["weights"]).unlink(missing_ok=True)
+        # Bound the tracked history to what is still on disk so the next gc_partition is over the
+        # live set (it would otherwise grow unbounded across a multi-day run).
+        self._snapshots = retained
         if self.verbose:
-            print(f"[snapshot] published {snap_id} ({len(self._snapshots)} total) → {weights_path}")
+            print(
+                f"[snapshot] published {snap_id} ({len(manifest_entries)} in manifest, "
+                f"{len(deletable)} GC'd) → {weights_path}"
+            )
 
-    def _write_manifest_atomic(self) -> None:
+    def _write_manifest_atomic(self, entries: list[dict]) -> None:
         """Rewrite ``manifest.json`` via temp-file + ``os.replace`` (atomic; never torn).
 
-        Schema (a NEW manifest, distinct from the BC-corpus ``manifest.py`` one), mirrored by
-        the Node consumer ``ppo-league.refresh()``::
+        ``entries`` is the (already pool_cap-truncated) list the manifest should list. Schema (a NEW
+        manifest, distinct from the BC-corpus ``manifest.py`` one), mirrored by the Node consumer
+        ``ppo-league.refresh()``::
 
             {"encodingVersion":2, "snapshots":[{"id","step","weights","createdAt"}], "latestStep":N}
         """
         manifest = {
             "encodingVersion": EXPECTED_ENCODING_VERSION,
-            "snapshots": self._snapshots,
-            "latestStep": self._snapshots[-1]["step"] if self._snapshots else 0,
+            "snapshots": entries,
+            "latestStep": entries[-1]["step"] if entries else 0,
         }
         manifest_path = self.snapshot_dir / "manifest.json"
         tmp_path = manifest_path.with_name(manifest_path.name + ".tmp")

--- a/ml/dicewars_ppo/snapshot_callback.py
+++ b/ml/dicewars_ppo/snapshot_callback.py
@@ -45,7 +45,6 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
@@ -57,13 +56,11 @@ from dicewars_bc.export_weights import export
 from dicewars_bc.manifest import EXPECTED_ENCODING_VERSION
 
 from .policy import repack_to_bc_checkpoint
-from .snapshot_manifest import gc_partition, plan_resume
+from .snapshot_manifest import gc_partition, plan_resume, snapshot_entry_from_filename
 
-# A published weights file: ``snap-<zero-padded-step>.weights.js`` (see ``_publish``). The capture
-# group recovers the producer step so a resume can rebuild its tracked set from a directory scan
-# (the manifest lists only the newest ``pool_cap`` — globbing disk is what makes the grace zone and
-# any stale files GC-eligible again). Anchored so a stray/temp file can never pose as a snapshot.
-_SNAPSHOT_FILE_RE = re.compile(r"snap-(\d+)\.weights\.js\Z")
+# The ``snap-<step>.weights.js`` filename parsing + stray/.tmp exclusion lives in
+# ``snapshot_manifest.snapshot_entry_from_filename`` (torch-free, CI-tested); the disk I/O (glob,
+# stat) stays here in the callback.
 
 
 class SnapshotCallback(BaseCallback):
@@ -155,25 +152,34 @@ class SnapshotCallback(BaseCallback):
         """Scan ``snapshot_dir`` for published weights files → manifest entries, ascending by step.
 
         The producer's tracked set is rebuilt from disk on resume (see ``_on_training_start``).
-        ``createdAt`` is recovered from each file's mtime (the original is only informational, not
-        persisted anywhere torch-free); a filename that does not match ``snap-<step>.weights.js`` is
-        skipped (a stray temp file or unrelated artifact must never enter the GC set).
+        Filename parsing + the stray/.tmp exclusion is ``snapshot_entry_from_filename`` (torch-free,
+        CI-tested); ``createdAt`` is recovered from each file's mtime (informational only — GC keys
+        on the step in the filename, not this stamp).
         """
         entries: list[dict] = []
         for path in self.snapshot_dir.glob("snap-*.weights.js"):
-            m = _SNAPSHOT_FILE_RE.match(path.name)
-            if m is None:
+            entry = snapshot_entry_from_filename(path.name)
+            if entry is None:
+                continue  # a .tmp torn-export sidecar or stray file — never adopt into the GC set
+            try:
+                created = datetime.fromtimestamp(path.stat().st_mtime, timezone.utc).isoformat()
+            except FileNotFoundError:
+                # Vanished between glob and stat (a peer rm / concurrent GC) — genuinely gone, so
+                # nothing to track, list, or delete. Skip it; adopting a non-existent file would put
+                # a dangling reference into the rewritten manifest.
                 continue
-            step = int(m.group(1))
-            created = datetime.fromtimestamp(path.stat().st_mtime, timezone.utc).isoformat()
-            entries.append(
-                {
-                    "id": f"snap-{step:09d}",
-                    "step": step,
-                    "weights": path.name,
-                    "createdAt": created,
-                }
-            )
+            except OSError as err:
+                # PRESENT but unstat-able (transient EIO/EBUSY on a flaky share). The file is
+                # real, so it MUST stay in the producer's view: its step (from the filename, not
+                # the stat) classifies it into future/deletable/retained. Dropping it would orphan
+                # a future/aged file from GC and — if every file blips at once — make this return
+                # [], so _on_training_start short-circuits "as fresh", skips the resume
+                # reconciliation, and leaves a stale manifest still listing future snapshots
+                # (reopening HOLE-C). createdAt is informational, so synthesize one and adopt it.
+                print(f"[snapshot] resume scan: stat {path.name} failed ({err}); adopting")
+                created = datetime.now(timezone.utc).isoformat()
+            entry["createdAt"] = created
+            entries.append(entry)
         entries.sort(key=lambda s: s["step"])
         return entries
 
@@ -183,7 +189,10 @@ class SnapshotCallback(BaseCallback):
         Deleting a file the manifest no longer references is pure disk hygiene — training is
         unaffected — so a transient FS error (``EIO`` on a flaky disk, a read-only-remounted
         share, ``EBUSY``) must NOT crash a multi-day run. ``FileNotFoundError`` is idempotent for
-        the single writer; any other ``OSError`` is logged and the file left for the next GC pass.
+        the single writer; any other ``OSError`` is logged and the file left on disk. Note the
+        tracked set is bounded to ``retained`` after each publish, so a failed unlink is NOT retried
+        by a later steady-state publish — it is reclaimed by a future restart's disk rescan
+        (``_discover_on_disk_snapshots`` re-adopts it and it ages back into ``deletable``).
         """
         try:
             (self.snapshot_dir / weights_name).unlink(missing_ok=True)

--- a/ml/dicewars_ppo/snapshot_manifest.py
+++ b/ml/dicewars_ppo/snapshot_manifest.py
@@ -11,7 +11,32 @@ A "snapshot entry" is the dict the producer appends to its manifest:
 
 from __future__ import annotations
 
+import re
 from collections.abc import Iterable, Sequence
+
+# A published weights file is ``snap-<zero-padded-step>.weights.js`` (see ``SnapshotCallback``).
+# ANCHORED (``\Z``) so a torn export's ``.weights.js.tmp`` sidecar — or any stray/unrelated file —
+# can never pose as a published snapshot and be adopted into the producer's GC/rehydration set. The
+# capture group recovers the producer step: the manifest lists only the newest ``pool_cap``, so
+# globbing disk by this pattern is what re-tracks the grace zone (and aged-out files) on resume.
+_SNAPSHOT_FILE_RE = re.compile(r"snap-(\d+)\.weights\.js\Z")
+
+
+def snapshot_entry_from_filename(name: str) -> dict | None:
+    """Parse a published weights filename into a manifest entry, or ``None`` if it isn't one.
+
+    Returns ``{"id", "step", "weights"}`` (the caller adds the informational ``createdAt`` from the
+    file's mtime — kept out of here so this helper stays pure and torch-free). ``None`` for anything
+    not matching the anchored ``snap-<step>.weights.js`` pattern: a ``.weights.js.tmp`` torn-export
+    sidecar, or a stray/unrelated file. This exclusion is the producer-side half of the atomic-
+    export safety net — a ``kill -9`` mid-export leaves a ``.tmp``, never a ``snap-*.weights.js``
+    the resume disk-scan would re-adopt. ``id`` is the step zero-padded to 9 digits.
+    """
+    m = _SNAPSHOT_FILE_RE.match(name)
+    if m is None:
+        return None
+    step = int(m.group(1))
+    return {"id": f"snap-{step:09d}", "step": step, "weights": name}
 
 
 def rehydrate_snapshots(snapshots: Iterable[dict], num_timesteps: int) -> list[dict]:
@@ -81,6 +106,10 @@ def plan_resume(
 
     Pure: the callback does the I/O (glob, ``unlink``, manifest write); the partitioning lives here.
     """
+    # Materialize: we iterate ``on_disk`` twice (rehydrate + the future split). A generator would be
+    # exhausted by ``rehydrate_snapshots`` and silently make ``future`` empty — reopening the HOLE-C
+    # republish-divergence window with no test failure. Listing it first keeps any iterable safe.
+    on_disk = list(on_disk)
     kept = rehydrate_snapshots(on_disk, resumed_step)
     cutoff = int(resumed_step)
     future = [s for s in on_disk if int(s["step"]) > cutoff]

--- a/ml/dicewars_ppo/snapshot_manifest.py
+++ b/ml/dicewars_ppo/snapshot_manifest.py
@@ -56,3 +56,33 @@ def gc_partition(
     retained = ordered[-keep_disk:]
     deletable = ordered[:-keep_disk] if keep_disk < len(ordered) else []
     return manifest_entries, retained, deletable
+
+
+def plan_resume(
+    on_disk: Iterable[dict], resumed_step: int, pool_cap: int, gc_grace: int
+) -> tuple[list[dict], list[dict], list[dict], list[dict]]:
+    """Plan the producer's disk + manifest state on resume from what is ACTUALLY on disk.
+
+    Task E / PR-3 hardening: the producer rehydrates from a directory scan of ``snap-*.weights.js``
+    (passed in as ``on_disk``), NOT from the truncated manifest. The manifest only lists the newest
+    ``pool_cap``, so trusting it would leave the ``gc_grace`` files that live on disk *beyond* the
+    manifest untracked — and therefore never GC-eligible — leaking ``gc_grace`` files per resume.
+
+    Returns ``(manifest_entries, retained, deletable, future)``:
+
+    - ``future`` — entries with ``step > resumed_step``. The resumed run will republish these ids at
+      the same step, so their stale files must be DELETED (a consumer importing the pre-crash
+      weights for an id about to change is the republish-divergence window; the file would also be
+      orphaned from this producer's GC). ``future`` is ``on_disk`` minus ``rehydrate_snapshots``.
+    - ``manifest_entries`` / ``retained`` / ``deletable`` — ``gc_partition`` of the ``kept`` set
+      (``step <= resumed_step``), so the producer re-adopts the grace zone into ``retained`` (keeps
+      it GC-eligible), lists the newest ``pool_cap`` in a rewritten manifest, and may delete files
+      already aged out beyond ``pool_cap + gc_grace``.
+
+    Pure: the callback does the I/O (glob, ``unlink``, manifest write); the partitioning lives here.
+    """
+    kept = rehydrate_snapshots(on_disk, resumed_step)
+    cutoff = int(resumed_step)
+    future = [s for s in on_disk if int(s["step"]) > cutoff]
+    manifest_entries, retained, deletable = gc_partition(kept, pool_cap, gc_grace)
+    return manifest_entries, retained, deletable, future

--- a/ml/dicewars_ppo/snapshot_manifest.py
+++ b/ml/dicewars_ppo/snapshot_manifest.py
@@ -1,0 +1,58 @@
+"""Pure (torch-free) PFSP snapshot-manifest helpers (Phase 3, task E / PR-3).
+
+Split out of :mod:`dicewars_ppo.snapshot_callback` so the resume-rehydration and single-writer GC
+*logic* can be unit-tested without importing torch / stable-baselines3 (the callback needs both to
+repack the live model; these functions need neither). The callback wires them to the live SB3 model;
+the bookkeeping math lives here, where the lean ``ml-test`` tier and a no-GPU dev box can cover it.
+
+A "snapshot entry" is the dict the producer appends to its manifest:
+``{"id", "step", "weights", "createdAt"}`` (see ``SnapshotCallback._publish``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+
+
+def rehydrate_snapshots(snapshots: Iterable[dict], num_timesteps: int) -> list[dict]:
+    """On resume, keep only entries at or before the step we are resuming at.
+
+    A crashed run may have published snapshots at steps the resumed run has not re-reached yet (the
+    checkpoint that drove the resume lagged the last snapshot). If we kept those "future" entries,
+    re-reaching that step would republish the SAME id — overwriting its ``.weights.js`` and
+    double-seating it in a consumer's pool. Dropping ``step > num_timesteps`` makes the producer's
+    publish cadence monotonic across the restart. Order-preserving.
+    """
+    cutoff = int(num_timesteps)
+    return [s for s in snapshots if int(s["step"]) <= cutoff]
+
+
+def gc_partition(
+    snapshots: Sequence[dict], pool_cap: int, gc_grace: int
+) -> tuple[list[dict], list[dict], list[dict]]:
+    """Partition published snapshots (sorted newest-by-step) into the three producer-GC zones.
+
+    Returns ``(manifest_entries, retained, deletable)``:
+
+    - ``manifest_entries`` — the newest ``pool_cap`` entries. This is what the manifest lists, so it
+      is exactly what consumers load into their sampleable pool.
+    - ``retained`` — the newest ``pool_cap + gc_grace`` entries. These are kept ON DISK. The grace
+      zone (``[pool_cap, pool_cap + gc_grace)``) is an on-disk buffer *beyond* the manifest: it lets
+      a consumer that read the manifest just before a truncation still find a file it is mid-import
+      on. (The consumer's ENOENT tolerance is the real backstop; this just shrinks the race window.)
+    - ``deletable`` — every older entry. Its ``.weights.js`` is safe to unlink (single-writer GC).
+
+    Invariants: ``manifest_entries ⊆ retained`` and ``retained ∩ deletable = ∅`` (by step), so the
+    producer never unlinks a file the manifest still references.
+    """
+    if not isinstance(pool_cap, int) or pool_cap <= 0:
+        raise ValueError(f"pool_cap must be a positive int, got {pool_cap!r}")
+    if not isinstance(gc_grace, int) or gc_grace < 0:
+        raise ValueError(f"gc_grace must be a non-negative int, got {gc_grace!r}")
+
+    ordered = sorted(snapshots, key=lambda s: int(s["step"]))
+    keep_disk = pool_cap + gc_grace
+    manifest_entries = ordered[-pool_cap:]
+    retained = ordered[-keep_disk:]
+    deletable = ordered[:-keep_disk] if keep_disk < len(ordered) else []
+    return manifest_entries, retained, deletable

--- a/ml/tests/test_env_server_argv.py
+++ b/ml/tests/test_env_server_argv.py
@@ -51,3 +51,42 @@ def test_no_league_flags_without_snapshot_manifest():
     assert "--reserve-baselines" not in joined
     assert "--pfsp-epsilon" not in joined
     assert "--pfsp-k" not in joined
+
+
+def test_persistence_flags_forwarded_when_set():
+    # Task E (B6 Python forwarding): the persistence trio rides its own gate, independent of the
+    # snapshot manifest — a fixed-field run with NO manifest still checkpoints/resumes.
+    argv = _argv(
+        snapshot_store="disk",
+        league_state_dir="/run/league-state",
+        league_dump_every=25,
+    )
+    assert "--snapshot-store=disk" in argv
+    assert "--league-state-dir=/run/league-state" in argv
+    assert "--league-dump-every=25" in argv
+    # No snapshot manifest was given, yet persistence flags still appear (manifest-independent).
+    assert "--snapshot-manifest" not in " ".join(argv)
+
+
+def test_persistence_flags_absent_when_unset():
+    # The point of the None defaults: an opt-out run is byte-identical to B5 (Node uses its own
+    # defaults — snapshot-store=memory, league-dump-every=50, persistence off).
+    joined = " ".join(_argv())
+    assert "--snapshot-store" not in joined
+    assert "--league-state-dir" not in joined
+    assert "--league-dump-every" not in joined
+
+
+def test_persistence_flags_coexist_with_pfsp_flags():
+    # A real task-E PFSP launch sets BOTH the snapshot manifest (PFSP pool) AND persistence (disk
+    # store + state dir). Both groups must appear without interfering.
+    argv = _argv(
+        snapshot_manifest="/tmp/snap/manifest.json",
+        snapshot_store="disk",
+        league_state_dir="/tmp/snap",
+        league_dump_every=50,
+    )
+    assert "--snapshot-manifest=/tmp/snap/manifest.json" in argv
+    assert "--snapshot-store=disk" in argv
+    assert "--league-state-dir=/tmp/snap" in argv
+    assert "--league-dump-every=50" in argv

--- a/ml/tests/test_snapshot_callback.py
+++ b/ml/tests/test_snapshot_callback.py
@@ -42,6 +42,15 @@ def _patch_export(monkeypatch):
     monkeypatch.setattr(snapshot_callback, "export", fake_export)
 
 
+def _fake_model(num_timesteps=0):
+    """Minimal stand-in for the SB3 model. ``_on_training_start`` reads ``num_timesteps`` (the
+    resume cursor — 0 for a fresh run, the resumed env-step count otherwise); ``policy`` is what
+    ``repack_to_bc_checkpoint`` consumes (faked in these tests). Both must be present, or
+    ``_on_training_start``'s unconditional ``int(self.model.num_timesteps)`` raises
+    ``AttributeError`` before the empty-dir short-circuit."""
+    return SimpleNamespace(policy=SimpleNamespace(), num_timesteps=num_timesteps)
+
+
 def test_snapshot_every_must_be_positive():
     with pytest.raises(ValueError, match="snapshot_every must be a positive int"):
         SnapshotCallback("/tmp/snaps", 0)
@@ -50,6 +59,7 @@ def test_snapshot_every_must_be_positive():
 def test_write_manifest_atomic_schema(tmp_path):
     """The manifest matches the Node consumer's schema exactly; no torn temp file is left behind."""
     cb = SnapshotCallback(tmp_path, snapshot_every=10)
+    cb.model = _fake_model()
     cb._on_training_start()
     cb._snapshots = [
         {
@@ -78,7 +88,7 @@ def test_write_manifest_atomic_schema(tmp_path):
 def test_publish_exports_weights_and_lists_them(tmp_path, monkeypatch):
     _patch_export(monkeypatch)
     cb = SnapshotCallback(tmp_path, snapshot_every=256, teacher="ppo-snapshot")
-    cb.model = SimpleNamespace(policy=SimpleNamespace())  # repack is faked → policy unused
+    cb.model = _fake_model()  # repack is faked → policy unused
     cb._on_training_start()
 
     cb._publish(256)
@@ -114,7 +124,7 @@ def test_on_step_publishes_on_cadence_only(tmp_path, monkeypatch):
 def test_publish_appends_in_step_order(tmp_path, monkeypatch):
     _patch_export(monkeypatch)
     cb = SnapshotCallback(tmp_path, snapshot_every=100)
-    cb.model = SimpleNamespace(policy=SimpleNamespace())
+    cb.model = _fake_model()
     cb._on_training_start()
 
     cb._publish(100)
@@ -128,7 +138,7 @@ def test_publish_truncates_manifest_and_gcs_old_files(tmp_path, monkeypatch):
     """Single-writer GC (task E / PR-3): manifest = newest pool_cap; disk = pool_cap + gc_grace."""
     _patch_export(monkeypatch)
     cb = SnapshotCallback(tmp_path, snapshot_every=100, pool_cap=2, gc_grace=1)
-    cb.model = SimpleNamespace(policy=SimpleNamespace())
+    cb.model = _fake_model()
     cb._on_training_start()
     for step in (100, 200, 300, 400, 500):
         cb._publish(step)
@@ -158,7 +168,7 @@ def test_on_training_start_rehydrates_and_deletes_future_files(tmp_path, monkeyp
     _patch_export(monkeypatch)
     # A prior run published snapshots at 100, 200, 300.
     cb0 = SnapshotCallback(tmp_path, snapshot_every=100)
-    cb0.model = SimpleNamespace(policy=SimpleNamespace())
+    cb0.model = _fake_model()
     cb0._on_training_start()
     for step in (100, 200, 300):
         cb0._publish(step)
@@ -166,7 +176,7 @@ def test_on_training_start_rehydrates_and_deletes_future_files(tmp_path, monkeyp
     # A new run resumes at step 250: snap-300 is AHEAD of the resume point and must be dropped AND
     # its stale file deleted (a consumer must not import pre-crash weights for a soon-changed id).
     cb = SnapshotCallback(tmp_path, snapshot_every=100)
-    cb.model = SimpleNamespace(policy=SimpleNamespace(), num_timesteps=250)
+    cb.model = _fake_model(250)
     cb._on_training_start()
     assert [s["step"] for s in cb._snapshots] == [100, 200]  # future snap-300 dropped from tracking
     assert not (
@@ -189,7 +199,7 @@ def test_resume_readopts_grace_zone_so_it_is_gc_eligible(tmp_path, monkeypatch):
     _patch_export(monkeypatch)
     # Prior run, pool_cap=2 gc_grace=1: after 100..500, disk = [300,400,500], manifest = [400,500].
     cb0 = SnapshotCallback(tmp_path, snapshot_every=100, pool_cap=2, gc_grace=1)
-    cb0.model = SimpleNamespace(policy=SimpleNamespace())
+    cb0.model = _fake_model()
     cb0._on_training_start()
     for step in (100, 200, 300, 400, 500):
         cb0._publish(step)
@@ -202,7 +212,7 @@ def test_resume_readopts_grace_zone_so_it_is_gc_eligible(tmp_path, monkeypatch):
     # Resume past all of them, then publish two more. If snap-300 (the grace-zone file) were not
     # re-tracked on resume, it could never enter `deletable` and would leak forever.
     cb = SnapshotCallback(tmp_path, snapshot_every=100, pool_cap=2, gc_grace=1)
-    cb.model = SimpleNamespace(policy=SimpleNamespace(), num_timesteps=500)
+    cb.model = _fake_model(500)
     cb._on_training_start()
     assert [s["step"] for s in cb._snapshots] == [300, 400, 500]  # grace zone re-adopted, tracked
     cb._publish(600)  # disk budget now exceeded → snap-300 must be GC'd, not leaked
@@ -221,7 +231,7 @@ def test_publish_does_not_crash_when_gc_unlink_fails(tmp_path, monkeypatch):
     pure disk hygiene and must NOT crash a multi-day run (manifest + weights already durable)."""
     _patch_export(monkeypatch)
     cb = SnapshotCallback(tmp_path, snapshot_every=100, pool_cap=1, gc_grace=0)
-    cb.model = SimpleNamespace(policy=SimpleNamespace())
+    cb.model = _fake_model()
     cb._on_training_start()
     cb._publish(100)
 

--- a/ml/tests/test_snapshot_callback.py
+++ b/ml/tests/test_snapshot_callback.py
@@ -65,7 +65,7 @@ def test_write_manifest_atomic_schema(tmp_path):
             "createdAt": "t1",
         },
     ]
-    cb._write_manifest_atomic()
+    cb._write_manifest_atomic(cb._snapshots)
 
     manifest = json.loads((tmp_path / "manifest.json").read_text())
     assert manifest["encodingVersion"] == EXPECTED_ENCODING_VERSION == 2
@@ -121,3 +121,53 @@ def test_publish_appends_in_step_order(tmp_path, monkeypatch):
     manifest = json.loads((tmp_path / "manifest.json").read_text())
     assert [s["step"] for s in manifest["snapshots"]] == [100, 200]
     assert manifest["latestStep"] == 200
+
+
+def test_publish_truncates_manifest_and_gcs_old_files(tmp_path, monkeypatch):
+    """Single-writer GC (task E / PR-3): manifest = newest pool_cap; disk = pool_cap + gc_grace."""
+    _patch_export(monkeypatch)
+    cb = SnapshotCallback(tmp_path, snapshot_every=100, pool_cap=2, gc_grace=1)
+    cb.model = SimpleNamespace(policy=SimpleNamespace())
+    cb._on_training_start()
+    for step in (100, 200, 300, 400, 500):
+        cb._publish(step)
+
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+    # Manifest lists only the newest pool_cap (=2).
+    assert [s["step"] for s in manifest["snapshots"]] == [400, 500]
+    assert manifest["latestStep"] == 500
+    # Disk keeps pool_cap + gc_grace (=3): the two manifest files + one grace buffer (step 300).
+    on_disk = sorted(p.name for p in tmp_path.glob("snap-*.weights.js"))
+    assert on_disk == [
+        "snap-000000300.weights.js",
+        "snap-000000400.weights.js",
+        "snap-000000500.weights.js",
+    ]
+    # GC never removes a manifest-referenced file.
+    for s in manifest["snapshots"]:
+        assert (tmp_path / s["weights"]).exists()
+    assert not list(tmp_path.glob("*.pt"))
+    assert not list(tmp_path.glob("manifest.json.tmp"))
+
+
+def test_on_training_start_rehydrates_and_drops_future_entries(tmp_path, monkeypatch):
+    """Resume rehydration (task E / PR-3): adopt the prior manifest minus entries ahead of the
+    resumed step, so re-reaching a step republishes its id exactly once (no duplicate)."""
+    _patch_export(monkeypatch)
+    # A prior run published snapshots at 100, 200, 300.
+    cb0 = SnapshotCallback(tmp_path, snapshot_every=100)
+    cb0.model = SimpleNamespace(policy=SimpleNamespace())
+    cb0._on_training_start()
+    for step in (100, 200, 300):
+        cb0._publish(step)
+
+    # A new run resumes at step 250: snap-300 is AHEAD of the resume point and must be dropped.
+    cb = SnapshotCallback(tmp_path, snapshot_every=100)
+    cb.model = SimpleNamespace(policy=SimpleNamespace(), num_timesteps=250)
+    cb._on_training_start()
+    assert [s["step"] for s in cb._snapshots] == [100, 200]  # future snap-300 dropped
+
+    cb._publish(300)  # re-reached → republished exactly once, no duplicate id
+    steps = [s["step"] for s in json.loads((tmp_path / "manifest.json").read_text())["snapshots"]]
+    assert steps == [100, 200, 300]
+    assert steps.count(300) == 1

--- a/ml/tests/test_snapshot_callback.py
+++ b/ml/tests/test_snapshot_callback.py
@@ -94,9 +94,10 @@ def test_publish_exports_weights_and_lists_them(tmp_path, monkeypatch):
         "createdAt": snaps[0]["createdAt"],  # timestamp present (exact value not pinned)
     }
     assert snaps[0]["createdAt"]  # non-empty ISO stamp
-    # No leftover temp checkpoint (.pt) or torn manifest temp.
+    # No leftover temp checkpoint (.pt), torn manifest temp, or torn weights temp (atomic export).
     assert not list(tmp_path.glob("*.pt"))
     assert not list(tmp_path.glob("manifest.json.tmp"))
+    assert not list(tmp_path.glob("*.weights.js.tmp"))
 
 
 def test_on_step_publishes_on_cadence_only(tmp_path, monkeypatch):
@@ -150,9 +151,10 @@ def test_publish_truncates_manifest_and_gcs_old_files(tmp_path, monkeypatch):
     assert not list(tmp_path.glob("manifest.json.tmp"))
 
 
-def test_on_training_start_rehydrates_and_drops_future_entries(tmp_path, monkeypatch):
-    """Resume rehydration (task E / PR-3): adopt the prior manifest minus entries ahead of the
-    resumed step, so re-reaching a step republishes its id exactly once (no duplicate)."""
+def test_on_training_start_rehydrates_and_deletes_future_files(tmp_path, monkeypatch):
+    """Resume rehydration (task E / PR-3, disk-scan): rebuild the tracked set from the snapshot dir
+    minus entries ahead of the resumed step, DELETE those future files (they get republished), so
+    re-reaching a step republishes its id exactly once (no duplicate, no stale weights)."""
     _patch_export(monkeypatch)
     # A prior run published snapshots at 100, 200, 300.
     cb0 = SnapshotCallback(tmp_path, snapshot_every=100)
@@ -161,13 +163,81 @@ def test_on_training_start_rehydrates_and_drops_future_entries(tmp_path, monkeyp
     for step in (100, 200, 300):
         cb0._publish(step)
 
-    # A new run resumes at step 250: snap-300 is AHEAD of the resume point and must be dropped.
+    # A new run resumes at step 250: snap-300 is AHEAD of the resume point and must be dropped AND
+    # its stale file deleted (a consumer must not import pre-crash weights for a soon-changed id).
     cb = SnapshotCallback(tmp_path, snapshot_every=100)
     cb.model = SimpleNamespace(policy=SimpleNamespace(), num_timesteps=250)
     cb._on_training_start()
-    assert [s["step"] for s in cb._snapshots] == [100, 200]  # future snap-300 dropped
+    assert [s["step"] for s in cb._snapshots] == [100, 200]  # future snap-300 dropped from tracking
+    assert not (
+        tmp_path / "snap-000000300.weights.js"
+    ).exists()  # ...and its file deleted on resume
+    # The rewritten manifest no longer lists the future entry (closes the republish window).
+    resumed_manifest = json.loads((tmp_path / "manifest.json").read_text())
+    assert [s["step"] for s in resumed_manifest["snapshots"]] == [100, 200]
 
     cb._publish(300)  # re-reached → republished exactly once, no duplicate id
     steps = [s["step"] for s in json.loads((tmp_path / "manifest.json").read_text())["snapshots"]]
     assert steps == [100, 200, 300]
     assert steps.count(300) == 1
+
+
+def test_resume_readopts_grace_zone_so_it_is_gc_eligible(tmp_path, monkeypatch):
+    """Disk leak fix (task E / PR-3): the manifest lists only pool_cap, but disk holds pool_cap +
+    gc_grace. A resume must re-track the grace-zone files (by scanning disk, not reading the
+    truncated manifest) so a later publish can still GC them — else they leak per resume."""
+    _patch_export(monkeypatch)
+    # Prior run, pool_cap=2 gc_grace=1: after 100..500, disk = [300,400,500], manifest = [400,500].
+    cb0 = SnapshotCallback(tmp_path, snapshot_every=100, pool_cap=2, gc_grace=1)
+    cb0.model = SimpleNamespace(policy=SimpleNamespace())
+    cb0._on_training_start()
+    for step in (100, 200, 300, 400, 500):
+        cb0._publish(step)
+    assert sorted(p.name for p in tmp_path.glob("snap-*.weights.js")) == [
+        "snap-000000300.weights.js",  # grace-zone file (NOT in the manifest)
+        "snap-000000400.weights.js",
+        "snap-000000500.weights.js",
+    ]
+
+    # Resume past all of them, then publish two more. If snap-300 (the grace-zone file) were not
+    # re-tracked on resume, it could never enter `deletable` and would leak forever.
+    cb = SnapshotCallback(tmp_path, snapshot_every=100, pool_cap=2, gc_grace=1)
+    cb.model = SimpleNamespace(policy=SimpleNamespace(), num_timesteps=500)
+    cb._on_training_start()
+    assert [s["step"] for s in cb._snapshots] == [300, 400, 500]  # grace zone re-adopted, tracked
+    cb._publish(600)  # disk budget now exceeded → snap-300 must be GC'd, not leaked
+    cb._publish(700)
+    on_disk = sorted(p.name for p in tmp_path.glob("snap-*.weights.js"))
+    assert "snap-000000300.weights.js" not in on_disk  # the formerly-leaked grace file is now GC'd
+    assert on_disk == [
+        "snap-000000500.weights.js",  # pool_cap + gc_grace = 3 newest survive
+        "snap-000000600.weights.js",
+        "snap-000000700.weights.js",
+    ]
+
+
+def test_publish_does_not_crash_when_gc_unlink_fails(tmp_path, monkeypatch):
+    """Robustness (task E / PR-3): a non-FileNotFound FS error while deleting an AGED-OUT file is
+    pure disk hygiene and must NOT crash a multi-day run (manifest + weights already durable)."""
+    _patch_export(monkeypatch)
+    cb = SnapshotCallback(tmp_path, snapshot_every=100, pool_cap=1, gc_grace=0)
+    cb.model = SimpleNamespace(policy=SimpleNamespace())
+    cb._on_training_start()
+    cb._publish(100)
+
+    # Make the next GC unlink raise a non-FileNotFound OSError (e.g. EIO / read-only remount).
+    real_unlink = snapshot_callback.Path.unlink
+
+    def flaky_unlink(self, *args, **kwargs):
+        if self.name == "snap-000000100.weights.js":
+            raise OSError("simulated EIO on aged-out file")
+        return real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(snapshot_callback.Path, "unlink", flaky_unlink)
+    cb._publish(200)  # snap-100 ages out; its unlink raises — must be swallowed, not propagated
+
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+    assert [s["step"] for s in manifest["snapshots"]] == [
+        200
+    ]  # publish completed despite the error
+    assert (tmp_path / "snap-000000100.weights.js").exists()  # left on disk for the next GC pass

--- a/ml/tests/test_snapshot_manifest.py
+++ b/ml/tests/test_snapshot_manifest.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import pytest
 
-from dicewars_ppo.snapshot_manifest import gc_partition, rehydrate_snapshots
+from dicewars_ppo.snapshot_manifest import gc_partition, plan_resume, rehydrate_snapshots
 
 
 def _snap(step):
@@ -96,3 +96,57 @@ def test_gc_partition_rejects_nonpositive_pool_cap(pool_cap):
 def test_gc_partition_rejects_negative_grace():
     with pytest.raises(ValueError, match="gc_grace"):
         gc_partition(_snaps(1), pool_cap=1, gc_grace=-1)
+
+
+# --- plan_resume ------------------------------------------------------------------------------
+
+
+def test_plan_resume_readopts_grace_zone_so_it_stays_gc_eligible():
+    # The leak fix: disk holds pool_cap + gc_grace, the manifest lists only pool_cap. Resuming from
+    # the FULL on-disk set (not the truncated manifest) must re-track the grace zone in `retained`,
+    # else those files are never GC-eligible again. Here pool_cap=2, gc_grace=1, resume past all.
+    manifest, retained, deletable, future = plan_resume(
+        _snaps(300, 400, 500), resumed_step=999, pool_cap=2, gc_grace=1
+    )
+    assert [s["step"] for s in manifest] == [400, 500]  # manifest = newest pool_cap
+    assert [s["step"] for s in retained] == [
+        300,
+        400,
+        500,
+    ]  # grace-zone 300 re-adopted, GC-eligible
+    assert deletable == []
+    assert future == []
+
+
+def test_plan_resume_marks_future_entries_for_deletion():
+    # A pre-crash snapshot AHEAD of the resumed step is republished by the resumed run → its stale
+    # file must be deleted (the republish-divergence window). It is NOT in the manifest/retained.
+    manifest, retained, deletable, future = plan_resume(
+        _snaps(100, 200, 300), resumed_step=250, pool_cap=40, gc_grace=10
+    )
+    assert [s["step"] for s in future] == [300]
+    assert [s["step"] for s in manifest] == [100, 200]
+    assert [s["step"] for s in retained] == [100, 200]
+    assert deletable == []  # below the disk budget, nothing aged out
+
+
+def test_plan_resume_partitions_grace_and_future_together():
+    # Both zones at once: resume at 350 over disk 100..600 with pool_cap=2, gc_grace=1.
+    manifest, retained, deletable, future = plan_resume(
+        _snaps(100, 200, 300, 400, 500, 600), resumed_step=350, pool_cap=2, gc_grace=1
+    )
+    assert [s["step"] for s in future] == [400, 500, 600]  # ahead of 350 → delete + republish
+    assert [s["step"] for s in manifest] == [200, 300]  # kept = [100,200,300]; newest pool_cap
+    assert [s["step"] for s in retained] == [100, 200, 300]  # newest pool_cap + gc_grace
+    assert [s["step"] for s in deletable] == []  # only 3 kept, exactly the disk budget
+
+
+def test_plan_resume_unordered_input_and_empty():
+    manifest, retained, deletable, future = plan_resume(
+        _snaps(300, 100, 200), resumed_step=999, pool_cap=1, gc_grace=0
+    )
+    assert [s["step"] for s in manifest] == [300]  # newest by step regardless of input order
+    assert {s["step"] for s in deletable} == {100, 200}
+    assert future == []
+    # Empty disk (fresh run) → all-empty plan, no error.
+    assert plan_resume([], resumed_step=0, pool_cap=40, gc_grace=10) == ([], [], [], [])

--- a/ml/tests/test_snapshot_manifest.py
+++ b/ml/tests/test_snapshot_manifest.py
@@ -10,7 +10,12 @@ from __future__ import annotations
 
 import pytest
 
-from dicewars_ppo.snapshot_manifest import gc_partition, plan_resume, rehydrate_snapshots
+from dicewars_ppo.snapshot_manifest import (
+    gc_partition,
+    plan_resume,
+    rehydrate_snapshots,
+    snapshot_entry_from_filename,
+)
 
 
 def _snap(step):
@@ -19,6 +24,46 @@ def _snap(step):
 
 def _snaps(*steps):
     return [_snap(s) for s in steps]
+
+
+# --- snapshot_entry_from_filename -------------------------------------------------------------
+
+
+def test_entry_from_filename_parses_and_keeps_padded_id():
+    assert snapshot_entry_from_filename("snap-000000256.weights.js") == {
+        "id": "snap-000000256",
+        "step": 256,
+        "weights": "snap-000000256.weights.js",
+    }
+
+
+def test_entry_from_filename_zero_pads_a_short_step():
+    # The producer always zero-pads the id to 9 digits; a shorter on-disk step still yields the
+    # padded id (so a resume rescan keys on the same id the original publish used).
+    assert snapshot_entry_from_filename("snap-5.weights.js") == {
+        "id": "snap-000000005",
+        "step": 5,
+        "weights": "snap-5.weights.js",
+    }
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "snap-000000256.weights.js.tmp",  # torn-export sidecar — THE atomic-export safety net
+        "snap-.weights.js",  # no step digits
+        "snap-abc.weights.js",  # non-numeric step
+        "manifest.json",  # the manifest itself
+        "snap-100.weights.js.bak",  # trailing junk (anchored \Z rejects it)
+        "prefix-snap-100.weights.js",  # not anchored at the start (match() anchors start)
+        "snap-100.weights.mjs",  # wrong extension
+        "snap-100.js",  # missing the .weights segment
+    ],
+)
+def test_entry_from_filename_rejects_non_snapshots(name):
+    # A non-conforming filename must never be adopted into the producer's GC/rehydration set —
+    # this is what stops a torn .tmp export from being re-globbed as a real snapshot on resume.
+    assert snapshot_entry_from_filename(name) is None
 
 
 # --- rehydrate_snapshots ----------------------------------------------------------------------
@@ -139,6 +184,17 @@ def test_plan_resume_partitions_grace_and_future_together():
     assert [s["step"] for s in manifest] == [200, 300]  # kept = [100,200,300]; newest pool_cap
     assert [s["step"] for s in retained] == [100, 200, 300]  # newest pool_cap + gc_grace
     assert [s["step"] for s in deletable] == []  # only 3 kept, exactly the disk budget
+
+
+def test_plan_resume_materializes_a_generator_input():
+    # plan_resume iterates on_disk TWICE (rehydrate, then the future split). Without the
+    # internal `list(on_disk)`, a generator would be exhausted after the first pass and `future`
+    # would silently come back empty — reopening the HOLE-C republish window with no other signal.
+    # Passing an iterator locks the materialization in.
+    _manifest, _retained, _deletable, future = plan_resume(
+        iter(_snaps(100, 200, 300, 400, 500, 600)), resumed_step=350, pool_cap=2, gc_grace=1
+    )
+    assert [s["step"] for s in future] == [400, 500, 600]
 
 
 def test_plan_resume_unordered_input_and_empty():

--- a/ml/tests/test_snapshot_manifest.py
+++ b/ml/tests/test_snapshot_manifest.py
@@ -1,0 +1,98 @@
+"""Pure manifest-helper math (Phase 3, task E / PR-3) — runs in the lean torch-free CI tier.
+
+These cover the resume-rehydration filter and the single-writer GC partition independently of the
+SB3 callback that wires them (which needs torch/stable-baselines3 and so runs only on shodan). The
+callback integration is covered by ``test_snapshot_callback.py``; the *logic* lives — and is
+tested — here, where no GPU stack is needed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dicewars_ppo.snapshot_manifest import gc_partition, rehydrate_snapshots
+
+
+def _snap(step):
+    return {"id": f"snap-{step}", "step": step, "weights": f"snap-{step}.weights.js"}
+
+
+def _snaps(*steps):
+    return [_snap(s) for s in steps]
+
+
+# --- rehydrate_snapshots ----------------------------------------------------------------------
+
+
+def test_rehydrate_keeps_entries_at_or_before_resumed_step():
+    snaps = _snaps(100, 200, 300)
+    assert [s["step"] for s in rehydrate_snapshots(snaps, 250)] == [100, 200]
+
+
+def test_rehydrate_keeps_an_entry_exactly_at_the_resumed_step():
+    # `<=` boundary: a snapshot published exactly at the resumed step is kept (re-reaching it is the
+    # same step, not a future republish).
+    assert [s["step"] for s in rehydrate_snapshots(_snaps(100, 200), 200)] == [100, 200]
+
+
+def test_rehydrate_drops_all_when_resuming_before_the_first_snapshot():
+    assert rehydrate_snapshots(_snaps(100, 200), 50) == []
+
+
+def test_rehydrate_is_order_preserving_and_nonmutating():
+    snaps = _snaps(100, 200, 300)
+    out = rehydrate_snapshots(snaps, 999)
+    assert [s["step"] for s in out] == [100, 200, 300]
+    assert len(snaps) == 3  # input untouched
+
+
+# --- gc_partition -----------------------------------------------------------------------------
+
+
+def test_gc_partition_manifest_is_newest_pool_cap():
+    manifest, retained, deletable = gc_partition(
+        _snaps(100, 200, 300, 400, 500), pool_cap=2, gc_grace=1
+    )
+    assert [s["step"] for s in manifest] == [400, 500]  # newest pool_cap
+    assert [s["step"] for s in retained] == [300, 400, 500]  # newest pool_cap + gc_grace
+    assert [s["step"] for s in deletable] == [100, 200]  # the rest
+
+
+def test_gc_partition_invariants_hold():
+    manifest, retained, deletable = gc_partition(_snaps(1, 2, 3, 4, 5, 6), pool_cap=3, gc_grace=2)
+    msteps = {s["step"] for s in manifest}
+    rsteps = {s["step"] for s in retained}
+    dsteps = {s["step"] for s in deletable}
+    assert msteps <= rsteps  # manifest is a subset of what's retained on disk
+    assert rsteps.isdisjoint(dsteps)  # never delete a retained (or manifest) file
+    assert rsteps | dsteps == {1, 2, 3, 4, 5, 6}  # every entry is either retained or deletable
+
+
+def test_gc_partition_nothing_deletable_below_disk_budget():
+    manifest, retained, deletable = gc_partition(_snaps(100, 200), pool_cap=40, gc_grace=10)
+    assert [s["step"] for s in manifest] == [100, 200]
+    assert [s["step"] for s in retained] == [100, 200]
+    assert deletable == []
+
+
+def test_gc_partition_sorts_unordered_input_by_step():
+    manifest, _retained, deletable = gc_partition(_snaps(300, 100, 200), pool_cap=1, gc_grace=0)
+    assert [s["step"] for s in manifest] == [300]  # newest by step regardless of input order
+    assert {s["step"] for s in deletable} == {100, 200}
+
+
+def test_gc_partition_zero_grace_deletes_everything_below_pool_cap():
+    _manifest, retained, deletable = gc_partition(_snaps(1, 2, 3), pool_cap=1, gc_grace=0)
+    assert [s["step"] for s in retained] == [3]
+    assert [s["step"] for s in deletable] == [1, 2]
+
+
+@pytest.mark.parametrize("pool_cap", [0, -1])
+def test_gc_partition_rejects_nonpositive_pool_cap(pool_cap):
+    with pytest.raises(ValueError, match="pool_cap"):
+        gc_partition(_snaps(1), pool_cap=pool_cap, gc_grace=0)
+
+
+def test_gc_partition_rejects_negative_grace():
+    with pytest.raises(ValueError, match="gc_grace"):
+        gc_partition(_snaps(1), pool_cap=1, gc_grace=-1)

--- a/scripts/lib/ppo-league.mjs
+++ b/scripts/lib/ppo-league.mjs
@@ -784,9 +784,17 @@ export function makeLeague({
         try {
           mod = await import(pathToFileURL(snap.weightsPath).href);
         } catch (err) {
-          if (err.code === 'ENOENT' || err.code === 'ERR_MODULE_NOT_FOUND') {
+          if (
+            (err.code === 'ENOENT' || err.code === 'ERR_MODULE_NOT_FOUND') &&
+            !existsSync(snap.weightsPath)
+          ) {
             // FIFO-evicted/unlinked since the checkpoint — keep the id in loadedIds (below) so a later
-            // refresh() never re-imports the deleted file; the book record stays credited.
+            // refresh() never re-imports the deleted file; the book record stays credited. The
+            // `!existsSync` guard mirrors refresh(): only a file that is GENUINELY GONE is dropped. A
+            // PRESENT-but-broken module (a missing transitive import / a corrupt artifact raising
+            // ERR_MODULE_NOT_FOUND) falls through to the rethrow below — a real bug must not be masked
+            // as a benign "weights gone" drop, and the two import paths must not diverge if the
+            // snapshot artifact format ever gains an import.
             droppedPool++;
             process.stderr.write(
               `[ppo-league] restore: snapshot ${snap.id} weights gone (${snap.weightsPath}); ` +
@@ -794,7 +802,7 @@ export function makeLeague({
             );
             continue;
           }
-          throw err; // any non-missing-file import error — fail loud
+          throw err; // present-but-broken artifact, or any non-missing-file import error — fail loud
         }
         if (!mod.BC_POLICY) {
           // A parseable module with no BC_POLICY export would fall through to makeBC's default param and

--- a/scripts/lib/ppo-league.mjs
+++ b/scripts/lib/ppo-league.mjs
@@ -15,8 +15,9 @@
  *   - **B1** — the empty-pool path (== task A) plus a decisive/truncated telemetry tally.
  *   - **B2** — the per-opponent win-rate book (`recordResult` pairwise crediting + `winRate(id)`).
  *   - **B3** — the snapshot pool + `refresh()`: poll the producer's `manifest.json`, hot-load each
- *     new self-play snapshot via `makeBC` (fresh filename per snapshot → ESM URL cache), FIFO-evict
- *     past `poolCap`, GC the evicted `.js`. B3 only *loads* the pool — `draw()` does not seat it yet.
+ *     new self-play snapshot via `makeBC` (fresh filename per snapshot → ESM URL cache), FIFO-trim the
+ *     in-memory pool past `poolCap` (disk GC is the producer's job — task E / PR-3; a consumer never
+ *     unlinks). B3 only *loads* the pool — `draw()` does not seat it yet.
  *   - **B4** — PFSP weighting **on**: when the pool is non-empty, `draw(seed)` seeds a `mulberry32`
  *     sampler and seats `count − R` snapshots drawn by `w(S) = max(ε, 1 − learnerWinRate(S))^k`
  *     (lower learner win-rate → higher weight) plus `R` reserved baselines (the [D-15]
@@ -27,7 +28,7 @@
  * @module scripts/lib/ppo-league
  */
 
-import { readFileSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
@@ -260,9 +261,9 @@ export function makeLeague({
   Object.freeze(baselineField);
 
   /*
-   * Persistence fingerprint (B6): every construction arg that steers `draw()`'s output OR FIFO
-   * eviction (which `unlinkSync`s files). `restore()` throws unless the persisted fingerprint matches
-   * this league's, because a resume under drifted CLI args must fail loud, not sample/GC divergently —
+   * Persistence fingerprint (B6): every construction arg that steers `draw()`'s output OR the
+   * FIFO-trimmed sampleable pool size. `restore()` throws unless the persisted fingerprint matches
+   * this league's, because a resume under drifted CLI args must fail loud, not sample divergently —
    * `pfspEpsilon`/`pfspK`/`reserveBaselines`/`poolCap`/baseline identity are as load-bearing as
    * `count`/`learnerSeat`. `baselineIds` is the trimmed ordered id list (the full determinant of both
    * the cycled `baselineField` and the `reserveBaselinePool`), normalized so cosmetic CSV whitespace
@@ -326,12 +327,13 @@ export function makeLeague({
   let manifestMtimeMs = -1;
   /*
    * Snapshots `refresh()` skipped because their `.js` was already gone at import time (task E / PR-1
-   * GC-race floor): under `SubprocVecEnv` N env-servers share one snapshot dir, and a peer can
-   * FIFO-evict + `unlinkSync` a snapshot between the producer publishing the manifest and a lagging
-   * worker importing it. The lagging worker tolerates the missing file (warn + skip + mark loaded)
-   * instead of crashing the whole run on a benign race; this counts how often it happened so the
-   * env-server can surface it on the DONE health line. Should stay low; a large value means the
-   * pool cap is too small for the snapshot cadence (workers evict faster than peers can load).
+   * GC-race floor): under `SubprocVecEnv` N env-servers share one snapshot dir with a single producer
+   * that owns disk GC (task E / PR-3). The producer `unlink`s an aged-out snapshot after truncating
+   * the manifest; a lagging worker reading a still-listing (older) manifest can try to import a file
+   * the producer has since GC'd. The lagging worker tolerates the missing file (warn + skip + mark
+   * loaded) instead of crashing the whole run on a benign race; this counts how often it happened so
+   * the env-server can surface it on the DONE health line. Should stay low; a large value means the
+   * pool cap is too small for the snapshot cadence (the producer GCs faster than a worker can load).
    */
   let refreshSkips = 0;
 
@@ -526,10 +528,12 @@ export function makeLeague({
      * (empty-pool fixed-field mode). Cheap when nothing changed: a single `statSync` mtime check short-
      * circuits before any parse/import. On a rewrite it diffs the manifest by stable id, dynamic-
      * `import()`s each NEW snapshot's `.js` (a fresh filename per snapshot, so the ESM URL cache never
-     * serves a stale module), wraps it with `makeBC({ policy })`, and FIFO-evicts past `poolCap`,
-     * GC-ing the evicted snapshot's `.js` file (the manifest still lists it, but `loadedIds` stops it
-     * being re-imported — restart recovery is a B6 concern). `draw()` does not sample the pool until
-     * B4, so in B3 this only grows `poolSize`; episode outcomes are unchanged.
+     * serves a stale module), wraps it with `makeBC({ policy })`, and FIFO-trims its IN-MEMORY pool
+     * past `poolCap`. It does NOT delete any file — disk GC is the single producer's job (task E /
+     * PR-3); a consumer that unlinked would race its SubprocVecEnv peers. `loadedIds` keeps an evicted
+     * id from being re-imported, and a file the producer has already GC'd is tolerated (the ENOENT
+     * guard below). `draw()` does not sample the pool until B4, so in B3 this only grows `poolSize`;
+     * episode outcomes are unchanged.
      *
      * @returns {Promise<{added:number, poolSize:number}>}
      */
@@ -567,7 +571,7 @@ export function makeLeague({
        * New snapshots to load, oldest-first (ascending step → push order == FIFO eviction order).
        * De-dup by id: the producer manifest is append-only and SHOULD list each id once, but a
        * producer resume can republish an id (PR-3 truncates that at the source), and two pool entries
-       * for one id would double its PFSP sampling weight and double-evict its file. Belt-and-braces.
+       * for one id would double its PFSP sampling weight and seat it twice in the pool. Belt-and-braces.
        */
       const seenFresh = new Set();
       const fresh = (manifest.snapshots ?? [])
@@ -585,20 +589,27 @@ export function makeLeague({
         try {
           mod = await import(pathToFileURL(weightsPath).href);
         } catch (err) {
-          if (err.code === 'ENOENT' || err.code === 'ERR_MODULE_NOT_FOUND') {
+          if (
+            (err.code === 'ENOENT' || err.code === 'ERR_MODULE_NOT_FOUND') &&
+            !existsSync(weightsPath)
+          ) {
             /*
-             * GC-race floor (task E): under SubprocVecEnv, N env-servers share one snapshot dir, so a
-             * peer worker can FIFO-evict + `unlinkSync` this snapshot's `.js` between the producer
-             * publishing the manifest and this (lagging) worker importing it. The file is gone for
-             * good — the snapshot is already superseded — so warn, mark its id loaded (never retry the
-             * dead path), and skip. A benign cross-worker race must not crash a multi-hour run. Any
-             * OTHER import error (a parse/syntax failure in a present file) is a real bug → rethrow.
+             * GC-race floor (task E): under SubprocVecEnv, N env-servers share one snapshot dir with a
+             * single producer (the Python `SnapshotCallback`) that owns disk GC — it `unlink`s an
+             * aged-out `.js` after truncating the manifest. A lagging worker can read a still-listing
+             * (older) manifest and try to import a file the producer has since GC'd. The file is gone
+             * for good — the snapshot is already superseded — so warn, mark its id loaded (never retry
+             * the dead path), and skip. A benign GC race must not crash a multi-hour run.
+             *
+             * The `!existsSync` guard makes the swallow mean "the file is genuinely gone": a present
+             * module that throws `ERR_MODULE_NOT_FOUND` for a MISSING TRANSITIVE IMPORT (or any parse/
+             * syntax failure) is a real bug in a published artifact → falls through to the rethrow.
              */
             refreshSkips++;
             loadedIds.add(snap.id);
             process.stderr.write(
               `[ppo-league] refresh: snapshot ${snap.id} weights gone before import (${weightsPath}); ` +
-                `skipped (peer GC race). refreshSkips=${refreshSkips}.\n`
+                `skipped (producer GC race). refreshSkips=${refreshSkips}.\n`
             );
             continue;
           }
@@ -621,12 +632,13 @@ export function makeLeague({
       /*
        * FIFO trim: keep the most recent `poolCap` snapshots sampleable. Disk deletion is the
        * PRODUCER's job now (task E / PR-3): the single Python process that owns the manifest GCs
-       * aged-out `.js` files AFTER truncating the manifest. A consumer must NOT unlink, or N
-       * SubprocVecEnv workers race to delete each other's files and a lagging worker imports a path a
-       * peer just removed (the GC race). Consumers tolerate a missing file in the import guard above;
-       * this loop only bounds the in-memory sampleable set. `loadedIds` still prevents re-importing an
-       * evicted id, and the ESM module registry retains the weights for the process lifetime
-       * regardless (see the `poolCap` JSDoc note).
+       * aged-out `.js` files AFTER truncating the manifest. If a consumer also unlinked, N
+       * SubprocVecEnv workers would race to delete each other's files and a lagging worker would
+       * import a path a peer just removed — a self-inflicted race the producer-owned-GC model avoids.
+       * Consumers still tolerate a producer-GC'd missing file in the import guard above; this loop
+       * only bounds the in-memory sampleable set. `loadedIds` still prevents re-importing an evicted
+       * id, and the ESM module registry retains the weights for the process lifetime regardless
+       * (see the `poolCap` JSDoc note).
        */
       while (pool.length > poolCap) {
         pool.shift();
@@ -658,7 +670,7 @@ export function makeLeague({
         // episodeCount is the resume seed-cursor (== decisiveGames + truncatedGames); the env-server
         // reads it after restore() to continue the seed sequence instead of replaying from 0.
         episodeCount,
-        // refreshSkips: cumulative snapshots skipped on a peer-GC race (should stay near 0).
+        // refreshSkips: cumulative snapshots skipped on a producer-GC race (should stay near 0).
         refreshSkips,
       };
     },
@@ -701,7 +713,7 @@ export function makeLeague({
      *
      * Gates, in order: (1) known `version`; (2) `encodingVersion === ENCODING_VERSION` — fail loud on
      * skew before importing anything (a mid-run encoding bump makes pooled snapshots unloadable, [D-23]);
-     * (3) `fingerprint` matches this league's config (drifted sampler/eviction args ⇒ divergent draws/GC);
+     * (3) `fingerprint` matches this league's config (drifted sampler/pool-cap args ⇒ divergent draws);
      * (4) `storeKind` matches this league's store — a checkpoint written by a `disk` store carries
      * `book: null` (the book lives in shards), so blindly restoring it into an in-memory store (or vice
      * versa) would silently zero the win-rate book and collapse the PFSP sampler to cold-start.
@@ -805,8 +817,11 @@ export function makeLeague({
       store.restore(state.book);
       decisiveGames = state.decisiveGames ?? 0;
       truncatedGames = state.truncatedGames ?? 0;
-      // The resume seed-cursor (task E). Fall back to the counter sum for forward-compat with any
-      // payload missing the explicit field, so resume still skips the already-played seeds.
+      // The resume seed-cursor (task E). A v2 payload always carries `episodeCount` (the version gate
+      // above rejects anything else), so the `??` only matters if that gate is ever loosened — it then
+      // falls back to the cursor's own invariant (== decisiveGames + truncatedGames), never a wrong
+      // value, so resume still skips exactly the already-played seeds. Defensive, consistent with the
+      // surrounding `?? 0` reads.
       episodeCount = state.episodeCount ?? decisiveGames + truncatedGames;
       refreshSkips = state.refreshSkips ?? 0;
       noSeatBeatGames = state.noSeatBeatGames ?? 0;

--- a/scripts/lib/ppo-league.mjs
+++ b/scripts/lib/ppo-league.mjs
@@ -27,7 +27,7 @@
  * @module scripts/lib/ppo-league
  */
 
-import { readFileSync, statSync, unlinkSync } from 'node:fs';
+import { readFileSync, statSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
@@ -56,8 +56,13 @@ const MAX_NO_SEATBEAT_GAMES = 10;
 /**
  * `toJSON()` checkpoint schema version (B6). `restore()` rejects an unknown version rather than
  * silently mis-reading an older/newer layout. Bump only on a breaking shape change to the snapshot.
+ *
+ * v2 (task E / PR-1): added `episodeCount` (the resume seed-cursor — without it a relaunched
+ * env-server replays seeds from 0 and re-books their outcomes, double-counting the win-rate book)
+ * and `refreshSkips` (the multi-worker GC-race health counter). B6 (v1) never ran live, so there
+ * are no v1 checkpoints in the wild — the bump just makes a stale checkpoint fail loud on resume.
  */
-const STATE_SCHEMA_VERSION = 1;
+const STATE_SCHEMA_VERSION = 2;
 
 /**
  * @typedef {object} LeagueStore the pluggable win-rate backend (see ppo-league-store.mjs).
@@ -124,9 +129,11 @@ export function resolveBaselineField(idCsv, count) {
  *   (B3). When set, `refresh()` polls it and hot-loads new self-play snapshots into the pool via
  *   `makeBC`. `null` (the default / no `--snapshot-manifest`) keeps the empty-pool fixed-field mode —
  *   `refresh()` is a no-op, so B3 is fully backward-compatible with task A / B1 / B2.
- * @param {number} [opts.poolCap=40] max snapshots kept live (sampleable) and on disk (B3). FIFO-by-
- *   step eviction keeps the most recent/hardest snapshots ([D-23]) and `unlinkSync`s the evicted
- *   `.js`, so this bounds DISK and the sampleable set. It does NOT bound process memory: Node's ESM
+ * @param {number} [opts.poolCap=40] max snapshots kept live (sampleable) (B3). FIFO-by-step eviction
+ *   keeps the most recent/hardest snapshots ([D-23]) in the in-memory pool. It bounds the SAMPLEABLE
+ *   set only — disk retention is the PRODUCER's job (task E / PR-3): a consumer no longer deletes
+ *   files (that would race N SubprocVecEnv workers); the single producer GCs aged-out `.js` after
+ *   truncating its manifest. It does NOT bound process memory either: Node's ESM
  *   module registry retains every dynamic-`import()`ed snapshot module for the process lifetime (each
  *   fresh filename is a distinct, permanently-cached module), so resident weights grow with the total
  *   number of snapshots ever loaded, not `poolCap`. Modest at realistic cadences (~2 MB each); if a
@@ -274,6 +281,17 @@ export function makeLeague({
   let decisiveGames = 0;
   let truncatedGames = 0;
   /*
+   * Episodes booked through `recordResult` — the **resume seed-cursor** (task E / PR-1). The
+   * env-server seeds episode `ep` with `seedBase + ep` and books exactly one result per loop
+   * iteration that reached a terminal (disconnect/error break out BEFORE `recordResult`), so this is
+   * the count of seeds already consumed-and-booked. On resume the env-server starts its loop at this
+   * value so it does NOT replay already-played seeds and re-fold their outcomes into the (restored)
+   * win-rate book — the silent double-count this counter exists to prevent. Always equals
+   * `decisiveGames + truncatedGames`; kept as its own field so the cursor stays correct even if a
+   * future change adds a third outcome bucket (the invariant is asserted in the persist suite).
+   */
+  let episodeCount = 0;
+  /*
    * Win-rate book (B2): stable opponent id → the LEARNER's pairwise record against it. `wins` is the
    * count of decisive games in which the learner outplaced that opponent; `games` the decisive games
    * the opponent appeared in (a cycled baseline seated twice in one game contributes two records).
@@ -306,6 +324,16 @@ export function makeLeague({
   const pool = [];
   const loadedIds = new Set();
   let manifestMtimeMs = -1;
+  /*
+   * Snapshots `refresh()` skipped because their `.js` was already gone at import time (task E / PR-1
+   * GC-race floor): under `SubprocVecEnv` N env-servers share one snapshot dir, and a peer can
+   * FIFO-evict + `unlinkSync` a snapshot between the producer publishing the manifest and a lagging
+   * worker importing it. The lagging worker tolerates the missing file (warn + skip + mark loaded)
+   * instead of crashing the whole run on a benign race; this counts how often it happened so the
+   * env-server can surface it on the DONE health line. Should stay low; a large value means the
+   * pool cap is too small for the snapshot cadence (workers evict faster than peers can load).
+   */
+  let refreshSkips = 0;
 
   /*
    * Opponent-array index → seat: the learner sits at `learnerSeat`; opponents fill the remaining
@@ -430,6 +458,9 @@ export function makeLeague({
      * yields two independent records for its id (one per seat), which is correct.
      */
     recordResult(drawn, result) {
+      // The resume seed-cursor (task E): one increment per booked episode, BEFORE the truncated/
+      // decisive split, so it counts every seed consumed regardless of outcome bucket.
+      episodeCount++;
       if (result.truncated) {
         truncatedGames++;
         return;
@@ -532,14 +563,47 @@ export function makeLeague({
       }
 
       const dir = dirname(snapshotManifest);
+      /*
+       * New snapshots to load, oldest-first (ascending step → push order == FIFO eviction order).
+       * De-dup by id: the producer manifest is append-only and SHOULD list each id once, but a
+       * producer resume can republish an id (PR-3 truncates that at the source), and two pool entries
+       * for one id would double its PFSP sampling weight and double-evict its file. Belt-and-braces.
+       */
+      const seenFresh = new Set();
       const fresh = (manifest.snapshots ?? [])
-        .filter(s => !loadedIds.has(s.id))
-        .sort((a, b) => a.step - b.step); // ascending step → push order == FIFO eviction order
+        .filter(s => {
+          if (loadedIds.has(s.id) || seenFresh.has(s.id)) return false;
+          seenFresh.add(s.id);
+          return true;
+        })
+        .sort((a, b) => a.step - b.step);
 
       let added = 0;
       for (const snap of fresh) {
         const weightsPath = resolve(dir, snap.weights);
-        const mod = await import(pathToFileURL(weightsPath).href);
+        let mod;
+        try {
+          mod = await import(pathToFileURL(weightsPath).href);
+        } catch (err) {
+          if (err.code === 'ENOENT' || err.code === 'ERR_MODULE_NOT_FOUND') {
+            /*
+             * GC-race floor (task E): under SubprocVecEnv, N env-servers share one snapshot dir, so a
+             * peer worker can FIFO-evict + `unlinkSync` this snapshot's `.js` between the producer
+             * publishing the manifest and this (lagging) worker importing it. The file is gone for
+             * good — the snapshot is already superseded — so warn, mark its id loaded (never retry the
+             * dead path), and skip. A benign cross-worker race must not crash a multi-hour run. Any
+             * OTHER import error (a parse/syntax failure in a present file) is a real bug → rethrow.
+             */
+            refreshSkips++;
+            loadedIds.add(snap.id);
+            process.stderr.write(
+              `[ppo-league] refresh: snapshot ${snap.id} weights gone before import (${weightsPath}); ` +
+                `skipped (peer GC race). refreshSkips=${refreshSkips}.\n`
+            );
+            continue;
+          }
+          throw err;
+        }
         if (!mod.BC_POLICY) {
           // No BC_POLICY export ⇒ makeBC's default param would silently load the SHIPPED BC as this
           // snapshot (a corrupt/truncated published artifact masquerading as a trained policy). Fail loud.
@@ -555,19 +619,17 @@ export function makeLeague({
       }
 
       /*
-       * FIFO eviction: keep the most recent `poolCap` sampleable and `unlinkSync` the evicted `.js`
-       * (D-23 disk retention — the fresh-filename rule would otherwise grow disk forever). This bounds
-       * DISK and the sampleable set, NOT process memory: the dynamic-`import()`ed module stays in
-       * Node's ESM registry for the process lifetime, so dropping the `fn` here does not free the
-       * ~2 MB weights (see the `poolCap` JSDoc note).
+       * FIFO trim: keep the most recent `poolCap` snapshots sampleable. Disk deletion is the
+       * PRODUCER's job now (task E / PR-3): the single Python process that owns the manifest GCs
+       * aged-out `.js` files AFTER truncating the manifest. A consumer must NOT unlink, or N
+       * SubprocVecEnv workers race to delete each other's files and a lagging worker imports a path a
+       * peer just removed (the GC race). Consumers tolerate a missing file in the import guard above;
+       * this loop only bounds the in-memory sampleable set. `loadedIds` still prevents re-importing an
+       * evicted id, and the ESM module registry retains the weights for the process lifetime
+       * regardless (see the `poolCap` JSDoc note).
        */
       while (pool.length > poolCap) {
-        const evicted = pool.shift();
-        try {
-          unlinkSync(evicted.weightsPath);
-        } catch {
-          /* already gone / shared / read-only — best-effort GC, never fail a refresh on it */
-        }
+        pool.shift();
       }
 
       manifestMtimeMs = stat.mtimeMs; // commit only after a clean load, so a throw retries next poll
@@ -593,6 +655,11 @@ export function makeLeague({
         truncatedGames,
         decisiveRate: total > 0 ? decisiveGames / total : 0,
         noSeatBeatGames,
+        // episodeCount is the resume seed-cursor (== decisiveGames + truncatedGames); the env-server
+        // reads it after restore() to continue the seed sequence instead of replaying from 0.
+        episodeCount,
+        // refreshSkips: cumulative snapshots skipped on a peer-GC race (should stay near 0).
+        refreshSkips,
       };
     },
 
@@ -614,6 +681,8 @@ export function makeLeague({
         fingerprint,
         decisiveGames,
         truncatedGames,
+        episodeCount, // resume seed-cursor (task E) — see the counter declaration above
+        refreshSkips, // cumulative GC-race skips (carried across restarts for a true run-total)
         noSeatBeatGames,
         warnedNoSeatBeat,
         storeKind: store.kind, // restore() rejects a backend switch — see the store-kind gate there
@@ -736,6 +805,10 @@ export function makeLeague({
       store.restore(state.book);
       decisiveGames = state.decisiveGames ?? 0;
       truncatedGames = state.truncatedGames ?? 0;
+      // The resume seed-cursor (task E). Fall back to the counter sum for forward-compat with any
+      // payload missing the explicit field, so resume still skips the already-played seeds.
+      episodeCount = state.episodeCount ?? decisiveGames + truncatedGames;
+      refreshSkips = state.refreshSkips ?? 0;
       noSeatBeatGames = state.noSeatBeatGames ?? 0;
       warnedNoSeatBeat = state.warnedNoSeatBeat ?? false;
       manifestMtimeMs = -1; // never trust a persisted mtime — force a fresh manifest re-poll

--- a/scripts/ppo-env-server.mjs
+++ b/scripts/ppo-env-server.mjs
@@ -177,6 +177,108 @@ export function resolveLeaguePersistence(opts, { seedBase, snapshotManifest }) {
   return { store, snapshotStore, leagueStateDir, leagueStatePath };
 }
 
+/**
+ * Build the league-state checkpoint dumper (B6 / task E PR-1). Extracted from `main()` so the
+ * write ORDER and the consecutive-failure abort are unit-testable without spawning the worker/socket
+ * (`main` is not exported).
+ *
+ * Write order (HOLE-B): the state file (`league.toJSON()`, carrying `episodeCount`) is written FIRST,
+ * then the disk store's win-rate shard is flushed. They are separate files for the disk store (the
+ * shard holds the book; `toJSON` emits `book: null`), so a crash can land between them. State-first
+ * leaves `episodeCount` AHEAD of the shard on a crash — resume skips those seeds, so the un-flushed
+ * games are LOST (bounded skew). Shard-first would leave it ahead of the cursor and resume would
+ * replay + re-fold those seeds — a silent DOUBLE-COUNT that biases the PFSP sampler. Lose-a-few beats
+ * count-twice. (In-memory store: the book rides inside `toJSON()`, so the order is moot.)
+ *
+ * Best-effort: a transient failure must not crash a multi-hour run — but a PERSISTENTLY dead path
+ * (full disk / unwritable dir) writes zero checkpoints while still printing a normal DONE line, the
+ * exact silent non-durability this feature prevents. So after `maxConsecutiveFailures` in a row,
+ * `dump()` throws and lets the operator fix the path instead of losing the whole resume window.
+ *
+ * @param {object} cfg
+ * @param {string|null} cfg.leagueStatePath checkpoint path; `null` ⇒ `dump()` is a no-op (persistence off).
+ * @param {object} cfg.league a `makeLeague(...)` instance (read via `toJSON()`).
+ * @param {object} cfg.store the win-rate backend (its `flush()` is the second write).
+ * @param {(path:string, obj:object)=>void} [cfg.writeJson] state writer (injectable for tests).
+ * @param {number} [cfg.maxConsecutiveFailures=10] consecutive failures before `dump()` aborts the run.
+ * @returns {{ dump: () => void, getDumpFailures: () => number }}
+ */
+export function makeCheckpointDumper({
+  leagueStatePath,
+  league,
+  store,
+  writeJson = writeJsonAtomic,
+  maxConsecutiveFailures = 10,
+}) {
+  let dumpFailures = 0; // total failed dumps — surfaced on the DONE line (0 on a healthy run)
+  let consecutiveDumpFailures = 0;
+  const dump = () => {
+    if (!leagueStatePath) return;
+    try {
+      writeJson(leagueStatePath, league.toJSON()); // state FIRST (HOLE-B: cursor may lead the shard)
+      store.flush(); // shard SECOND
+      consecutiveDumpFailures = 0;
+    } catch (err) {
+      dumpFailures++;
+      process.stderr.write(
+        `[ppo-env-server] league-state dump #${dumpFailures} failed: ${err.message}\n`
+      );
+      if (++consecutiveDumpFailures >= maxConsecutiveFailures) {
+        throw new Error(
+          `PPO env-server: ${consecutiveDumpFailures} consecutive league-state dumps failed to ` +
+            `${leagueStatePath} — checkpoint path unwritable; aborting (last: ${err.message}).`
+        );
+      }
+    }
+  };
+  return { dump, getDumpFailures: () => dumpFailures };
+}
+
+/**
+ * The `PPO_ENV_SERVER DONE …` health line (a key=value map the B5 probes parse). Extracted so the
+ * field set is unit-testable and so it can be emitted identically from BOTH the normal exit and the
+ * abnormal-exit path (a thrown refresh / dump-abort / zero-decision storm) without drift.
+ *
+ * @param {number} played wire terminals surfaced this launch.
+ * @param {object} s `league.stats()`.
+ * @param {number} dumpFailures from the checkpoint dumper.
+ */
+export function formatDoneLine(played, s, dumpFailures) {
+  return (
+    `PPO_ENV_SERVER DONE episodes=${played} decisiveGames=${s.decisiveGames} ` +
+    `truncatedGames=${s.truncatedGames} decisiveRate=${s.decisiveRate.toFixed(4)} ` +
+    `poolSize=${s.poolSize} loadedSnapshots=${s.loadedSnapshots} bookSize=${s.bookSize} ` +
+    `episodeCount=${s.episodeCount} refreshSkips=${s.refreshSkips} ` +
+    `noSeatBeatGames=${s.noSeatBeatGames} dumpFailures=${dumpFailures}`
+  );
+}
+
+/**
+ * The `ep` the episode loop starts at (task E / PR-1, HOLE-A): the league's booked-episode count, so a
+ * relaunch CONTINUES the seed sequence (`seed = seedBase + ep`) instead of replaying booked seeds and
+ * re-folding their outcomes into the restored win-rate book — a silent double-count. A fresh run reads
+ * 0. Extracted + exported so the loop-start derivation is unit-testable without spawning the worker.
+ *
+ * @param {object} league a `makeLeague(...)` instance.
+ * @returns {number}
+ */
+export function resumeStartEpisode(league) {
+  return league.stats().episodeCount;
+}
+
+/**
+ * Episode-loop predicate. `episodes === 0` runs until the client disconnects; otherwise `episodes` is
+ * the run TOTAL across restarts (NOT per-launch), so when the resume cursor already meets it the body
+ * never runs (a relaunch of an already-complete budget is a clean no-op, not a fresh N episodes).
+ *
+ * @param {number} ep current episode index (== the seed cursor).
+ * @param {number} episodes the `--episodes` budget (0 = unbounded).
+ * @returns {boolean}
+ */
+export function shouldRunEpisode(ep, episodes) {
+  return episodes === 0 || ep < episodes;
+}
+
 async function main() {
   /*
    * A learner client (or the parent reading our stdout) can vanish mid-run; a broken
@@ -252,49 +354,13 @@ async function main() {
   }
 
   /*
-   * Atomically checkpoint the league (B6). No-op unless persistence is opted in.
-   *
-   * Write order (task E / PR-1, HOLE-B): the state file (`league.toJSON()`, carrying `episodeCount`)
-   * is written FIRST, then the disk store's own win-rate shard is flushed. The two are separate files
-   * for the disk store (the shard holds the book; toJSON emits `book: null`), so a crash can land
-   * between them. Writing state first means a crash in that window leaves `episodeCount` AHEAD of the
-   * shard — on resume the env-server skips those seeds, so the at-most-`dumpEvery` un-flushed games are
-   * simply LOST (the already-accepted bounded skew). Flushing the shard first would instead leave it
-   * ahead of `episodeCount`, and resume would replay those seeds and re-fold them into the shard —
-   * a silent DOUBLE-COUNT that biases the PFSP sampler. Lose-a-few beats count-twice. (For the
-   * in-memory store the book rides inside `league.toJSON()`, so it is always atomic with the cursor and
-   * the order is moot.) Best-effort: a dump failure must never crash a multi-hour run.
+   * Atomically checkpoint the league (B6) — the HOLE-B state-then-flush ordering and the
+   * consecutive-failure abort live in `makeCheckpointDumper` (extracted so they are unit-testable
+   * without spawning the worker). No-op unless persistence is opted in.
    */
   let bookedSinceDump = 0;
-  let dumpFailures = 0; // total failed dumps — surfaced on the DONE line (should read 0 on a healthy run)
-  let consecutiveDumpFailures = 0;
-  const MAX_CONSECUTIVE_DUMP_FAILURES = 10;
-  const dumpLeagueState = () => {
-    if (!leagueStatePath) return;
-    try {
-      writeJsonAtomic(leagueStatePath, league.toJSON());
-      store.flush();
-      consecutiveDumpFailures = 0;
-    } catch (err) {
-      /*
-       * Best-effort — a transient dump failure must not crash a multi-hour run. But a PERSISTENTLY dead
-       * checkpoint path (full disk, unwritable dir) would otherwise write zero checkpoints for the whole
-       * run while still printing a normal DONE line — exactly the silent non-durability this feature
-       * exists to prevent. Track failures, surface the count on DONE, and fail loud after a sustained run
-       * of them so the operator fixes the path instead of losing the entire resume window.
-       */
-      dumpFailures++;
-      process.stderr.write(
-        `[ppo-env-server] league-state dump #${dumpFailures} failed: ${err.message}\n`
-      );
-      if (++consecutiveDumpFailures >= MAX_CONSECUTIVE_DUMP_FAILURES) {
-        throw new Error(
-          `PPO env-server: ${consecutiveDumpFailures} consecutive league-state dumps failed to ` +
-            `${leagueStatePath} — checkpoint path unwritable; aborting (last: ${err.message}).`
-        );
-      }
-    }
-  };
+  const checkpointer = makeCheckpointDumper({ leagueStatePath, league, store });
+  const dumpLeagueState = checkpointer.dump;
   /*
    * Best-effort flush on a graceful kill (SIGTERM). A signal landing mid-decision can't run until the
    * main thread unparks from Atomics.wait, so the periodic dump below — not this — is the durability
@@ -453,13 +519,13 @@ async function main() {
      * double-count. A fresh start reads 0 (behavior unchanged). For a fixed `--episodes=N`, N is the
      * run TOTAL across restarts, not per-launch (mirrors the Python-side `remaining` budget).
      */
-    const resumeEp = league.stats().episodeCount;
+    const resumeEp = resumeStartEpisode(league);
     if (resumeEp > 0) {
       process.stderr.write(
         `[ppo-env-server] resuming episode loop at ep=${resumeEp} (seed-cursor).\n`
       );
     }
-    for (let ep = resumeEp; episodes === 0 || ep < episodes; ep++) {
+    for (let ep = resumeEp; shouldRunEpisode(ep, episodes); ep++) {
       if (closed || lostError) break;
       /*
        * Poll the snapshot manifest at the episode boundary (B3): hot-load any newly published
@@ -582,30 +648,47 @@ async function main() {
      * decisive episode INCLUDING zero-decision skips — so `episodes < decisiveGames` is the visible
      * signature of a zero-decision episode that was booked but surfaced no frame (the B2 reordering).
      * `noSeatBeatGames` should be 0 — a nonzero value flags a placement-contract break that left the
-     * win-rate book under-credited (PFSP drifting toward uniform). env.py drains and drops this line
-     * (only the anchored LISTENING line is parsed), so appending fields is safe.
+     * win-rate book under-credited (PFSP drifting toward uniform). `env_server.py`'s
+     * `EnvServerProcess._drain_stdout` drops this line (only the anchored LISTENING line is parsed),
+     * so appending fields is safe.
      */
     // Final checkpoint on a clean loop exit (B6) — captures the tail of episodes since the last
     // periodic dump. No-op when not persisting.
     dumpLeagueState();
     const s = league.stats();
-    const doneLine =
-      `PPO_ENV_SERVER DONE episodes=${played} decisiveGames=${s.decisiveGames} ` +
-      `truncatedGames=${s.truncatedGames} decisiveRate=${s.decisiveRate.toFixed(4)} ` +
-      `poolSize=${s.poolSize} loadedSnapshots=${s.loadedSnapshots} bookSize=${s.bookSize} ` +
-      `episodeCount=${s.episodeCount} refreshSkips=${s.refreshSkips} ` +
-      `noSeatBeatGames=${s.noSeatBeatGames} dumpFailures=${dumpFailures}`;
+    const doneLine = formatDoneLine(played, s, checkpointer.getDumpFailures());
     process.stdout.write(`${doneLine}\n`);
     /*
-     * Mirror the health summary to STDERR (task E / PR-1): env.py drains and DROPS stdout (only the
-     * anchored LISTENING line is parsed), so this window is invisible to the trainer's logs unless it
-     * also lands on stderr (which the Python parent inherits). `refreshSkips` (peer GC race),
-     * `dumpFailures` (unwritable checkpoint path), and `noSeatBeatGames` (broken placement contract)
-     * should all read 0 on a healthy run — a nonzero value is often the ONLY signal of a silent fault
-     * on a multi-day shodan run. Appending fields to the stdout line stays safe (env.py drops it; the
-     * probes parse a key=value map).
+     * Mirror the health summary to STDERR (task E / PR-1): `env_server.py`'s `_drain_stdout` reader
+     * thread captures only the anchored LISTENING line on stdout and DROPS the rest, so this window is
+     * invisible to the trainer's logs unless it also lands on stderr (which the Python parent inherits,
+     * `stderr=None`). `refreshSkips` (producer GC race), `dumpFailures` (unwritable checkpoint path),
+     * and `noSeatBeatGames` (broken placement contract) should all read 0 on a healthy run — a nonzero
+     * value is often the ONLY signal of a silent fault on a multi-day shodan run, so prefix `WARN` when
+     * any is nonzero to make it greppable. Appending fields to the stdout line stays safe (it is
+     * dropped; the probes parse a key=value map).
      */
-    process.stderr.write(`[ppo-env-server] ${doneLine}\n`);
+    const healthWarn =
+      s.refreshSkips > 0 || s.noSeatBeatGames > 0 || checkpointer.getDumpFailures() > 0;
+    process.stderr.write(`[ppo-env-server]${healthWarn ? ' WARN' : ''} ${doneLine}\n`);
+  } catch (err) {
+    /*
+     * Abnormal exit (task E / S-3): a thrown `refresh()` / encoding skew, the dump-abort, or a
+     * zero-decision storm all skip the normal DONE emission above — yet these are exactly the runs
+     * where `refreshSkips`/`noSeatBeatGames`/`dumpFailures` matter most. Surface the health summary on
+     * stderr here (best-effort, marked ABNORMAL EXIT) before the worker is reaped, then rethrow so the
+     * top-level handler still logs the fatal + sets exit 1. A failure reading stats() mid-teardown must
+     * not mask the original error.
+     */
+    try {
+      const s = league.stats();
+      process.stderr.write(
+        `[ppo-env-server] WARN ABNORMAL EXIT ${formatDoneLine(played, s, checkpointer.getDumpFailures())}\n`
+      );
+    } catch {
+      /* stats() unavailable mid-teardown — the rethrown error below is what matters */
+    }
+    throw err;
   } finally {
     /*
      * Always reap the worker — otherwise its still-listening server keeps the process alive (a

--- a/scripts/ppo-env-server.mjs
+++ b/scripts/ppo-env-server.mjs
@@ -252,9 +252,18 @@ async function main() {
   }
 
   /*
-   * Atomically checkpoint the league (B6). No-op unless persistence is opted in. Flush the store's own
-   * win-rate shard FIRST (the disk store's book lives there; toJSON emits null for it), then write the
-   * counters/pool/loadedIds state. Best-effort: a dump failure must never crash a multi-hour run.
+   * Atomically checkpoint the league (B6). No-op unless persistence is opted in.
+   *
+   * Write order (task E / PR-1, HOLE-B): the state file (`league.toJSON()`, carrying `episodeCount`)
+   * is written FIRST, then the disk store's own win-rate shard is flushed. The two are separate files
+   * for the disk store (the shard holds the book; toJSON emits `book: null`), so a crash can land
+   * between them. Writing state first means a crash in that window leaves `episodeCount` AHEAD of the
+   * shard — on resume the env-server skips those seeds, so the at-most-`dumpEvery` un-flushed games are
+   * simply LOST (the already-accepted bounded skew). Flushing the shard first would instead leave it
+   * ahead of `episodeCount`, and resume would replay those seeds and re-fold them into the shard —
+   * a silent DOUBLE-COUNT that biases the PFSP sampler. Lose-a-few beats count-twice. (For the
+   * in-memory store the book rides inside `league.toJSON()`, so it is always atomic with the cursor and
+   * the order is moot.) Best-effort: a dump failure must never crash a multi-hour run.
    */
   let bookedSinceDump = 0;
   let dumpFailures = 0; // total failed dumps — surfaced on the DONE line (should read 0 on a healthy run)
@@ -263,8 +272,8 @@ async function main() {
   const dumpLeagueState = () => {
     if (!leagueStatePath) return;
     try {
-      store.flush();
       writeJsonAtomic(leagueStatePath, league.toJSON());
+      store.flush();
       consecutiveDumpFailures = 0;
     } catch (err) {
       /*
@@ -437,7 +446,20 @@ async function main() {
      * which resolves `connected` with `closed`/exitCode already set so the loop exits immediately).
      */
     await connected;
-    for (let ep = 0; episodes === 0 || ep < episodes; ep++) {
+    /*
+     * Resume seed-cursor (task E / PR-1, HOLE-A): start the loop at the league's booked-episode count
+     * so a relaunched env-server CONTINUES the seed sequence (`seed = seedBase + ep`) instead of
+     * replaying seeds from 0 and re-folding their outcomes into the restored win-rate book — a silent
+     * double-count. A fresh start reads 0 (behavior unchanged). For a fixed `--episodes=N`, N is the
+     * run TOTAL across restarts, not per-launch (mirrors the Python-side `remaining` budget).
+     */
+    const resumeEp = league.stats().episodeCount;
+    if (resumeEp > 0) {
+      process.stderr.write(
+        `[ppo-env-server] resuming episode loop at ep=${resumeEp} (seed-cursor).\n`
+      );
+    }
+    for (let ep = resumeEp; episodes === 0 || ep < episodes; ep++) {
       if (closed || lostError) break;
       /*
        * Poll the snapshot manifest at the episode boundary (B3): hot-load any newly published
@@ -567,12 +589,23 @@ async function main() {
     // periodic dump. No-op when not persisting.
     dumpLeagueState();
     const s = league.stats();
-    process.stdout.write(
+    const doneLine =
       `PPO_ENV_SERVER DONE episodes=${played} decisiveGames=${s.decisiveGames} ` +
-        `truncatedGames=${s.truncatedGames} decisiveRate=${s.decisiveRate.toFixed(4)} ` +
-        `poolSize=${s.poolSize} loadedSnapshots=${s.loadedSnapshots} bookSize=${s.bookSize} ` +
-        `noSeatBeatGames=${s.noSeatBeatGames} dumpFailures=${dumpFailures}\n`
-    );
+      `truncatedGames=${s.truncatedGames} decisiveRate=${s.decisiveRate.toFixed(4)} ` +
+      `poolSize=${s.poolSize} loadedSnapshots=${s.loadedSnapshots} bookSize=${s.bookSize} ` +
+      `episodeCount=${s.episodeCount} refreshSkips=${s.refreshSkips} ` +
+      `noSeatBeatGames=${s.noSeatBeatGames} dumpFailures=${dumpFailures}`;
+    process.stdout.write(`${doneLine}\n`);
+    /*
+     * Mirror the health summary to STDERR (task E / PR-1): env.py drains and DROPS stdout (only the
+     * anchored LISTENING line is parsed), so this window is invisible to the trainer's logs unless it
+     * also lands on stderr (which the Python parent inherits). `refreshSkips` (peer GC race),
+     * `dumpFailures` (unwritable checkpoint path), and `noSeatBeatGames` (broken placement contract)
+     * should all read 0 on a healthy run — a nonzero value is often the ONLY signal of a silent fault
+     * on a multi-day shodan run. Appending fields to the stdout line stays safe (env.py drops it; the
+     * probes parse a key=value map).
+     */
+    process.stderr.write(`[ppo-env-server] ${doneLine}\n`);
   } finally {
     /*
      * Always reap the worker — otherwise its still-listening server keeps the process alive (a

--- a/scripts/ppo-league-probe.mjs
+++ b/scripts/ppo-league-probe.mjs
@@ -123,10 +123,11 @@ export function parseRSweep(opts, fallback) {
 
 /**
  * Reject `poolCap < poolSize` up front: the league FIFO-evicts the live pool down to `poolCap`
- * (`ppo-league.mjs`), so a smaller cap would (a) make the probe sample a SMALLER, skewed field than
- * the requested mix, and (b) `unlinkSync` the evicted shims from the shared scratch dir — which a
- * `--workers>1` R-sweep then re-`import()`s on the next R from a cold module cache, crashing with a
- * bare `ENOENT`. This tool never wants eviction, so fail the launch with an actionable message instead.
+ * (`ppo-league.mjs`), so a smaller cap would make the probe sample a SMALLER, skewed field than the
+ * requested mix. (Eviction no longer unlinks shims — disk GC moved to the producer in task E / PR-3,
+ * and a missing shim is now tolerated by `refresh()` regardless — but a shrunk sampleable field still
+ * misreports throughput/decisive-rate.) This tool never wants eviction, so fail the launch with an
+ * actionable message instead.
  *
  * @param {number} poolCap
  * @param {number} poolSize - the number of snapshots the manifest will seat (`specs.length`)

--- a/tests/ml/ppo-env-server-checkpoint.test.js
+++ b/tests/ml/ppo-env-server-checkpoint.test.js
@@ -1,0 +1,176 @@
+/**
+ * PPO env-server checkpoint dumper + DONE health line (Phase 3, task E / PR-1 — [D-26]).
+ *
+ * These pin the two seams the PR's crash-safety guarantees actually live in, extracted from `main()`
+ * (which is not exported — it spawns a worker/socket) precisely so they can be unit-tested:
+ *
+ *  - `makeCheckpointDumper` — the HOLE-B write ORDER (state file BEFORE the store shard, so a crash
+ *    in the window loses bounded games instead of double-counting into the PFSP book) and the
+ *    consecutive-failure abort (a persistently-dead checkpoint path must fail loud, not silently
+ *    write zero checkpoints for a multi-day run). A revert that swaps the two writes, or drops the
+ *    abort, would otherwise pass every other test.
+ *  - `formatDoneLine` — the exact health-field set the B5 probes parse and the stderr mirror emits.
+ */
+
+import {
+  makeCheckpointDumper,
+  formatDoneLine,
+  resumeStartEpisode,
+  shouldRunEpisode,
+} from '../../scripts/ppo-env-server.mjs';
+
+/** A fake league whose toJSON pushes a marker so write order is observable. */
+function fakeLeague(order) {
+  return {
+    toJSON: () => {
+      order.push('state');
+      return { version: 2, episodeCount: 7 };
+    },
+  };
+}
+
+/** A fake store whose flush pushes a marker (and can be made to throw). */
+function fakeStore(order, { throwOnFlush = false } = {}) {
+  return {
+    kind: 'disk',
+    flush: () => {
+      order.push('flush');
+      if (throwOnFlush) throw new Error('shard write failed (simulated)');
+    },
+  };
+}
+
+describe('makeCheckpointDumper — HOLE-B write order', () => {
+  it('writes the state file FIRST, then flushes the store shard (cursor may lead the shard, never trail)', () => {
+    const order = [];
+    const writes = [];
+    const dumper = makeCheckpointDumper({
+      leagueStatePath: '/run/league-state.json',
+      league: fakeLeague(order),
+      store: fakeStore(order),
+      writeJson: (path, obj) => {
+        order.push('write');
+        writes.push({ path, obj });
+      },
+    });
+    dumper.dump();
+    // `state` (toJSON) and `write` happen together, then `flush` — the state file is durable before
+    // the shard. Shard-first would let a crash leave the shard ahead of the cursor → resume replays
+    // and double-counts those seeds into the win-rate book.
+    expect(order).toEqual(['state', 'write', 'flush']);
+    expect(writes).toEqual([{ path: '/run/league-state.json', obj: { version: 2, episodeCount: 7 } }]);
+    expect(dumper.getDumpFailures()).toBe(0);
+  });
+
+  it('is a no-op when persistence is off (leagueStatePath null) — never touches writeJson/store', () => {
+    const order = [];
+    let wrote = false;
+    const dumper = makeCheckpointDumper({
+      leagueStatePath: null,
+      league: fakeLeague(order),
+      store: fakeStore(order),
+      writeJson: () => {
+        wrote = true;
+      },
+    });
+    dumper.dump();
+    expect(order).toEqual([]);
+    expect(wrote).toBe(false);
+    expect(dumper.getDumpFailures()).toBe(0);
+  });
+});
+
+describe('makeCheckpointDumper — failure accounting + abort', () => {
+  it('on a flush failure, the state file is still written (state-ahead = the SAFE skew) and dump does not throw', () => {
+    const order = [];
+    const dumper = makeCheckpointDumper({
+      leagueStatePath: '/run/league-state.json',
+      league: fakeLeague(order),
+      store: fakeStore(order, { throwOnFlush: true }),
+      writeJson: () => order.push('write'),
+    });
+    expect(() => dumper.dump()).not.toThrow(); // best-effort: a transient failure never crashes the run
+    expect(order).toEqual(['state', 'write', 'flush']); // state was written BEFORE the flush threw
+    expect(dumper.getDumpFailures()).toBe(1);
+  });
+
+  it('aborts loud after maxConsecutiveFailures consecutive failures (a dead checkpoint path)', () => {
+    const dumper = makeCheckpointDumper({
+      leagueStatePath: '/run/league-state.json',
+      league: { toJSON: () => ({}) },
+      store: { kind: 'disk', flush: () => {} },
+      writeJson: () => {
+        throw new Error('ENOSPC: no space left on device');
+      },
+      maxConsecutiveFailures: 3,
+    });
+    expect(() => dumper.dump()).not.toThrow(); // 1
+    expect(() => dumper.dump()).not.toThrow(); // 2
+    expect(() => dumper.dump()).toThrow(/3 consecutive league-state dumps failed/); // 3 → abort
+    expect(dumper.getDumpFailures()).toBe(3);
+  });
+
+  it('a success resets the consecutive-failure counter, so it takes a fresh run of failures to abort', () => {
+    let failNext = true;
+    const dumper = makeCheckpointDumper({
+      leagueStatePath: '/run/league-state.json',
+      league: { toJSON: () => ({}) },
+      store: { kind: 'disk', flush: () => {} },
+      writeJson: () => {
+        if (failNext) throw new Error('transient EIO');
+      },
+      maxConsecutiveFailures: 2,
+    });
+    expect(() => dumper.dump()).not.toThrow(); // fail #1 (consecutive=1)
+    failNext = false;
+    expect(() => dumper.dump()).not.toThrow(); // success → consecutive reset to 0
+    failNext = true;
+    expect(() => dumper.dump()).not.toThrow(); // fail again (consecutive=1, not 2 → no abort)
+    expect(dumper.getDumpFailures()).toBe(2); // total failures counted across the run
+  });
+});
+
+describe('formatDoneLine', () => {
+  it('emits every health field the B5 probes parse, with the dumper failure count', () => {
+    const s = {
+      decisiveGames: 120,
+      truncatedGames: 5,
+      decisiveRate: 0.96,
+      poolSize: 8,
+      loadedSnapshots: 30,
+      bookSize: 11,
+      episodeCount: 125,
+      refreshSkips: 2,
+      noSeatBeatGames: 0,
+    };
+    const line = formatDoneLine(125, s, 3);
+    expect(line).toBe(
+      'PPO_ENV_SERVER DONE episodes=125 decisiveGames=120 truncatedGames=5 decisiveRate=0.9600 ' +
+        'poolSize=8 loadedSnapshots=30 bookSize=11 episodeCount=125 refreshSkips=2 ' +
+        'noSeatBeatGames=0 dumpFailures=3'
+    );
+  });
+});
+
+describe('resume loop bounds (task E / PR-1, HOLE-A)', () => {
+  it('resumeStartEpisode reads the league booked-episode count (0 fresh, N resumed)', () => {
+    expect(resumeStartEpisode({ stats: () => ({ episodeCount: 0 }) })).toBe(0);
+    expect(resumeStartEpisode({ stats: () => ({ episodeCount: 42 }) })).toBe(42);
+  });
+
+  it('shouldRunEpisode runs unbounded when episodes=0 (until client disconnect)', () => {
+    expect(shouldRunEpisode(0, 0)).toBe(true);
+    expect(shouldRunEpisode(1_000_000, 0)).toBe(true);
+  });
+
+  it('treats --episodes=N as a run TOTAL: stops at N regardless of where the resume cursor starts', () => {
+    // Fresh run: plays ep 0..99, stops at 100.
+    expect(shouldRunEpisode(99, 100)).toBe(true);
+    expect(shouldRunEpisode(100, 100)).toBe(false);
+    // Resumed at 99 (99 already booked): plays exactly ep 99, then stops — N is the total, not +N more.
+    expect(shouldRunEpisode(99, 100)).toBe(true);
+    // Resume cursor already meets/exceeds the budget → body never runs (clean no-op, not a fresh N).
+    expect(shouldRunEpisode(100, 100)).toBe(false);
+    expect(shouldRunEpisode(150, 100)).toBe(false);
+  });
+});

--- a/tests/ml/ppo-league-persist.test.js
+++ b/tests/ml/ppo-league-persist.test.js
@@ -249,6 +249,24 @@ describe('toJSON / restore — fail-loud gates', () => {
     expect(b.stats().poolSize).toBe(0); // atomic — nothing applied
   });
 
+  it('rethrows a PRESENT-but-broken pooled module on resume instead of dropping it as "weights gone"', async () => {
+    // restore()'s `!existsSync` guard mirrors refresh() (task E / S-1): a pooled snapshot file that
+    // EXISTS but whose own `import` target is missing throws ERR_MODULE_NOT_FOUND — a real bug in a
+    // published artifact, NOT a GC-evicted file — so it must fail loud, not be silently dropped from
+    // the live pool (the asymmetry that existed before the two import paths were harmonized).
+    const manifest = writeManifest([snap(100)]);
+    const a = league(manifest);
+    await a.refresh();
+    const state = a.toJSON();
+    const file = 'snap-777.weights.js';
+    writeFileSync(join(dir, file), "import './does-not-exist.js';\nexport const BC_POLICY = {};\n");
+    state.pool.push({ id: 'snap-broken', step: 777, weightsPath: resolve(dir, file) });
+    state.loadedIds.push('snap-broken');
+    const b = league(manifest);
+    await expect(b.restore(state)).rejects.toThrow(); // present file → guard falls through to rethrow
+    expect(b.stats().poolSize).toBe(0); // atomic — NOT a silent droppedPool skip
+  });
+
   it('rejects a store-backend switch on resume (would silently zero the book)', async () => {
     // A memory-store checkpoint carries the full book; restoring it into a disk-store league (whose book
     // lives in shards) — or the reverse — would wipe the win-rate book. The storeKind gate forbids it.

--- a/tests/ml/ppo-league-persist.test.js
+++ b/tests/ml/ppo-league-persist.test.js
@@ -158,11 +158,55 @@ describe('toJSON / restore — pool reconstruction edge cases', () => {
   });
 });
 
+describe('toJSON / restore — resume seed-cursor (task E / PR-1, HOLE-A)', () => {
+  it('tracks episodeCount as the booked-episode count and round-trips it as the resume cursor', async () => {
+    const a = league(null);
+    record(a, a.draw(0).drawn, { 1: 1 }); // decisive
+    a.recordResult(a.draw(1).drawn, { truncated: true, seatBeat: null }); // truncated (still booked)
+    record(a, a.draw(2).drawn, { 2: 0 }); // decisive
+    const s = a.stats();
+    expect(s.episodeCount).toBe(3);
+    // The invariant the env-server's resume cursor relies on (seed = seedBase + episodeCount).
+    expect(s.episodeCount).toBe(s.decisiveGames + s.truncatedGames);
+
+    const b = league(null);
+    await b.restore(JSON.parse(JSON.stringify(a.toJSON())));
+    expect(b.stats().episodeCount).toBe(3); // the seed-cursor survives the restart
+    // A post-resume booking advances the cursor (resume continues, never replays seed 0..2).
+    record(b, b.draw(3).drawn, { 1: 1 });
+    expect(b.stats().episodeCount).toBe(4);
+  });
+
+  it('persists a nonzero refreshSkips across a restart (run-total health metric)', async () => {
+    // Drive a GC-race skip (the producer GCd a file before this worker loaded it), then prove the
+    // counter carries through toJSON/restore.
+    const f100 = snap(100);
+    const manifest = writeManifest([f100, snap(200), snap(300)]);
+    rmSync(join(dir, f100.weights), { force: true }); // gone before refresh imports it
+    const b = league(manifest);
+    const warn = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    await b.refresh(); // skips the gone snap-100 → refreshSkips = 1
+    warn.mockRestore();
+    expect(b.stats().refreshSkips).toBe(1);
+
+    const c = league(manifest);
+    await c.restore(JSON.parse(JSON.stringify(b.toJSON())));
+    expect(c.stats().refreshSkips).toBe(1);
+  });
+});
+
 describe('toJSON / restore — fail-loud gates', () => {
   it('rejects an unknown checkpoint version without mutating', async () => {
     const b = league(null);
     await expect(b.restore({ version: 999 })).rejects.toThrow(/version/);
     await expect(b.restore(null)).rejects.toThrow(/version/);
+  });
+
+  it('rejects a stale v1 checkpoint (schema bumped to v2 for the resume cursor)', async () => {
+    // B6 (v1) never ran live, but a v1 payload must still fail loud rather than resume with a missing
+    // episodeCount and replay seeds from 0. (restore() back-fills the cursor only for a v2 payload.)
+    const b = league(null);
+    await expect(b.restore({ version: 1 })).rejects.toThrow(/version/);
   });
 
   it('rejects a top-level encodingVersion skew before importing anything', async () => {

--- a/tests/ml/ppo-league-snapshots.test.js
+++ b/tests/ml/ppo-league-snapshots.test.js
@@ -193,6 +193,20 @@ describe('ppo-league snapshots — multi-worker GC race (task E / PR-1 floor)', 
     expect(lg.stats().refreshSkips).toBe(0); // a parse error is not a skip
   });
 
+  it('rethrows ERR_MODULE_NOT_FOUND when the file is PRESENT but a transitive import is missing', async () => {
+    // The `!existsSync` guard (task E / S-1): a present module whose own `import` target is missing
+    // throws ERR_MODULE_NOT_FOUND too — but it is a real bug in a published artifact, NOT a GC race,
+    // so it must rethrow (not get masked as a benign skip just because the error code matches).
+    const manifest = writeManifest([snap(100)]);
+    writeFileSync(
+      join(dir, 'snap-000100.weights.js'),
+      "import './does-not-exist.js';\nexport const BC_POLICY = {};\n"
+    );
+    const lg = league(manifest);
+    await expect(lg.refresh()).rejects.toThrow(); // present file → guard falls through to rethrow
+    expect(lg.stats().refreshSkips).toBe(0); // a missing transitive import is not a GC-race skip
+  });
+
   it('de-dups the manifest by id so a republished id never doubles in the pool', async () => {
     // A producer-resume republish (PR-3 truncates this at the source) could list one id twice with
     // different steps; refresh() must seat it once, not twice (a double weight + double eviction).

--- a/tests/ml/ppo-league-snapshots.test.js
+++ b/tests/ml/ppo-league-snapshots.test.js
@@ -119,33 +119,100 @@ describe('ppo-league snapshots — hot-loading into the pool', () => {
   });
 });
 
-describe('ppo-league snapshots — FIFO eviction + disk GC', () => {
-  it('keeps the most-recent poolCap and GCs the evicted snapshot .js (FIFO by step)', async () => {
+describe('ppo-league snapshots — FIFO trim (disk GC is the producer’s job, task E / PR-3)', () => {
+  it('FIFO-trims the live pool to poolCap but does NOT delete files (consumer never unlinks)', async () => {
     const f100 = snap(100);
     const f200 = snap(200);
     const f300 = snap(300);
     const lg = league(writeManifest([f100, f200, f300]), { poolCap: 2 });
-    expect(await lg.refresh()).toEqual({ added: 3, poolSize: 2 }); // loaded 3, evicted oldest
+    expect(await lg.refresh()).toEqual({ added: 3, poolSize: 2 }); // loaded 3, evicted oldest from pool
 
     expect(lg.stats()).toMatchObject({ poolSize: 2, loadedSnapshots: 3 });
-    expect(existsSync(join(dir, f100.weights))).toBe(false); // step 100 evicted → file GC'd
+    // Disk deletion moved to the single producer (PR-3): a consumer must NOT unlink (it would race N
+    // SubprocVecEnv workers), so every file still exists even though snap-100 left the sampleable pool.
+    expect(existsSync(join(dir, f100.weights))).toBe(true);
     expect(existsSync(join(dir, f200.weights))).toBe(true);
     expect(existsSync(join(dir, f300.weights))).toBe(true);
   });
 
-  it('never re-imports an evicted (GC-deleted) snapshot — the loadedIds guard', async () => {
+  it('never re-imports an evicted snapshot, even after the producer GCs its file (loadedIds guard)', async () => {
     const f100 = snap(100);
     const path = writeManifest([f100, snap(200), snap(300)]);
     const lg = league(path, { poolCap: 2 });
-    await lg.refresh();
-    expect(existsSync(join(dir, f100.weights))).toBe(false); // evicted + deleted
+    await lg.refresh(); // snap-100 evicted from the live pool (still tracked in loadedIds)
+    // The single producer GCs the aged-out file (the consumer no longer does); simulate that here.
+    rmSync(join(dir, f100.weights), { force: true });
 
     /*
-     * Force a re-read (bump mtime, same content). snap-100 is in loadedIds → not re-imported from the
-     * now-missing file, so refresh must not throw and must add nothing.
+     * Force a re-read (bump mtime, same content). snap-100 is in loadedIds → the `fresh` filter
+     * excludes it, so it is never re-imported from the now-missing file: refresh must not throw, add
+     * nothing, and NOT count a skip (the import was never attempted).
      */
     utimesSync(path, ++mtimeTick, mtimeTick);
     expect(await lg.refresh()).toEqual({ added: 0, poolSize: 2 });
+    expect(lg.stats().refreshSkips).toBe(0);
+  });
+});
+
+describe('ppo-league snapshots — multi-worker GC race (task E / PR-1 floor)', () => {
+  it('tolerates a snapshot whose file was GCd before import: warn-skip, mark loaded, no throw', async () => {
+    /*
+     * The multi-worker GC race (task E): the single producer (or, transiently, a peer) deletes a
+     * snapshot's `.js` between publishing the manifest entry and a LAGGING worker importing it. The
+     * lagging worker must skip the dead snapshot (refreshSkips++ + mark it loaded) and load the rest —
+     * never crash a multi-hour run on a benign race.
+     */
+    const f100 = snap(100);
+    const manifest = writeManifest([f100, snap(200), snap(300)]);
+    // The producer published the manifest entry, then aged snap-100's file out — gone before we load it.
+    rmSync(join(dir, f100.weights), { force: true });
+
+    const b = league(manifest, { poolCap: 40 }); // a lagging worker that hasn't loaded snap-100 yet
+    const warn = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    const res = await b.refresh(); // snap-100's file is gone → skipped, not fatal
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+
+    expect(res).toEqual({ added: 2, poolSize: 2 }); // snap-200 + snap-300 loaded
+    expect(b.stats().refreshSkips).toBe(1);
+    expect(b.stats().loadedSnapshots).toBe(3); // snap-100 marked loaded so it is never retried
+    expect(b.stats().poolSize).toBe(2);
+
+    // A later poll (bumped mtime) never retries the dead snap-100 and adds nothing more.
+    utimesSync(manifest, ++mtimeTick, mtimeTick);
+    expect(await b.refresh()).toEqual({ added: 0, poolSize: 2 });
+    expect(b.stats().refreshSkips).toBe(1); // unchanged — snap-100 is in loadedIds now
+  });
+
+  it('still rethrows a non-missing-file import error (a present but broken module is a real bug)', async () => {
+    const manifest = writeManifest([snap(100)]);
+    // Overwrite the snapshot file with a syntax error — import() throws SyntaxError, not ENOENT.
+    writeFileSync(join(dir, 'snap-000100.weights.js'), 'export const = broken syntax;\n');
+    const lg = league(manifest);
+    await expect(lg.refresh()).rejects.toThrow(); // not swallowed by the GC-race ENOENT branch
+    expect(lg.stats().refreshSkips).toBe(0); // a parse error is not a skip
+  });
+
+  it('de-dups the manifest by id so a republished id never doubles in the pool', async () => {
+    // A producer-resume republish (PR-3 truncates this at the source) could list one id twice with
+    // different steps; refresh() must seat it once, not twice (a double weight + double eviction).
+    const f = writeSnapshot(100);
+    const manifest = join(dir, 'manifest.json');
+    writeFileSync(
+      manifest,
+      JSON.stringify({
+        encodingVersion: 2,
+        snapshots: [
+          { id: 'snap-dup', step: 100, weights: f },
+          { id: 'snap-dup', step: 200, weights: f },
+        ],
+        latestStep: 200,
+      })
+    );
+    utimesSync(manifest, ++mtimeTick, mtimeTick);
+    const lg = league(manifest);
+    expect(await lg.refresh()).toEqual({ added: 1, poolSize: 1 });
+    expect(lg.stats().loadedSnapshots).toBe(1);
   });
 });
 


### PR DESCRIPTION
## What

The locally-verifiable foundation for Phase-3 **task C/E** (SubprocVecEnv + shodan training-ops), per the design in **[D-26]** (13-agent design workflow: 4 readers → 3 design takes → synthesize → 4 adversarial verifiers → finalize). Task B (the PFSP league) is feature-complete; this is the first of the C/E slices.

Three slices in one PR (PR-1 and PR-3's Node halves are entangled in `ppo-league.mjs`, so they ship together):

- **PR-1 — Node crash-safety + resume hardening** (`scripts/lib/ppo-league.mjs`, `scripts/ppo-env-server.mjs`)
  - `episodeCount` **resume seed-cursor** (persisted/restored/in `stats()`); the env-server loop now starts at it, so a relaunch continues the seed sequence instead of replaying from 0 and re-booking outcomes (silent double-count — **HOLE-A**).
  - `refresh()` **GC-race floor**: a lagging worker tolerates a peer-evicted snapshot file (warn + mark loaded + `refreshSkips++`), dedups `fresh` by id, and rethrows non-missing import errors.
  - `dumpLeagueState` flipped to **state-then-flush** (**HOLE-B**: turns a crash-window disk-book double-count into bounded loss).
  - `STATE_SCHEMA_VERSION` 1→2; DONE health summary mirrored to **stderr** (env.py drops stdout).
- **PR-2 — Python B6 flag forwarding** (`ml/dicewars_ppo/env_server.py`): `EnvServerProcess` forwards `snapshot_store` / `league_state_dir` / `league_dump_every` to argv on their own (manifest-independent) gate; byte-identical when unset.
- **PR-3 — single-writer snapshot GC + resume rehydration**: removed the consumer `unlinkSync` (deletion is now the single producer's job); new torch-free `ml/dicewars_ppo/snapshot_manifest.py` (`rehydrate_snapshots` + `gc_partition`); `SnapshotCallback` rehydrates a prior manifest minus entries ahead of the resumed step (**HOLE-C**) and GCs aged files after truncating the manifest.

## Headline decision (D-26)

**VecNormalize is dropped** — it would corrupt our Dict-obs encoding contract (standardizes the int `edge_from`/`edge_to` keys, `ValueError`s on the `edge_mask` MultiBinary, breaks the masked-mean pool) and is pointless on a `{0,1}`/γ=0.999 return. This **reverses the PLAN's literal "checkpoint…VecNormalize…" wording**; confirmed with the maintainer.

## Verification

- Full JS suite **1147 passing** (+6 new league tests), `npm run build` + eslint + prettier clean.
- Torch-free Python tiers green: `test_snapshot_manifest.py` (12), `test_env_server_argv.py` (6); ruff + py_compile clean.
- ⚠️ This dev box has no torch/sb3 (the ml venv is shodan-only), so the **torch-gated** `test_snapshot_callback.py` (updated for the new GC/rehydration + `_write_manifest_atomic(entries)` signature) and the live SubprocVecEnv paths run **on shodan** (PR-4+). The GC/rehydration math is mirrored in the torch-free `test_snapshot_manifest.py`.

## Not in this PR (remaining task C/E)

PR-4 `train.py` + `_train_common.py` (SubprocVecEnv(forkserver) + VecMonitor + TB/CSV + `--from-scratch`) · PR-5 checkpoint/resume core (incl. **HOLE-D** budget fix) · PR-6 committed `scripts/shodan/ppo-train.sh` + schtasks runbook · PR-7 deferred test-hardening. Then the long BEAT run at R=3, gated by `npm run ppo:gate` vs `ai_lookahead@596f781`.

See `docs/ml-bot/DECISIONS.md` (D-26) + `PLAN.md` task C/E + `LOG.md`.