### PR TITLE
feat(ml): Phase-3 task C/E PR-4 — train.py + torch-free _train_common (SubprocVecEnv + TB/CSV + --from-scratch)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,8 @@ DiceWarsJS is a turn-based strategy game where players compete to conquer territ
   - ai_adaptive: Adapts strategy based on game conditions
   - ai_strategist: Expected-value strategy using exact dice odds and connectivity economics (strongest in arena benchmarks; authored by Claude Opus 4.8)
   - ai_lookahead: Standalone shallow-expectimax search over win/loss branches with board-value evaluation (authored by GPT-5.5)
+  - ai_expectimax: Chance-node expectimax over the exact battle distribution — the "search-first" ML-bot baseline (docs/ml-bot/), at parity with ai_lookahead
+  - ai_bc: Behavioral-cloning net that imitates ai_lookahead, running in-browser via a pure-JS forward pass (bcForward.js) over exported weights (bcPolicyWeights.js); ml-bot Phase 2
 
 - **Bot Arena** (src/arena/): Headless bot-vs-bot tournament system — ELO ratings (elo.js), match/tournament runners, custom-bot compilation & validation, replay format. Powers `npm run arena`, the in-game Arena screen, and the CLI bot tooling. See docs/BOT_GUIDE.md for authoring a bot (a function: state → { from, to } | null).
 
@@ -133,6 +135,15 @@ DiceWarsJS is a turn-based strategy game where players compete to conquer territ
 - **Map Generation** (src/engine/MapGenerator.js): Creates the hexagonal grid and territories.
 
 - **Battle Resolution** (src/engine/BattleResolver.js): Handles attack resolution and dice distribution.
+
+### ML / Self-Play Bot Pipeline (`ml/`, `docs/ml-bot/`)
+
+An active, multi-session effort to produce an ML/self-play bot stronger than `ai_lookahead`. **Read `docs/ml-bot/README.md` first** (then PLAN/DECISIONS/LOG/RESULTS) — that folder is the source of truth for status and decisions, not this file.
+
+- **`ml/`**: in-repo Python/PyTorch trainers — `dicewars_bc` (behavioral cloning, Phase 2) and `dicewars_ppo` (PPO league, Phase 3). Has its own `pyproject.toml`, `requirements.txt`, and `ml/tests/` (pytest). Training runs on the GPU box `shodan`; a CPU box is fine for the dev loop.
+- **Encoding contract** (lives in-repo so JS and trainer stay versioned together): `src/arena/encodeObservation.js` + `ENCODING_VERSION` + the corpus `manifest.json`. The JS encoder and the Python trainer that consumes it **must change in the same commit**.
+- **Exported weights** loaded by in-browser bots: `src/ai/bcPolicyWeights.js` (BC) and `src/ai/ppoPolicyWeights.js` (PPO). Distinct files — don't confuse them.
+- **Pipeline scripts**: `npm run selfplay` (JSONL corpus) → `npm run encode-corpus` (packed tensors) → train in `ml/` → `npm run ppo:export` (ckpt → weights). PPO RL loop driven by `npm run ppo:env-server` (+ `ppo:env-smoke`, `ppo:throughput-probe`, `ppo:league-probe`, `ppo:gate`).
 
 ### Important Design Patterns
 
@@ -180,6 +191,7 @@ The full suite forks many workers; running several copies at once can exhaust RA
 - **Husky pre-commit hook**: Runs `lint-staged` automatically — `eslint --fix` + `prettier --write` on staged `.js`/`.jsx`/`.mjs` files, and `prettier --write` on staged `.json`/`.md`/`.yml`/`.yaml` files. Note it formats Markdown too, but it has occasionally failed to fully normalize a `.md` file (e.g. a multi-line inline-code span), so if CI's `format:check` (`prettier --check .`) flags a doc, run `npx prettier --write <file>` yourself.
 - **Vitest globals**: Tests use `globals: true` in vitest config, so `describe`, `it`, `expect`, `vi`, `beforeEach`, `afterEach` are available without imports. Use `import { vi } from 'vitest'` only if needed for explicit typing.
 - **Test environment is `node` by default**: To keep memory down, the suite runs under the lightweight Node environment, not jsdom. A test that touches `document`, `window`, `localStorage`, canvas, or renders a Preact component must declare `// @vitest-environment jsdom` as the first line of the file, or it will fail with `X is not defined`.
+- **JS↔Python encoding contract**: `src/arena/encodeObservation.js` feeds the `ml/` trainers. Any change to feature columns/order must bump `ENCODING_VERSION` and land alongside the matching trainer change in one commit, or the trained net silently mismatches the live observation.
 
 ## Common Pitfalls to Avoid
 

--- a/docs/ml-bot/DECISIONS.md
+++ b/docs/ml-bot/DECISIONS.md
@@ -1513,21 +1513,42 @@ resumed snapshot producer republished ids ahead of the resumed step → rehydrat
 `step <= num_timesteps`; **HOLE-D** `reset_num_timesteps=False` makes a fixed `--timesteps` additive (a
 crash-loop trains unbounded) → `remaining = max(timesteps − num_timesteps, 0)` (task-E).
 
-**Build sequence (PR slices).** PR-1 Node crash-safety + GC-race floor + resume hardening (DONE) · PR-2
-`EnvServerProcess` B6-flag forwarding (DONE) · PR-3 SnapshotCallback rehydration + single-writer producer
-GC, consumer `unlinkSync` removed (DONE) · PR-4 `_train_common.py` + `train.py` (SubprocVecEnv + VecMonitor
+**Build sequence (PR slices).** PR-1 Node crash-safety + GC-race floor + resume hardening (DONE, #70) ·
+PR-2 `EnvServerProcess` B6-flag forwarding (DONE, #70) · PR-3 SnapshotCallback rehydration + single-writer
+producer GC, consumer `unlinkSync` removed (DONE, #70) · PR-4 `_train_common.py` + `train.py`
+(SubprocVecEnv + VecMonitor
 
-- TB/CSV + `--from-scratch`) · PR-5 idempotent checkpoint/resume core · PR-6 committed shodan launcher +
-  schtasks runbook · PR-7 deferred test-hardening (env-server `main()` persistence integration test; live
-  cross-worker `SharedDiskStore`).
+- TB/CSV + `--from-scratch`) (DONE locally) · PR-5 idempotent checkpoint/resume core · PR-6 committed
+  shodan launcher + schtasks runbook · PR-7 deferred test-hardening (env-server `main()` persistence
+  integration test; live cross-worker `SharedDiskStore`).
 
-**Status: IN PROGRESS — foundation PR-1→PR-3 landed locally (branch `ml-bot/task-ce-foundation`).** PR-1:
+**Status: IN PROGRESS — foundation PR-1→PR-3 MERGED (#70); PR-4 DONE locally (branch `ml-bot/task-ce-pr4-train`). Next: PR-5 resume core.** PR-1:
 `episodeCount` resume-cursor, `dumpLeagueState` state-then-flush order, `refresh()` ENOENT-tolerance +
 id-dedup + `refreshSkips` health counter (stderr DONE mirror), schema v1→v2. PR-2: `snapshot_store` /
 `league_state_dir` / `league_dump_every` forwarded by `EnvServerProcess` on their own gate (manifest-
 independent), byte-identical when unset. PR-3: NEW torch-free `snapshot_manifest.py` (`rehydrate_snapshots`
 
 - `gc_partition`); `SnapshotCallback` rehydrates on resume + GCs as the single disk writer; the consumer
-  no longer unlinks. Local verification: `tests/ml/` 196 green, the torch-free Python tiers green
-  (`test_snapshot_manifest.py` 12, `test_env_server_argv.py` 6), eslint + ruff clean. The torch-gated
-  callback tests + the live SubprocVecEnv/shodan paths are verified on shodan (PR-4+).
+  no longer unlinks. Verification: `tests/ml/` 196 green, the torch-free Python tiers green
+  (`test_snapshot_manifest.py` 12, `test_env_server_argv.py` 6), eslint + ruff clean. **Foundation
+  PR-1→PR-3 MERGED as PR #70 (`97de4e4`).**
+
+**PR-4 (DONE locally, branch `ml-bot/task-ce-pr4-train`).** New torch-free `_train_common.py` holds the
+shared env-thunk (`_make_env_thunk`), CLI surface (`build_parser(description)`), validation
+(`_validate_args`), and `resolve_from_scratch` (the `--from-scratch`↔`--freeze-trunk` mutex + per-mode
+LR/ent-coef relaxation via a `None` sentinel); `train_tracer.py` re-imports them and is byte-identical
+(`build_model` gained `venv=None` + a from-scratch warm-start gate that is always-off for the tracer).
+New `train.py` = `VecMonitor(SubprocVecEnv(start_method=forkserver))` built BEFORE `MaskablePPO` (Q4) +
+`set_logger(configure(--log-dir, [stdout,csv,tensorboard]))` before `learn` + `--no-tensorboard`
+
+- provenance (`from_scratch`/`warm_started_from`) in the repack. `tensorboard>=2.12` added to `[rl]`;
+  HOLE-D left as an explicit `TODO(PR-5)` (fresh runs only, `reset_num_timesteps=True`); B6 persistence
+  flags + CSV cross-session append + the live forkserver smoke deferred (PR-5/PR-7). Reviewed by a
+  6-dimension adversarial workflow → **SHIP-AFTER-FIXES, 0 blockers**; all 6 minor findings folded —
+  chief among them the env-thunk had captured the torch-ful `ModelConfig` (a forkserver/spawn worker
+  would import torch on unpickle, defeating Q4's whole point), fixed by hoisting `max_areas`/
+  `player_count` to locals so the closure captures only primitives + the stdlib Namespace
+  (cloudpickle-proven: no `dicewars_bc`/`ModelConfig`/`torch` in the serialized env-fn). ruff clean;
+  lean torch-free tier (`test_train_common_args.py`, incl. a closure-capture guard) + gated torch/sb3
+  tier (`test_train_args.py` build_model/logging/wrap-order, `test_train_tracer_args.py` re-export
+  wiring) green. The torch-gated tests + the live SubprocVecEnv/shodan paths run on shodan.

--- a/docs/ml-bot/LOG.md
+++ b/docs/ml-bot/LOG.md
@@ -21,6 +21,70 @@ Entry template:
 
 ---
 
+## 2026-06-27 — Task C/E PR-4 — `train.py` + torch-free `_train_common.py` (SubprocVecEnv + TB/CSV + `--from-scratch`)
+
+**Phase:** 3 · **Who:** Ivan + Claude
+
+**Did:**
+
+- **Built PR-4** ([D-26] build sequence; branch `ml-bot/task-ce-pr4-train` off master @ PR #70 `97de4e4`).
+  Grounded it with a **6-reader understand+readiness workflow** (synthesis confirmed the PR-1→3
+  foundation is consistent, HOLE-A/B/C implemented + HOLE-D correctly deferred, B6 flags opt-in/
+  byte-identical when unset), then implemented:
+  - NEW torch-free `ml/dicewars_ppo/_train_common.py`: shared `DEFAULT_OPPONENTS`, `_make_env_thunk`,
+    `build_parser(description)`, `_validate_args`, and `resolve_from_scratch` (the `--from-scratch`↔
+    `--freeze-trunk` mutex + per-mode LR/ent-coef relaxation via a `None` sentinel). `ModelConfig` kept
+    `TYPE_CHECKING`-only under `from __future__ import annotations` so the module is torch/sb3-free.
+  - `train_tracer.py` re-imports them and is **byte-identical** (`build_model` gained `venv=None` +
+    a from-scratch warm-start gate that is always-off for the tracer, which has no such flag).
+  - NEW `ml/dicewars_ppo/train.py`: the real driver — `VecMonitor(SubprocVecEnv(start_method=forkserver))`
+    constructed BEFORE `MaskablePPO` ([D-26] Q4: CUDA inits at model construction, after the env fork);
+    `set_logger(configure(--log-dir, [stdout,csv(,tensorboard)]))` before `learn`; `--no-tensorboard`;
+    provenance (`from_scratch`/`warm_started_from`) in the repack; `--start-method` (forkserver/spawn/fork).
+  - `tensorboard>=2.12` → `[rl]` (not `[dev]`; lean CI unaffected). HOLE-D left as an explicit
+    `TODO(PR-5)` (fresh runs only, `reset_num_timesteps=True`).
+- **Adversarially reviewed** with a 6-dimension verify-each-finding workflow → **SHIP-AFTER-FIXES, 0
+  blockers**. Folded all 6 minor findings.
+
+**Learned / decided:**
+
+- **The load-bearing torch-free fix.** The env-thunk closure originally captured `cfg` (the torch-ful
+  `ModelConfig`), so a `SubprocVecEnv(forkserver/spawn)` worker would import torch on cloudpickle-unpickle
+  — silently defeating the whole point of the extraction ([D-26] Q4) even though the module _imported_
+  torch-free. Fix: hoist `max_areas`/`player_count` to locals before the closure so it captures only
+  primitives + the stdlib Namespace. **Cloudpickle-proven** with a real `ModelConfig`: no
+  `dicewars_bc`/`ModelConfig`/`torch` bytes in the serialized env-fn. Added a lean-tier closure-capture
+  guard (`'cfg' not in co_freevars` + a primitive-only allowlist) so this can't regress.
+- **HP defaults for `train.py` (decision, reversible):** warm-start keeps the protective tracer defaults
+  (lr 1e-4 / ent 0.0); `--from-scratch` relaxes to lr 1e-3 / ent 0.01. The task-A BEAT config
+  (`--lr 2.5e-4 --ent-coef 0.01`) is NOT baked as a default — production HPs belong to the PR-6 launcher,
+  not a stale magic number in the driver.
+- **`tensorboard` is a HARD import for SB3's TB sink** (it RAISES, not no-ops, when absent). `train.py`
+  degrades to CSV-only + a loud WARNING if it's missing, so a long run never dies on a partial env.
+
+**Dead ends / surprises:**
+
+- One understand-workflow reader audited the wrong file (the BC `dicewars_bc/train.py`, not the PPO
+  tracer); the synthesis caught and discarded its file-specific claims. The review's own suggested
+  closure-test (`SimpleNamespace` + type-module check) would have **false-passed** — the verifier flagged
+  it, so the committed guard uses a primitive allowlist + a `co_freevars` check instead.
+- Local box is Python 3.9 (project targets 3.10+); validated via two throwaway venvs (lean: gymnasium-only,
+  no torch; gated: system-torch + sb3-contrib 2.7.1). The 6 `export_onnx` failures are a pre-existing 3.9
+  `zip(strict=)` incompat in an untouched file, not PR-4.
+
+**Verification:** ruff clean; 29 lean torch-free tests + 114 gated/ppo tests green; both CLIs compose;
+tracer parser surface confirmed unchanged; cloudpickle torch-free proof.
+
+**Next:**
+
+- PR-5: idempotent checkpoint/resume core (policy + optimizer + `num_timesteps` + RNG + league pool/book;
+  `reset_num_timesteps=False` + `remaining=max(timesteps−num_timesteps,0)` for HOLE-D; CSV cross-session
+  append; wire the B6 `--snapshot-store`/`--league-state-dir`/`--league-dump-every` flags into `train.py`).
+- PR-6: committed shodan launcher + schtasks runbook (owns the production HPs). PR-7: live SubprocVecEnv
+  (forkserver) smoke + env-server `main()` persistence integration test.
+
+---
+
 ## 2026-06-27 — Task C/E foundation — PR #70 review-hardening (4-agent review)
 
 **Phase:** 3 · **Who:** Ivan + Claude

--- a/docs/ml-bot/PLAN.md
+++ b/docs/ml-bot/PLAN.md
@@ -538,20 +538,31 @@ ppo:gate` over **3040 seat-fair games**: PPO **11.5 ± 1.3%** vs Lookahead **15.
   VecNormalize wording below); two-half idempotent resume (Python SB3 half + Node league half),
   bounded-skew not bit-exact; `SubprocVecEnv(forkserver)` + `VecMonitor` in the parent; consumer
   ENOENT-tolerance then producer-single-writer GC; `--from-scratch` control. **Foundation PR-1→PR-3
-  landed locally** (branch `ml-bot/task-ce-foundation`): Node crash-safety + GC-race floor +
-  `episodeCount` resume-cursor (PR-1); `EnvServerProcess` B6-flag forwarding (PR-2); SnapshotCallback
-  rehydration + single-writer producer GC, consumer `unlinkSync` removed (PR-3). `tests/ml/` 196 +
-  torch-free Python tiers green; eslint + ruff clean.
-- [ ] **(C)** Scale envs across cores; add the short **from-scratch control** run ([D-19] decision 1).
-      _Lands in PR-4/PR-5 (`train.py`: `SubprocVecEnv(forkserver)` + `--from-scratch`); see [D-26]._
+  MERGED (PR #70, `97de4e4`):** Node crash-safety + GC-race floor + `episodeCount` resume-cursor (PR-1);
+  `EnvServerProcess` B6-flag forwarding (PR-2); SnapshotCallback rehydration + single-writer producer
+  GC, consumer `unlinkSync` removed (PR-3). **PR-4 landed locally** (branch `ml-bot/task-ce-pr4-train`):
+  new torch-free `_train_common.py` (shared env-thunk/parser/validation + `resolve_from_scratch`) reused
+  by a byte-identical `train_tracer.py`; new `train.py` = `VecMonitor(SubprocVecEnv(forkserver))` +
+  TensorBoard/CSV logging + `--from-scratch`; `tensorboard` added to `[rl]`. Adversarially reviewed
+  (6-dimension workflow, SHIP-AFTER-FIXES → all 6 minor findings folded, incl. the load-bearing
+  thunk-capture fix that makes the torch-free-worker invariant genuinely true — cloudpickle-proven).
+  ruff clean; lean torch-free tier + gated torch/sb3 tier green.
+- [~] **(C)** Scale envs across cores; add the short **from-scratch control** run ([D-19] decision 1).
+  **PR-4 landed locally** (branch `ml-bot/task-ce-pr4-train`): `train.py` swaps `DummyVecEnv` →
+  `VecMonitor(SubprocVecEnv(start_method=forkserver))` (env fork before `MaskablePPO`/CUDA init)
+  and adds the `--from-scratch` flag (mutex with `--freeze-trunk`, relaxed LR/ent-coef, provenance
+  stamped). _Still open: the actual cross-core scaling validation + the short from-scratch control
+  RUN itself — both need shodan + [rl]; the wiring is in place. See [D-26]._
 - [ ] **(D)** Add **annealed potential-based reward shaping** (Δlargest-group/territory/dice/elims,
       `F = γΦ(s′)−Φ(s)`, env-side in JS) only if terminal-only learning is too slow.
 - [ ] **(E) shodan training-ops (prerequisite for the long BEAT run):** schtasks-wrapped WSL launch
       (the only disconnect-surviving pattern); idempotent checkpoint/resume of policy + optimizer +
       RNG + step + league pool/book (**NOT VecNormalize** — dropped per [D-26]); TensorBoard + a flat
       CSV that survives sessions; swap `DummyVecEnv` → `SubprocVecEnv` for real cross-core parallelism.
-      _Remaining slices: PR-4 (`train.py` + TB/CSV), PR-5 (checkpoint/resume core), PR-6 (committed
-      shodan launcher + schtasks runbook), PR-7 (deferred test-hardening). See [D-26]._
+      _Slices: **PR-4 `train.py` + TB/CSV + SubprocVecEnv + `--from-scratch` — landed locally** (branch
+      `ml-bot/task-ce-pr4-train`; the cross-session CSV append is explicitly PR-5's resume seam, not
+      PR-4's), PR-5 (checkpoint/resume core), PR-6 (committed shodan launcher + schtasks runbook),
+      PR-7 (deferred test-hardening). See [D-26]._
 
 **Acceptance criteria.**
 

--- a/ml/dicewars_ppo/_train_common.py
+++ b/ml/dicewars_ppo/_train_common.py
@@ -1,0 +1,256 @@
+"""Torch-free shared core for the PPO training drivers (``train_tracer`` + ``train``).
+
+This module holds the pieces that BOTH the tiny tracer (``train_tracer.py``) and the
+real training driver (``train.py``) share: the fixed baseline field, the per-env
+factory (``_make_env_thunk``), the common argparse surface (``build_parser``), the
+argument validation (``_validate_args``), and the ``--from-scratch`` resolution
+helper (``resolve_from_scratch``). One source of truth keeps the green CI tracer
+byte-identical to before the extraction ([D-26] Q1).
+
+**Why torch-free is load-bearing.** ``train.py`` runs envs under
+``SubprocVecEnv(start_method="forkserver")``: each worker process imports the module
+that owns the pickled env-thunk (this one). If anything here pulled in ``torch`` /
+``sb3_contrib`` at import time, every env worker would drag the whole learner stack
+into its address space — defeating the forkserver/CUDA-after-fork safety ([D-26] Q4)
+and bloating each worker. So this module imports ONLY argparse / math / pathlib /
+``.env`` (which is itself torch-free), and the ``cfg: ModelConfig`` annotation is kept
+lazy via ``from __future__ import annotations`` + a ``TYPE_CHECKING`` import — the
+string annotation is never evaluated at runtime, so ``dicewars_bc.model`` (torch-ful)
+is never imported here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .env import DiceWarsEnv
+
+if TYPE_CHECKING:  # annotation-only; never imported at runtime (keeps this module torch-free)
+    from dicewars_bc.model import ModelConfig
+
+# Fixed, seed-pure, heterogeneous baseline field ([D-15]: strong bots in every game
+# keep it decisive; no Math.random bots so episodes stay reproducible). resolveOpponents
+# cycles this list to fill the (player_count - 1) opponent seats.
+DEFAULT_OPPONENTS = "ai_lookahead,ai_strategist,ai_expectimax,ai_bc,ai_defensive"
+
+
+def _make_env_thunk(cfg: ModelConfig, args: argparse.Namespace, env_index: int):
+    """A zero-arg env factory for ``DummyVecEnv``/``SubprocVecEnv`` — each launches an env-server.
+
+    The env's ``player_count`` MUST equal the BC config's (the players-tensor height the
+    obs frame carries; ``_check_dims`` rejects a mismatch), so it's taken from ``cfg``,
+    not a free flag. Each env gets a disjoint ``seed_base`` block so parallel envs don't
+    replay identical episodes — and, because each Node worker keys its persistence files
+    on ``seedBase`` (``league-state-<seedBase>.json``), the same offset also keeps those
+    per-worker files distinct under ``SubprocVecEnv``.
+    """
+
+    # Hoist the two scalars the thunk needs OUT of cfg before building the closure. This is the
+    # load-bearing detail behind the torch-free invariant: a SubprocVecEnv(forkserver/spawn) worker
+    # cloudpickles this closure and unpickles it in the child. If the closure captured `cfg` (a
+    # torch-ful ``dicewars_bc.model.ModelConfig`` dataclass), the child would import that module —
+    # and torch with it — on unpickle, defeating the whole point of [D-26] Q4. Capturing only ints
+    # (+ the stdlib Namespace + str/None below) keeps the worker's env_fn genuinely torch-free.
+    max_areas = cfg.max_areas
+    player_count = cfg.player_count
+
+    # All vec-env servers poll the SAME producer manifest, so they share one snapshot pool ([D-22]).
+    # `snapshot_dir` is resolved absolute in _validate_args so producer (this process) and consumers
+    # (the Node servers, cwd=repo-root) agree on the path regardless of cwd.
+    snapshot_manifest = (
+        str(Path(args.snapshot_dir) / "manifest.json") if args.snapshot_dir else None
+    )
+
+    def _thunk() -> DiceWarsEnv:
+        return DiceWarsEnv(
+            max_areas=max_areas,
+            player_count=player_count,
+            server_kwargs={
+                "opponents": args.opponents,
+                "max_turns": args.max_turns,
+                "learner_seat": args.learner_seat,
+                "seed_base": args.seed_base + env_index * 1_000_000,
+                "snapshot_manifest": snapshot_manifest,
+                "snapshot_pool_cap": args.snapshot_pool_cap,
+                "reserve_baselines": args.reserve_baselines,
+                "pfsp_epsilon": args.pfsp_epsilon,
+                "pfsp_k": args.pfsp_k,
+            },
+        )
+
+    return _thunk
+
+
+def build_parser(description: str | None = None) -> argparse.ArgumentParser:
+    """The argparse surface shared by both drivers.
+
+    ``description`` is threaded so each caller's ``--help`` shows ITS module docstring
+    (the tracer passes its ``__doc__``, ``train.py`` passes its own) — the parser body
+    is identical otherwise. ``train.py`` extends the returned parser with its own flags
+    (``--from-scratch`` / ``--log-dir`` / …) and overrides a few defaults via
+    ``set_defaults``; the tracer uses it as-is, so its argv behavior is byte-identical to
+    before the extraction.
+    """
+    p = argparse.ArgumentParser(
+        description=description, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument(
+        "--checkpoint",
+        default="checkpoints/v2-base/bc_model.pt",
+        help="v2-BC checkpoint to warm-start from (the deployed ai_bc).",
+    )
+    p.add_argument(
+        "--out", default="checkpoints/ppo-tracer.pt", help="Repacked BC-format output .pt"
+    )
+    p.add_argument("--opponents", default=DEFAULT_OPPONENTS, help="CSV of fixed baseline bot ids")
+    p.add_argument("--learner-seat", type=int, default=0, help="Seat the learner occupies")
+    p.add_argument(
+        "--n-envs", type=int, default=1, help="Parallel DummyVecEnv envs (1-2 for a tracer)"
+    )
+    # Budget — kept tiny: total_timesteps / (n_steps * n_envs) = number of PPO updates.
+    p.add_argument(
+        "--timesteps", type=int, default=2048, help="Total env steps (a handful of updates)"
+    )
+    p.add_argument(
+        "--n-steps", type=int, default=512, help="Rollout length per env before each update"
+    )
+    p.add_argument(
+        "--batch-size", type=int, default=128, help="Minibatch (must divide n_steps*n_envs)"
+    )
+    p.add_argument("--n-epochs", type=int, default=4, help="PPO epochs per rollout")
+    # Low LR by default so a short run can't wreck the warm-started actor ([D-19] decision 1).
+    p.add_argument(
+        "--lr", type=float, default=1e-4, help="Learning rate (low; protects the warm start)"
+    )
+    p.add_argument(
+        "--gamma", type=float, default=0.999, help="Discount (high: sparse terminal-win signal)"
+    )
+    p.add_argument("--gae-lambda", type=float, default=0.95)
+    p.add_argument(
+        "--ent-coef", type=float, default=0.0, help="Entropy bonus (0 keeps the warm start stable)"
+    )
+    p.add_argument("--vf-coef", type=float, default=0.5)
+    p.add_argument(
+        "--freeze-trunk",
+        action="store_true",
+        help="Freeze the BC trunk+edge_head (train the fresh critic only; actor unchanged).",
+    )
+    p.add_argument("--max-turns", type=int, default=500, help="Stalemate cap (→ Gym truncation)")
+    p.add_argument("--seed", type=int, default=0, help="PPO/torch seed")
+    p.add_argument("--seed-base", type=int, default=1, help="Env-server episode seed base")
+    p.add_argument("--device", default="cpu", help="torch device (cpu is fine — the net is tiny)")
+    # PFSP snapshots (B3 / [D-22]). --snapshot-dir off ⇒ fixed-field (task A) empty-pool mode.
+    p.add_argument(
+        "--snapshot-dir",
+        default=None,
+        help="Publish snapshots (weights + manifest.json) here for the league to hot-load; "
+        "unset ⇒ fixed-field (no PFSP).",
+    )
+    p.add_argument(
+        "--snapshot-every",
+        type=int,
+        default=50_000,
+        help="Snapshot cadence in total env steps (only used with --snapshot-dir).",
+    )
+    p.add_argument(
+        "--snapshot-pool-cap",
+        type=int,
+        default=40,
+        help="Max snapshots the env-server league holds live (FIFO-by-step; forwarded).",
+    )
+    # PFSP sampler knobs (B4 / [D-23]). Only bite with --snapshot-dir (a non-empty pool); forwarded
+    # to the env-server league's draw(). w(S) = max(eps, 1 - learnerWinRate(S)) ** k.
+    p.add_argument(
+        "--reserve-baselines",
+        type=int,
+        default=3,
+        help="R baselines reserved per drawn field (turtle-equilibrium defense; distinct non-ai_bc "
+        "ids, no-replacement). Only used with --snapshot-dir.",
+    )
+    p.add_argument(
+        "--pfsp-epsilon",
+        type=float,
+        default=0.05,
+        help="PFSP weight floor eps in (0, 1] for w(S)=max(eps,1-winRate)**k. Only used with "
+        "--snapshot-dir.",
+    )
+    p.add_argument(
+        "--pfsp-k",
+        type=float,
+        default=2.0,
+        help="PFSP weight exponent k (>= 0) for w(S)=max(eps,1-winRate)**k. Only used with "
+        "--snapshot-dir.",
+    )
+    return p
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    rollout = args.n_steps * args.n_envs
+    if rollout % args.batch_size != 0:
+        raise SystemExit(
+            f"--batch-size {args.batch_size} must divide n_steps*n_envs = {rollout} "
+            f"(n_steps={args.n_steps}, n_envs={args.n_envs})."
+        )
+    if args.n_envs < 1:
+        raise SystemExit("--n-envs must be >= 1.")
+    if not Path(args.checkpoint).is_file():
+        raise SystemExit(f"--checkpoint not found: {args.checkpoint}")
+    # PFSP knobs (B4): validate UNCONDITIONALLY. In fixed-field mode (no --snapshot-dir) these
+    # knobs are NOT forwarded to the env-server — env_server.py only appends them on the snapshot
+    # branch — so Node never sees or validates the Python-supplied value. That makes THIS check the
+    # sole guard there; without it a bad value would be silently dropped (Node falls back to its own
+    # defaults). The bounds mirror the Node makeLeague guards so the two layers stay consistent when
+    # the knobs ARE forwarded; math.isfinite mirrors Number.isFinite so inf/nan fail here.
+    if args.reserve_baselines < 0:
+        raise SystemExit("--reserve-baselines must be >= 0.")
+    if not 0.0 < args.pfsp_epsilon <= 1.0:
+        raise SystemExit("--pfsp-epsilon must be in (0, 1].")
+    if not math.isfinite(args.pfsp_k) or args.pfsp_k < 0:
+        raise SystemExit("--pfsp-k must be a finite number >= 0.")
+    if args.snapshot_dir is not None:
+        if args.snapshot_every <= 0:
+            raise SystemExit("--snapshot-every must be > 0 when --snapshot-dir is set.")
+        if args.snapshot_pool_cap <= 0:
+            raise SystemExit("--snapshot-pool-cap must be > 0.")
+        # Absolutize so the producer (this process) and the Node consumers (cwd=repo-root)
+        # resolve the same manifest path; create it now so env-servers can stat() it from ep 0.
+        args.snapshot_dir = str(Path(args.snapshot_dir).resolve())
+        Path(args.snapshot_dir).mkdir(parents=True, exist_ok=True)
+
+
+def resolve_from_scratch(args: argparse.Namespace) -> None:
+    """Resolve ``--from-scratch`` interactions for ``train.py`` (a no-op for the tracer).
+
+    Two things happen here, both torch-free so the lean CI tier can test them:
+
+    1. **Mutual exclusivity.** ``--from-scratch`` (skip the BC warm-start) and
+       ``--freeze-trunk`` (train the critic only, actor frozen at the warm start) are
+       contradictory — there is no warm start to freeze — so the pair is rejected.
+
+    2. **Per-mode LR / entropy relaxation ([D-26] Q6).** ``train.py`` sets ``--lr`` and
+       ``--ent-coef`` defaults to ``None`` (a sentinel) so an OMITTED flag relaxes per
+       mode while an EXPLICIT ``--lr`` / ``--ent-coef`` always sticks — argparse can't
+       distinguish an explicit value that happens to equal the default from an omission,
+       hence the sentinel. A from-scratch net has no BC prior to protect, so it gets a
+       higher LR and a non-zero entropy bonus to explore; a warm start keeps the
+       protective low defaults. These are intentionally conservative smoke/control values;
+       a production learning run passes explicit HPs (the committed launcher / runbook in
+       PR-6 owns the per-run values — e.g. task A's BEAT config used ``--lr 2.5e-4
+       --ent-coef 0.01``).
+
+    The tracer never carries ``from_scratch`` and never calls this, so its numeric
+    ``--lr``/``--ent-coef`` defaults stand untouched (byte-identical).
+    """
+    from_scratch = getattr(args, "from_scratch", False)
+    if from_scratch and getattr(args, "freeze_trunk", False):
+        raise SystemExit(
+            "--from-scratch and --freeze-trunk are mutually exclusive: there is no warm-started "
+            "trunk to freeze when training from scratch."
+        )
+    if getattr(args, "lr", None) is None:
+        args.lr = 1e-3 if from_scratch else 1e-4
+    if getattr(args, "ent_coef", None) is None:
+        args.ent_coef = 0.01 if from_scratch else 0.0

--- a/ml/dicewars_ppo/_train_common.py
+++ b/ml/dicewars_ppo/_train_common.py
@@ -10,9 +10,11 @@ byte-identical to before the extraction ([D-26] Q1).
 **Why torch-free is load-bearing.** ``train.py`` runs envs under
 ``SubprocVecEnv(start_method="forkserver")``: each worker process imports the module
 that owns the pickled env-thunk (this one). If anything here pulled in ``torch`` /
-``sb3_contrib`` at import time, every env worker would drag the whole learner stack
-into its address space — defeating the forkserver/CUDA-after-fork safety ([D-26] Q4)
-and bloating each worker. So this module imports ONLY argparse / math / pathlib /
+``sb3_contrib`` at import time, unpickling the env-thunk in a worker would import the
+learner stack right there — the [D-26] Q4 invariant the tests pin. (The worker process is
+not otherwise torch-free: ``torch`` already rides in via the re-imported/preloaded
+``__main__``; the point is that the thunk itself adds nothing and the env path stays clean.)
+So this module imports ONLY argparse / math / pathlib /
 ``.env`` (which is itself torch-free), and the ``cfg: ModelConfig`` annotation is kept
 lazy via ``from __future__ import annotations`` + a ``TYPE_CHECKING`` import — the
 string annotation is never evaluated at runtime, so ``dicewars_bc.model`` (torch-ful)
@@ -32,8 +34,9 @@ if TYPE_CHECKING:  # annotation-only; never imported at runtime (keeps this modu
     from dicewars_bc.model import ModelConfig
 
 # Fixed, seed-pure, heterogeneous baseline field ([D-15]: strong bots in every game
-# keep it decisive; no Math.random bots so episodes stay reproducible). resolveOpponents
-# cycles this list to fill the (player_count - 1) opponent seats.
+# keep it decisive; no Math.random bots so episodes stay reproducible). The Node league's
+# resolveBaselineField (scripts/lib/ppo-league.mjs) cycles this list to fill the
+# (player_count - 1) opponent seats.
 DEFAULT_OPPONENTS = "ai_lookahead,ai_strategist,ai_expectimax,ai_bc,ai_defensive"
 
 
@@ -188,6 +191,11 @@ def build_parser(description: str | None = None) -> argparse.ArgumentParser:
 
 
 def _validate_args(args: argparse.Namespace) -> None:
+    if args.batch_size <= 0:
+        # Guard BEFORE the modulo below: batch_size==0 would raise a raw ZeroDivisionError, and
+        # batch_size<0 would slip past the divisibility check (Python's modulo follows the divisor
+        # sign, e.g. 512 % -4 == 0) — so bound it here as a clean SystemExit.
+        raise SystemExit(f"--batch-size must be > 0 (got {args.batch_size}).")
     rollout = args.n_steps * args.n_envs
     if rollout % args.batch_size != 0:
         raise SystemExit(
@@ -196,6 +204,15 @@ def _validate_args(args: argparse.Namespace) -> None:
         )
     if args.n_envs < 1:
         raise SystemExit("--n-envs must be >= 1.")
+    # An EXPLICIT bad learning rate / entropy coef is the costliest misconfig (lr==0 ⇒ a no-op run;
+    # lr<0 ⇒ gradient ASCENT; ent<0 ⇒ malformed objective) yet the only one otherwise unguarded — so
+    # bound it here with the rest. `is not None` keeps this order-independent w.r.t. train.py's None
+    # sentinel: an omitted lr/ent is filled to a valid constant by resolve_from_scratch AFTER this
+    # runs, while the tracer's numeric defaults pass through untouched.
+    if args.lr is not None and args.lr <= 0:
+        raise SystemExit(f"--lr must be > 0 (got {args.lr}).")
+    if args.ent_coef is not None and args.ent_coef < 0:
+        raise SystemExit(f"--ent-coef must be >= 0 (got {args.ent_coef}).")
     if not Path(args.checkpoint).is_file():
         raise SystemExit(f"--checkpoint not found: {args.checkpoint}")
     # PFSP knobs (B4): validate UNCONDITIONALLY. In fixed-field mode (no --snapshot-dir) these

--- a/ml/dicewars_ppo/train.py
+++ b/ml/dicewars_ppo/train.py
@@ -1,0 +1,225 @@
+"""Real PPO training driver — the scaling counterpart to ``train_tracer`` (PLAN task C/E, [D-26]).
+
+    python -m dicewars_ppo.train \
+        --checkpoint checkpoints/v2-base/bc_model.pt \
+        --timesteps 1000000 --n-envs 8 --lr 2.5e-4 --ent-coef 0.01 \
+        --snapshot-dir checkpoints/league --log-dir runs/ppo-long \
+        --out checkpoints/ppo.pt
+
+What this is (and how it differs from ``train_tracer``). The tracer is the smallest
+end-to-end loop — one ``DummyVecEnv``, no logging, deliberately non-learning HPs — that
+proves the JS↔Py↔ONNX pipeline closes. THIS driver is for the long BEAT run: it runs
+envs across cores under ``SubprocVecEnv(forkserver)`` (one Node env-server per worker
+process), wraps them in ``VecMonitor`` so ``rollout/ep_rew_mean`` logs, and writes
+TensorBoard event files + a flat ``progress.csv`` under ``--log-dir``. The PPO update,
+warm-start, repack, and the export-gate verification are SHARED with the tracer
+(``build_model`` / ``_verify_repack_exportable`` imported from ``train_tracer``) and the
+CLI surface + env factory + validation are SHARED via ``_train_common`` — one source of
+truth, so the green CI tracer stays byte-identical ([D-26] Q1).
+
+Process model ([D-26] Q4). ``SubprocVecEnv`` forks the env workers, then
+``MaskablePPO`` is constructed (which inits CUDA) — in that order. ``forkserver`` is the
+default start method because CUDA inits AFTER the fork, so a plain ``fork`` could inherit
+a half-initialized context; ``spawn`` is the portable fallback. Each worker imports only
+the torch-free ``dicewars_ppo.env`` (via the pickled thunk in ``_train_common``), never
+the learner stack. ``VecMonitor`` wraps in the PARENT so episode stats still surface.
+
+``--from-scratch`` ([D-26] Q6, [D-19] control). Skip the BC warm-start and train the
+actor from a fresh init — a short control run that proves a gate win is real PPO learning,
+not fixed-field BC exploitation. It still loads ``--checkpoint`` for the architecture
+(``ModelConfig``), is mutually exclusive with ``--freeze-trunk``, and relaxes the
+``--lr``/``--ent-coef`` defaults (see ``_train_common.resolve_from_scratch``).
+
+Scope (PR-4). Fresh runs only. Full idempotent checkpoint/resume (policy + optimizer +
+RNG + ``num_timesteps`` + league pool/book, ``reset_num_timesteps=False``, CSV
+continuation) is PR-5; the committed shodan launcher + schtasks runbook is PR-6. See the
+``TODO(PR-5)`` at ``model.learn`` and ``_train_common.resolve_from_scratch``'s note on
+production HPs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+import torch
+from stable_baselines3.common.logger import configure
+from stable_baselines3.common.vec_env import SubprocVecEnv, VecMonitor
+
+from . import _train_common
+from .policy import load_bc_checkpoint, repack_to_bc_checkpoint
+from .snapshot_callback import SnapshotCallback
+from .train_tracer import _verify_repack_exportable, build_model
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """The training CLI — the shared ``_train_common`` surface plus this driver's own flags.
+
+    Overrides two defaults vs the tracer: ``--out`` (a distinct file so a bare run can't clobber
+    a tracer checkpoint) and the ``--lr``/``--ent-coef`` sentinel (``None``) that lets
+    ``resolve_from_scratch`` relax them per mode while an explicit value always sticks. The
+    tracer never touches ``set_defaults``/these flags, so its parser is byte-identical.
+    """
+    p = _train_common.build_parser(__doc__)
+    p.set_defaults(out="checkpoints/ppo.pt", lr=None, ent_coef=None)
+    p.add_argument(
+        "--from-scratch",
+        action="store_true",
+        help="Skip the BC warm-start: train the actor from a fresh init (the [D-19] control). "
+        "Still loads --checkpoint for the architecture; mutually exclusive with --freeze-trunk; "
+        "relaxes --lr/--ent-coef when those are not given explicitly.",
+    )
+    p.add_argument(
+        "--log-dir",
+        default=None,
+        help="Directory for the flat progress.csv + TensorBoard event files. Unset ⇒ stdout only.",
+    )
+    p.add_argument(
+        "--no-tensorboard",
+        action="store_true",
+        help="With --log-dir set, write only the CSV sink (skip TensorBoard event files).",
+    )
+    p.add_argument(
+        "--start-method",
+        default="forkserver",
+        choices=("forkserver", "spawn", "fork"),
+        help="SubprocVecEnv worker start method (CUDA inits at MaskablePPO construction, AFTER the "
+        "envs fork — [D-26] Q4). forkserver is the safe default; spawn is the portable fallback.",
+    )
+    return p
+
+
+def _validate(args: argparse.Namespace) -> None:
+    _train_common._validate_args(args)
+    _train_common.resolve_from_scratch(args)
+
+
+def _tensorboard_available() -> bool:
+    """Is the ``tensorboard`` package importable? (SB3's TB sink hard-imports it — see below.)"""
+    return importlib.util.find_spec("tensorboard") is not None
+
+
+def _make_logger(args: argparse.Namespace):
+    """Configure the SB3 logger sinks for ``--log-dir`` (or ``None`` to keep SB3's stdout default).
+
+    Returns a configured ``Logger`` (caller passes it to ``model.set_logger`` BEFORE ``learn``) or
+    ``None`` when ``--log-dir`` is unset. ``VecMonitor`` (not this logger) is what populates the
+    ``rollout/ep_rew_mean`` / ``ep_len_mean`` keys these sinks then record.
+
+    SB3's ``TensorBoardOutputFormat`` HARD-imports the ``tensorboard`` package and RAISES if it
+    is absent (it does NOT silently no-op). ``tensorboard`` is in the ``[rl]`` extra, so the normal
+    path has it; but rather than crash a long run on a partial env, degrade to CSV-only with a loud
+    warning when it is missing (``--no-tensorboard`` opts out of the TB sink entirely).
+    """
+    if args.log_dir is None:
+        return None
+    sinks = ["stdout", "csv"]
+    if not args.no_tensorboard:
+        if _tensorboard_available():
+            sinks.append("tensorboard")
+        else:
+            print(
+                "WARNING: --log-dir set but the `tensorboard` package is not installed; writing "
+                "CSV only. Install the [rl] extra for TensorBoard, or pass --no-tensorboard."
+            )
+    # NOTE: SB3's CSVOutputFormat opens <log_dir>/progress.csv for writing and TRUNCATES it on each
+    # run, and configure() resets the TB event stream. PR-4 is fresh-run only; cross-session
+    # continuation (re-set_logger after a resume load) is PR-5's resume work, not this seam.
+    return configure(str(Path(args.log_dir)), sinks)
+
+
+def train(args: argparse.Namespace) -> Path:
+    cfg, ckpt = load_bc_checkpoint(args.checkpoint)
+    print(
+        f"loaded BC checkpoint {args.checkpoint}: encoding_version==2, "
+        f"max_areas={cfg.max_areas} player_count={cfg.player_count} "
+        f"context_hidden={cfg.context_hidden}"
+    )
+    mode = "from-scratch" if args.from_scratch else "warm-start"
+    print(
+        f"train config: mode={mode} n_envs={args.n_envs} start_method={args.start_method} "
+        f"opponents=[{args.opponents}] timesteps={args.timesteps} n_steps={args.n_steps} "
+        f"lr={args.lr} ent_coef={args.ent_coef} gamma={args.gamma}"
+    )
+
+    # PFSP snapshot publisher (B3): periodically repack+export the live actor so the env-servers'
+    # leagues hot-load it as a self-play opponent. Off unless --snapshot-dir is given (fixed-field).
+    callback = None
+    if args.snapshot_dir:
+        callback = SnapshotCallback(
+            args.snapshot_dir,
+            args.snapshot_every,
+            pool_cap=args.snapshot_pool_cap,
+            teacher="ppo-snapshot",
+        )
+        print(
+            f"snapshot publisher: every {args.snapshot_every} steps → {args.snapshot_dir} "
+            f"(consumer pool_cap={args.snapshot_pool_cap})"
+        )
+
+    # SubprocVecEnv (one Node env-server per worker process) THEN VecMonitor, both in the PARENT
+    # ([D-26] Q4). Each disjoint seed_base block (env_index * 1e6 inside the thunk) keeps parallel
+    # envs from replaying identical episodes AND gives each Node worker a distinct
+    # league-state-<seedBase>.json under persistence (PR-5/6).
+    venv = SubprocVecEnv(
+        [_train_common._make_env_thunk(cfg, args, i) for i in range(args.n_envs)],
+        start_method=args.start_method,
+    )
+    venv = VecMonitor(venv)
+
+    # build_model constructs MaskablePPO on this venv (CUDA inits here, after the fork) and either
+    # warm-starts or, with --from-scratch, leaves the fresh init.
+    model, venv = build_model(cfg, ckpt, args, venv=venv)
+
+    logger = _make_logger(args)
+    if logger is not None:
+        model.set_logger(logger)  # must precede learn()
+        sinks = "csv" if args.no_tensorboard else "csv+tensorboard"
+        print(f"logging: stdout + {sinks} → {args.log_dir}")
+
+    try:
+        # PR-4 trains FRESH runs only: reset_num_timesteps defaults True ⇒ num_timesteps starts at 0
+        # and --timesteps is the absolute budget. TODO(PR-5 / [D-26] HOLE-D): resume must pass
+        # reset_num_timesteps=False AND cap remaining = max(timesteps - num_timesteps, 0), else a
+        # crash-loop makes --timesteps additive and trains unbounded.
+        model.learn(total_timesteps=args.timesteps, progress_bar=False, callback=callback)
+    finally:
+        # Always reap the env workers (each owns a Node child) even on error.
+        venv.close()
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    repacked = repack_to_bc_checkpoint(
+        model.policy,
+        extra={
+            "teacher": "ppo",
+            "ppo_timesteps": int(args.timesteps),
+            "ppo_lr": float(args.lr),
+            "ppo_ent_coef": float(args.ent_coef),
+            "ppo_gamma": float(args.gamma),
+            "from_scratch": bool(args.from_scratch),
+            # None when from-scratch (no BC prior); the checkpoint path otherwise (provenance only).
+            "warm_started_from": None if args.from_scratch else str(args.checkpoint),
+        },
+    )
+    torch.save(repacked, out_path)
+    print(f"saved repacked BC-format checkpoint → {out_path}")
+
+    _verify_repack_exportable(out_path, cfg)
+    return out_path
+
+
+def main() -> None:
+    # Line-buffer stdout/stderr so progress AND a fatal traceback flush immediately even when
+    # redirected to a file (block buffering otherwise swallows the final traceback on a crash).
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
+    args = build_parser().parse_args()
+    _validate(args)
+    train(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/dicewars_ppo/train.py
+++ b/ml/dicewars_ppo/train.py
@@ -18,11 +18,18 @@ CLI surface + env factory + validation are SHARED via ``_train_common`` — one 
 truth, so the green CI tracer stays byte-identical ([D-26] Q1).
 
 Process model ([D-26] Q4). ``SubprocVecEnv`` forks the env workers, then
-``MaskablePPO`` is constructed (which inits CUDA) — in that order. ``forkserver`` is the
-default start method because CUDA inits AFTER the fork, so a plain ``fork`` could inherit
-a half-initialized context; ``spawn`` is the portable fallback. Each worker imports only
-the torch-free ``dicewars_ppo.env`` (via the pickled thunk in ``_train_common``), never
-the learner stack. ``VecMonitor`` wraps in the PARENT so episode stats still surface.
+``MaskablePPO`` is constructed (which inits CUDA) — in that order, so CUDA is never live
+at fork time and no worker can inherit a half-initialized CUDA context. ``forkserver`` is
+the default (``spawn`` the portable fallback) because the training parent is multithreaded
+once ``torch`` is imported, and forking *that* process (plain ``fork``) is the classic
+fork-after-threads hazard — forkserver/spawn instead start each worker from a separate,
+quiescent process. What the extraction actually guarantees is narrower but load-bearing:
+the env-thunk lives in the torch-free ``_train_common`` and captures only primitives, so a
+worker UNPICKLES it without importing ``torch`` — the [D-26] Q4 invariant the tests pin.
+(The worker *process* is not torch-free regardless of start method: ``torch`` rides in via
+the re-imported/preloaded ``__main__`` = this module; the workers just never touch it —
+each only drives a Node env-server over a socket.) ``VecMonitor`` wraps in the PARENT so
+episode stats still surface.
 
 ``--from-scratch`` ([D-26] Q6, [D-19] control). Skip the BC warm-start and train the
 actor from a fresh init — a short control run that proves a gate win is real PPO learning,
@@ -102,19 +109,21 @@ def _tensorboard_available() -> bool:
 
 
 def _make_logger(args: argparse.Namespace):
-    """Configure the SB3 logger sinks for ``--log-dir`` (or ``None`` to keep SB3's stdout default).
+    """Configure the SB3 logger sinks for ``--log-dir``; returns ``(logger, sinks)``.
 
-    Returns a configured ``Logger`` (caller passes it to ``model.set_logger`` BEFORE ``learn``) or
-    ``None`` when ``--log-dir`` is unset. ``VecMonitor`` (not this logger) is what populates the
+    Returns ``(configured Logger, [sink names])`` — the caller passes the logger to
+    ``model.set_logger`` BEFORE ``learn`` and reports the ACTUAL ``sinks`` (so the status line
+    can't claim a sink the degradation path dropped) — or ``(None, [])`` when ``--log-dir`` is
+    unset (SB3 keeps its stdout default). ``VecMonitor`` (not this logger) is what populates the
     ``rollout/ep_rew_mean`` / ``ep_len_mean`` keys these sinks then record.
 
     SB3's ``TensorBoardOutputFormat`` HARD-imports the ``tensorboard`` package and RAISES if it
     is absent (it does NOT silently no-op). ``tensorboard`` is in the ``[rl]`` extra, so the normal
     path has it; but rather than crash a long run on a partial env, degrade to CSV-only with a loud
-    warning when it is missing (``--no-tensorboard`` opts out of the TB sink entirely).
+    warning (on stderr) when it is missing (``--no-tensorboard`` opts out of the TB sink entirely).
     """
     if args.log_dir is None:
-        return None
+        return None, []
     sinks = ["stdout", "csv"]
     if not args.no_tensorboard:
         if _tensorboard_available():
@@ -122,12 +131,14 @@ def _make_logger(args: argparse.Namespace):
         else:
             print(
                 "WARNING: --log-dir set but the `tensorboard` package is not installed; writing "
-                "CSV only. Install the [rl] extra for TensorBoard, or pass --no-tensorboard."
+                "CSV only. Install the [rl] extra for TensorBoard, or pass --no-tensorboard.",
+                file=sys.stderr,
             )
-    # NOTE: SB3's CSVOutputFormat opens <log_dir>/progress.csv for writing and TRUNCATES it on each
-    # run, and configure() resets the TB event stream. PR-4 is fresh-run only; cross-session
-    # continuation (re-set_logger after a resume load) is PR-5's resume work, not this seam.
-    return configure(str(Path(args.log_dir)), sinks)
+    # NOTE: SB3's CSVOutputFormat opens <log_dir>/progress.csv with mode "w+t", TRUNCATING it on
+    # each run, and configure() starts a FRESH TB event file (old events.out.tfevents.* are left in
+    # place, so re-running the same --log-dir accumulates overlapping curves). PR-4 is fresh-run
+    # only; cross-session continuation (re-set_logger after a resume load) is PR-5's resume work.
+    return configure(str(Path(args.log_dir)), sinks), sinks
 
 
 def train(args: argparse.Namespace) -> Path:
@@ -173,11 +184,12 @@ def train(args: argparse.Namespace) -> Path:
     # warm-starts or, with --from-scratch, leaves the fresh init.
     model, venv = build_model(cfg, ckpt, args, venv=venv)
 
-    logger = _make_logger(args)
+    logger, sinks = _make_logger(args)
     if logger is not None:
         model.set_logger(logger)  # must precede learn()
-        sinks = "csv" if args.no_tensorboard else "csv+tensorboard"
-        print(f"logging: stdout + {sinks} → {args.log_dir}")
+        # Report the ACTUAL sinks (the TB-missing degradation path drops "tensorboard"), so this
+        # line can never disagree with the warning _make_logger may have just printed.
+        print(f"logging: {' + '.join(sinks)} → {args.log_dir}")
 
     try:
         # PR-4 trains FRESH runs only: reset_num_timesteps defaults True ⇒ num_timesteps starts at 0
@@ -186,8 +198,15 @@ def train(args: argparse.Namespace) -> Path:
         # crash-loop makes --timesteps additive and trains unbounded.
         model.learn(total_timesteps=args.timesteps, progress_bar=False, callback=callback)
     finally:
-        # Always reap the env workers (each owns a Node child) even on error.
-        venv.close()
+        # Always reap the env workers (each owns a Node child) even on error. Guard the close: when
+        # learn() raised because a SubprocVecEnv worker already died (the common failure here), the
+        # close()'s worker-pipe ops raise EOFError/BrokenPipeError — and a raise in `finally` would
+        # REPLACE the in-flight exception as the primary traceback, burying the real cause. Demote
+        # any teardown error to a stderr warning so learn()'s exception stays the headline.
+        try:
+            venv.close()
+        except Exception as close_exc:
+            print(f"WARNING: venv.close() failed during teardown: {close_exc!r}", file=sys.stderr)
 
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/ml/dicewars_ppo/train_tracer.py
+++ b/ml/dicewars_ppo/train_tracer.py
@@ -30,7 +30,6 @@ byte-identical to the warm-start, a useful sanity floor.
 from __future__ import annotations
 
 import argparse
-import math
 import sys
 from pathlib import Path
 
@@ -40,7 +39,8 @@ from stable_baselines3.common.vec_env import DummyVecEnv
 
 from dicewars_bc.model import EdgePolicyNet, ModelConfig
 
-from .env import DiceWarsEnv
+from . import _train_common
+from ._train_common import _make_env_thunk, _validate_args
 from .policy import (
     MaskableEdgePolicy,
     load_bc_checkpoint,
@@ -49,53 +49,30 @@ from .policy import (
 )
 from .snapshot_callback import SnapshotCallback
 
-# Fixed, seed-pure, heterogeneous baseline field ([D-15]: strong bots in every game
-# keep it decisive; no Math.random bots so episodes stay reproducible). resolveOpponents
-# cycles this list to fill the (player_count - 1) opponent seats.
-DEFAULT_OPPONENTS = "ai_lookahead,ai_strategist,ai_expectimax,ai_bc,ai_defensive"
-
-
-def _make_env_thunk(cfg: ModelConfig, args: argparse.Namespace, env_index: int):
-    """A zero-arg env factory for ``DummyVecEnv`` — each launches its own env-server.
-
-    The env's ``player_count`` MUST equal the BC config's (the players-tensor height the
-    obs frame carries; ``_check_dims`` rejects a mismatch), so it's taken from ``cfg``,
-    not a free flag. Each env gets a disjoint ``seed_base`` block so parallel envs don't
-    replay identical episodes.
-    """
-
-    # All vec-env servers poll the SAME producer manifest, so they share one snapshot pool ([D-22]).
-    # `snapshot_dir` is resolved absolute in _validate_args so producer (this process) and consumers
-    # (the Node servers, cwd=repo-root) agree on the path regardless of cwd.
-    snapshot_manifest = (
-        str(Path(args.snapshot_dir) / "manifest.json") if args.snapshot_dir else None
-    )
-
-    def _thunk() -> DiceWarsEnv:
-        return DiceWarsEnv(
-            max_areas=cfg.max_areas,
-            player_count=cfg.player_count,
-            server_kwargs={
-                "opponents": args.opponents,
-                "max_turns": args.max_turns,
-                "learner_seat": args.learner_seat,
-                "seed_base": args.seed_base + env_index * 1_000_000,
-                "snapshot_manifest": snapshot_manifest,
-                "snapshot_pool_cap": args.snapshot_pool_cap,
-                "reserve_baselines": args.reserve_baselines,
-                "pfsp_epsilon": args.pfsp_epsilon,
-                "pfsp_k": args.pfsp_k,
-            },
-        )
-
-    return _thunk
+# The fixed baseline field, the env factory, the argparse surface, and the arg validation now
+# live in the torch-free `_train_common` so `train.py` can share them (a SubprocVecEnv worker
+# imports the env-thunk's module and must not drag torch/sb3 in — see _train_common's docstring).
+# They are re-imported above so the tracer's body (and its tests, which call `tt._make_env_thunk` /
+# `tt._validate_args` / `tt.build_parser`) keeps the exact same names and behavior as before.
 
 
 def build_model(
-    cfg: ModelConfig, ckpt: dict, args: argparse.Namespace
+    cfg: ModelConfig,
+    ckpt: dict,
+    args: argparse.Namespace,
+    venv: DummyVecEnv | None = None,
 ) -> tuple[MaskablePPO, DummyVecEnv]:
-    """Construct the vec-env + warm-started ``MaskablePPO``. Returns ``(model, venv)``."""
-    venv = DummyVecEnv([_make_env_thunk(cfg, args, i) for i in range(args.n_envs)])
+    """Construct the vec-env + ``MaskablePPO`` (warm-started unless ``--from-scratch``).
+
+    ``venv`` lets ``train.py`` inject its ``VecMonitor(SubprocVecEnv(...))`` stack; when it is
+    ``None`` (the tracer's only path) a sequential ``DummyVecEnv`` is built here exactly as
+    before — byte-identical. ``--from-scratch`` (set only by ``train.py``; the tracer's args
+    never carry it, so ``getattr`` is ``False`` and the warm-start branch always runs) skips the
+    BC warm-start so the actor trains from a fresh init — the [D-19] control that proves a gate
+    win is real learning rather than warm-start exploitation. Returns ``(model, venv)``.
+    """
+    if venv is None:
+        venv = DummyVecEnv([_make_env_thunk(cfg, args, i) for i in range(args.n_envs)])
 
     model = MaskablePPO(
         MaskableEdgePolicy,
@@ -115,11 +92,15 @@ def build_model(
         verbose=1,
     )
 
-    # Load the BC trunk + edge_head into the actor (the fresh scalar critic stays at init).
-    warm_start_from_bc(model.policy, ckpt)
     n_total = sum(p.numel() for p in model.policy.parameters())
     n_actor = sum(p.numel() for p in model.policy.bc_net.parameters())
-    print(f"warm-started actor from BC checkpoint: {n_actor:,} actor params, {n_total:,} total")
+    if getattr(args, "from_scratch", False):
+        # No BC prior loaded — the actor keeps MaskableEdgePolicy._build's fresh init.
+        print(f"from-scratch: skipped BC warm-start — {n_actor:,} actor params, {n_total:,} total")
+    else:
+        # Load the BC trunk + edge_head into the actor (the fresh scalar critic stays at init).
+        warm_start_from_bc(model.policy, ckpt)
+        print(f"warm-started actor from BC checkpoint: {n_actor:,} actor params, {n_total:,} total")
 
     if args.freeze_trunk:
         for p in model.policy.bc_net.parameters():
@@ -197,131 +178,13 @@ def train(args: argparse.Namespace) -> Path:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    p = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
-    )
-    p.add_argument(
-        "--checkpoint",
-        default="checkpoints/v2-base/bc_model.pt",
-        help="v2-BC checkpoint to warm-start from (the deployed ai_bc).",
-    )
-    p.add_argument(
-        "--out", default="checkpoints/ppo-tracer.pt", help="Repacked BC-format output .pt"
-    )
-    p.add_argument("--opponents", default=DEFAULT_OPPONENTS, help="CSV of fixed baseline bot ids")
-    p.add_argument("--learner-seat", type=int, default=0, help="Seat the learner occupies")
-    p.add_argument(
-        "--n-envs", type=int, default=1, help="Parallel DummyVecEnv envs (1-2 for a tracer)"
-    )
-    # Budget — kept tiny: total_timesteps / (n_steps * n_envs) = number of PPO updates.
-    p.add_argument(
-        "--timesteps", type=int, default=2048, help="Total env steps (a handful of updates)"
-    )
-    p.add_argument(
-        "--n-steps", type=int, default=512, help="Rollout length per env before each update"
-    )
-    p.add_argument(
-        "--batch-size", type=int, default=128, help="Minibatch (must divide n_steps*n_envs)"
-    )
-    p.add_argument("--n-epochs", type=int, default=4, help="PPO epochs per rollout")
-    # Low LR by default so a short run can't wreck the warm-started actor ([D-19] decision 1).
-    p.add_argument(
-        "--lr", type=float, default=1e-4, help="Learning rate (low; protects the warm start)"
-    )
-    p.add_argument(
-        "--gamma", type=float, default=0.999, help="Discount (high: sparse terminal-win signal)"
-    )
-    p.add_argument("--gae-lambda", type=float, default=0.95)
-    p.add_argument(
-        "--ent-coef", type=float, default=0.0, help="Entropy bonus (0 keeps the warm start stable)"
-    )
-    p.add_argument("--vf-coef", type=float, default=0.5)
-    p.add_argument(
-        "--freeze-trunk",
-        action="store_true",
-        help="Freeze the BC trunk+edge_head (train the fresh critic only; actor unchanged).",
-    )
-    p.add_argument("--max-turns", type=int, default=500, help="Stalemate cap (→ Gym truncation)")
-    p.add_argument("--seed", type=int, default=0, help="PPO/torch seed")
-    p.add_argument("--seed-base", type=int, default=1, help="Env-server episode seed base")
-    p.add_argument("--device", default="cpu", help="torch device (cpu is fine — the net is tiny)")
-    # PFSP snapshots (B3 / [D-22]). --snapshot-dir off ⇒ fixed-field (task A) empty-pool mode.
-    p.add_argument(
-        "--snapshot-dir",
-        default=None,
-        help="Publish snapshots (weights + manifest.json) here for the league to hot-load; "
-        "unset ⇒ fixed-field (no PFSP).",
-    )
-    p.add_argument(
-        "--snapshot-every",
-        type=int,
-        default=50_000,
-        help="Snapshot cadence in total env steps (only used with --snapshot-dir).",
-    )
-    p.add_argument(
-        "--snapshot-pool-cap",
-        type=int,
-        default=40,
-        help="Max snapshots the env-server league holds live (FIFO-by-step; forwarded).",
-    )
-    # PFSP sampler knobs (B4 / [D-23]). Only bite with --snapshot-dir (a non-empty pool); forwarded
-    # to the env-server league's draw(). w(S) = max(eps, 1 - learnerWinRate(S)) ** k.
-    p.add_argument(
-        "--reserve-baselines",
-        type=int,
-        default=3,
-        help="R baselines reserved per drawn field (turtle-equilibrium defense; distinct non-ai_bc "
-        "ids, no-replacement). Only used with --snapshot-dir.",
-    )
-    p.add_argument(
-        "--pfsp-epsilon",
-        type=float,
-        default=0.05,
-        help="PFSP weight floor eps in (0, 1] for w(S)=max(eps,1-winRate)**k. Only used with "
-        "--snapshot-dir.",
-    )
-    p.add_argument(
-        "--pfsp-k",
-        type=float,
-        default=2.0,
-        help="PFSP weight exponent k (>= 0) for w(S)=max(eps,1-winRate)**k. Only used with "
-        "--snapshot-dir.",
-    )
-    return p
+    """The tracer CLI — the shared ``_train_common`` surface stamped with this module's docstring.
 
-
-def _validate_args(args: argparse.Namespace) -> None:
-    rollout = args.n_steps * args.n_envs
-    if rollout % args.batch_size != 0:
-        raise SystemExit(
-            f"--batch-size {args.batch_size} must divide n_steps*n_envs = {rollout} "
-            f"(n_steps={args.n_steps}, n_envs={args.n_envs})."
-        )
-    if args.n_envs < 1:
-        raise SystemExit("--n-envs must be >= 1.")
-    if not Path(args.checkpoint).is_file():
-        raise SystemExit(f"--checkpoint not found: {args.checkpoint}")
-    # PFSP knobs (B4): validate UNCONDITIONALLY. In fixed-field mode (no --snapshot-dir) these
-    # knobs are NOT forwarded to the env-server — env_server.py only appends them on the snapshot
-    # branch — so Node never sees or validates the Python-supplied value. That makes THIS check the
-    # sole guard there; without it a bad value would be silently dropped (Node falls back to its own
-    # defaults). The bounds mirror the Node makeLeague guards so the two layers stay consistent when
-    # the knobs ARE forwarded; math.isfinite mirrors Number.isFinite so inf/nan fail here.
-    if args.reserve_baselines < 0:
-        raise SystemExit("--reserve-baselines must be >= 0.")
-    if not 0.0 < args.pfsp_epsilon <= 1.0:
-        raise SystemExit("--pfsp-epsilon must be in (0, 1].")
-    if not math.isfinite(args.pfsp_k) or args.pfsp_k < 0:
-        raise SystemExit("--pfsp-k must be a finite number >= 0.")
-    if args.snapshot_dir is not None:
-        if args.snapshot_every <= 0:
-            raise SystemExit("--snapshot-every must be > 0 when --snapshot-dir is set.")
-        if args.snapshot_pool_cap <= 0:
-            raise SystemExit("--snapshot-pool-cap must be > 0.")
-        # Absolutize so the producer (this process) and the Node consumers (cwd=repo-root)
-        # resolve the same manifest path; create it now so env-servers can stat() it from ep 0.
-        args.snapshot_dir = str(Path(args.snapshot_dir).resolve())
-        Path(args.snapshot_dir).mkdir(parents=True, exist_ok=True)
+    The parser body lives in ``_train_common.build_parser`` (so ``train.py`` shares it verbatim);
+    passing ``__doc__`` keeps the tracer's ``--help`` text exactly as before the extraction.
+    ``_validate_args`` is re-imported from ``_train_common`` (used in ``main``).
+    """
+    return _train_common.build_parser(__doc__)
 
 
 def main() -> None:

--- a/ml/pyproject.toml
+++ b/ml/pyproject.toml
@@ -29,6 +29,11 @@ rl = [
   "stable-baselines3>=2.3",
   "sb3-contrib>=2.3",
   "pettingzoo>=1.24",
+  # train.py's TensorBoard sink. SB3's TensorBoardOutputFormat HARD-imports this (it RAISES, not
+  # no-ops, when the TB sink is enabled and tensorboard is absent), so it lives in [rl] (the GPU
+  # box). train.py also degrades to CSV-only + a warning if it's missing (--no-tensorboard opts
+  # out entirely). The lean ml-test CI never installs [rl] / calls _make_logger, so no CI change.
+  "tensorboard>=2.12",
 ]
 dev = [
   "pytest>=7.4",

--- a/ml/tests/test_train_args.py
+++ b/ml/tests/test_train_args.py
@@ -115,7 +115,9 @@ def test_train_wraps_subproc_then_vecmonitor(tmp_path, monkeypatch, from_scratch
     monkeypatch.setattr(tr.torch, "save", lambda obj, path: calls.append(("save",)))
     monkeypatch.setattr(tr, "_verify_repack_exportable", lambda out, cfg: calls.append(("verify",)))
 
-    extra = ["--start-method", "spawn"] + (["--from-scratch"] if from_scratch else [])
+    extra = ["--start-method", "spawn", "--out", str(tmp_path / "out.pt")] + (
+        ["--from-scratch"] if from_scratch else []
+    )
     a = _args(tmp_path, extra=extra)
     tr._validate(a)
     tr.train(a)
@@ -182,28 +184,100 @@ def test_make_logger_sink_selection(tmp_path, monkeypatch):
     monkeypatch.setattr(tr, "configure", fake_configure)
     monkeypatch.setattr(tr, "_tensorboard_available", lambda: True)
 
-    # no --log-dir → SB3 keeps its stdout default (no configured logger)
+    # no --log-dir → SB3 keeps its stdout default (no configured logger, empty sink list)
     a = _args(tmp_path)
     tr._validate(a)
-    assert tr._make_logger(a) is None
+    assert tr._make_logger(a) == (None, [])
 
-    # --log-dir → stdout + csv + tensorboard
+    # --log-dir → stdout + csv + tensorboard; the RETURNED sinks mirror what configure() got, so
+    # train()'s status line is built from reality rather than from the --no-tensorboard flag.
     b = _args(tmp_path, extra=["--log-dir", str(tmp_path / "runs")])
     tr._validate(b)
-    assert tr._make_logger(b) == "LOGGER"
+    logger, sinks = tr._make_logger(b)
+    assert logger == "LOGGER"
+    assert sinks == ["stdout", "csv", "tensorboard"]
     assert captured["sinks"] == ["stdout", "csv", "tensorboard"]
 
     # --log-dir + --no-tensorboard → stdout + csv only
     captured.clear()
     c = _args(tmp_path, extra=["--log-dir", str(tmp_path / "runs"), "--no-tensorboard"])
     tr._validate(c)
-    tr._make_logger(c)
+    _, sinks = tr._make_logger(c)
+    assert sinks == ["stdout", "csv"]
     assert captured["sinks"] == ["stdout", "csv"]
 
-    # --log-dir but tensorboard missing → degrade to csv only (no raise)
+    # --log-dir but tensorboard missing → degrade to csv only (no raise); the returned sinks reflect
+    # the drop, so train() reports "csv" not "csv+tensorboard" (the contradiction this guards).
     captured.clear()
     monkeypatch.setattr(tr, "_tensorboard_available", lambda: False)
     d = _args(tmp_path, extra=["--log-dir", str(tmp_path / "runs")])
     tr._validate(d)
-    tr._make_logger(d)
+    _, sinks = tr._make_logger(d)
+    assert sinks == ["stdout", "csv"]
     assert captured["sinks"] == ["stdout", "csv"]
+
+
+def test_train_wires_snapshot_callback_and_logger(tmp_path, monkeypatch):
+    """With --snapshot-dir + --log-dir, train() must construct SnapshotCallback (forwarding the
+    keyword-only pool_cap, whose name-drift would fail only on a live shodan run), hand it to
+    learn(callback=...), and call set_logger BEFORE learn — all the train()-level wiring the
+    isolated _make_logger / wrap-order tests don't exercise. Fakes only, so no Node child spawns."""
+    calls = []
+    fake_cfg = SimpleNamespace(max_areas=32, player_count=7, context_hidden=64)
+    monkeypatch.setattr(tr, "load_bc_checkpoint", lambda ckpt: (fake_cfg, {"k": "v"}))
+    monkeypatch.setattr(tr, "SubprocVecEnv", lambda thunks, start_method=None: SimpleNamespace())
+    monkeypatch.setattr(
+        tr, "VecMonitor", lambda venv: SimpleNamespace(close=lambda: calls.append(("close",)))
+    )
+
+    class FakeSnapshotCallback:
+        def __init__(self, snapshot_dir, snapshot_every, *, pool_cap, teacher):
+            calls.append(("SnapshotCallback", pool_cap, teacher))
+
+    monkeypatch.setattr(tr, "SnapshotCallback", FakeSnapshotCallback)
+
+    class FakeModel:
+        def __init__(self):
+            self.policy = object()
+
+        def set_logger(self, logger):
+            calls.append(("set_logger", logger))
+
+        def learn(self, **kwargs):
+            # record the callback's TYPE so we prove the SnapshotCallback instance reached learn()
+            calls.append(("learn", type(kwargs.get("callback")).__name__))
+
+    monkeypatch.setattr(tr, "build_model", lambda cfg, ckpt, args, venv=None: (FakeModel(), venv))
+    monkeypatch.setattr(tr, "configure", lambda folder, sinks: "LOGGER")
+    monkeypatch.setattr(tr, "_tensorboard_available", lambda: True)
+    monkeypatch.setattr(
+        tr,
+        "repack_to_bc_checkpoint",
+        lambda policy, *, extra=None: {"state_dict": {}, "config": {}, "encoding_version": 2},
+    )
+    monkeypatch.setattr(tr.torch, "save", lambda obj, path: None)
+    monkeypatch.setattr(tr, "_verify_repack_exportable", lambda out, cfg: None)
+
+    a = _args(
+        tmp_path,
+        extra=[
+            "--out",  # keep the repack write inside tmp_path (no stray checkpoints/ in cwd)
+            str(tmp_path / "out.pt"),
+            "--log-dir",
+            str(tmp_path / "runs"),
+            "--snapshot-dir",
+            str(tmp_path / "league"),
+            "--snapshot-pool-cap",
+            "17",
+        ],
+    )
+    tr._validate(a)
+    tr.train(a)
+
+    # pool_cap forwarded to the producer callback (the tracer omits it; train.py must not)
+    assert ("SnapshotCallback", 17, "ppo-snapshot") in calls
+    # the SnapshotCallback instance reached learn(callback=...)
+    assert ("learn", "FakeSnapshotCallback") in calls
+    # set_logger fired, and BEFORE learn() (the "must precede learn()" invariant)
+    assert ("set_logger", "LOGGER") in calls
+    assert calls.index(("set_logger", "LOGGER")) < calls.index(("learn", "FakeSnapshotCallback"))

--- a/ml/tests/test_train_args.py
+++ b/ml/tests/test_train_args.py
@@ -1,0 +1,209 @@
+"""train.py-specific surface: --from-scratch, the lr/ent sentinel, SubprocVecEnv→VecMonitor order.
+
+Torch/SB3-gated (``train`` imports them at module scope), so this runs on shodan and skips in the
+lean ``ml-test`` CI job — same pattern as test_train_tracer_args.py. The shared parser/validate
+core is covered lean in test_train_common_args.py; this file covers ONLY what train.py adds on top:
+the ``--from-scratch`` flag and its mutex/relaxation, the None-sentinel defaults, and that
+``train()`` wraps SubprocVecEnv THEN VecMonitor in the parent ([D-26] Q4) and stamps from-scratch
+provenance — all WITHOUT spawning a Node env-server or running a real rollout (the live forkserver
+smoke is a shodan/PR-7 concern).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("sb3_contrib")
+
+import dicewars_ppo.train as tr  # noqa: E402
+
+
+def _args(tmp_path, extra=None):
+    ckpt = tmp_path / "ckpt.pt"
+    ckpt.write_bytes(b"x")
+    argv = ["--checkpoint", str(ckpt)] + (extra or [])
+    return tr.build_parser().parse_args(argv)
+
+
+def test_parser_adds_from_scratch_and_sentinels(tmp_path):
+    a = _args(tmp_path)
+    assert a.from_scratch is False
+    # train.py overrides --lr/--ent-coef to a None sentinel so resolve_from_scratch can relax them.
+    assert a.lr is None
+    assert a.ent_coef is None
+    # distinct output so a bare train.py run can't clobber a tracer checkpoint
+    assert a.out == "checkpoints/ppo.pt"
+    assert a.start_method == "forkserver"
+
+
+def test_validate_rejects_from_scratch_with_freeze_trunk(tmp_path):
+    a = _args(tmp_path, extra=["--from-scratch", "--freeze-trunk"])
+    with pytest.raises(SystemExit, match="mutually exclusive"):
+        tr._validate(a)
+
+
+def test_validate_relaxes_from_scratch_hps(tmp_path):
+    a = _args(tmp_path, extra=["--from-scratch"])
+    tr._validate(a)
+    assert a.lr == 1e-3
+    assert a.ent_coef == 0.01
+
+
+def test_validate_warm_start_fills_protective_hps(tmp_path):
+    a = _args(tmp_path)
+    tr._validate(a)
+    assert a.lr == 1e-4
+    assert a.ent_coef == 0.0
+
+
+def test_validate_explicit_hps_stick_under_from_scratch(tmp_path):
+    a = _args(tmp_path, extra=["--from-scratch", "--lr", "7e-4", "--ent-coef", "0.05"])
+    tr._validate(a)
+    assert a.lr == 7e-4
+    assert a.ent_coef == 0.05
+
+
+@pytest.mark.parametrize("from_scratch", [True, False])
+def test_train_wraps_subproc_then_vecmonitor(tmp_path, monkeypatch, from_scratch):
+    """train() must build SubprocVecEnv, then VecMonitor around it, in the parent, and stamp the
+    from-scratch provenance — verified with fakes so no Node child spawns and no rollout runs."""
+    calls = []
+    fake_cfg = SimpleNamespace(max_areas=32, player_count=7, context_hidden=64)
+    monkeypatch.setattr(tr, "load_bc_checkpoint", lambda ckpt: (fake_cfg, {"k": "v"}))
+
+    class FakeSubproc:
+        def __init__(self, thunks, start_method=None):
+            calls.append(("SubprocVecEnv", len(thunks), start_method))
+
+    class FakeMonitor:
+        def __init__(self, venv):
+            # the wrap order assertion: VecMonitor must receive the SubprocVecEnv instance
+            calls.append(("VecMonitor", isinstance(venv, FakeSubproc)))
+
+        def close(self):
+            calls.append(("close",))
+
+    monkeypatch.setattr(tr, "SubprocVecEnv", FakeSubproc)
+    monkeypatch.setattr(tr, "VecMonitor", FakeMonitor)
+
+    captured = {}
+
+    class FakeModel:
+        def __init__(self):
+            self.policy = object()
+
+        def learn(self, **kwargs):
+            calls.append(("learn",))
+
+        def set_logger(self, logger):
+            calls.append(("set_logger",))
+
+    def fake_build_model(cfg, ckpt, args, venv=None):
+        captured["venv_is_monitor"] = isinstance(venv, FakeMonitor)
+        return FakeModel(), venv
+
+    monkeypatch.setattr(tr, "build_model", fake_build_model)
+
+    def fake_repack(policy, *, extra=None):
+        captured["extra"] = extra
+        return {"state_dict": {}, "config": {}, "encoding_version": 2, **(extra or {})}
+
+    monkeypatch.setattr(tr, "repack_to_bc_checkpoint", fake_repack)
+    monkeypatch.setattr(tr.torch, "save", lambda obj, path: calls.append(("save",)))
+    monkeypatch.setattr(tr, "_verify_repack_exportable", lambda out, cfg: calls.append(("verify",)))
+
+    extra = ["--start-method", "spawn"] + (["--from-scratch"] if from_scratch else [])
+    a = _args(tmp_path, extra=extra)
+    tr._validate(a)
+    tr.train(a)
+
+    subproc = ("SubprocVecEnv", 1, "spawn")  # default --n-envs == 1
+    assert subproc in calls
+    assert ("VecMonitor", True) in calls  # VecMonitor wrapped the SubprocVecEnv
+    assert calls.index(subproc) < calls.index(("VecMonitor", True))  # SubprocVecEnv FIRST
+    assert captured["venv_is_monitor"] is True  # build_model got the monitored venv
+    assert ("close",) in calls  # env workers reaped in finally
+
+    assert captured["extra"]["teacher"] == "ppo"
+    assert captured["extra"]["from_scratch"] is from_scratch
+    if from_scratch:
+        assert captured["extra"]["warm_started_from"] is None
+    else:
+        assert captured["extra"]["warm_started_from"] == a.checkpoint
+
+
+@pytest.mark.parametrize("from_scratch", [True, False])
+def test_build_model_warm_start_gated_on_from_scratch(tmp_path, monkeypatch, from_scratch):
+    """build_model must SKIP warm_start_from_bc under --from-scratch and CALL it otherwise — the
+    single decision that makes the [D-19] control valid. Fakes MaskablePPO so no real net/rollout
+    is built; a regression that warm-started anyway would otherwise keep every other test green."""
+    import dicewars_ppo.train_tracer as tt
+
+    warm_calls = []
+    monkeypatch.setattr(tt, "warm_start_from_bc", lambda policy, ckpt: warm_calls.append(True))
+
+    class FakePolicy:
+        def parameters(self):
+            return []
+
+        class _BC:
+            def parameters(self):
+                return []
+
+        bc_net = _BC()
+
+    class FakeModel:
+        def __init__(self, *args, **kwargs):
+            self.policy = FakePolicy()
+
+    monkeypatch.setattr(tt, "MaskablePPO", lambda *args, **kwargs: FakeModel())
+
+    cfg = SimpleNamespace(max_areas=32, player_count=7)
+    extra = ["--from-scratch"] if from_scratch else []
+    a = _args(tmp_path, extra=extra)
+    tr._validate(a)
+    # venv != None so build_model does not construct a DummyVecEnv (no Node spawn).
+    tt.build_model(cfg, {"k": "v"}, a, venv=object())
+
+    assert warm_calls == ([] if from_scratch else [True])
+
+
+def test_make_logger_sink_selection(tmp_path, monkeypatch):
+    captured = {}
+
+    def fake_configure(folder, sinks):
+        captured["folder"] = folder
+        captured["sinks"] = list(sinks)
+        return "LOGGER"
+
+    monkeypatch.setattr(tr, "configure", fake_configure)
+    monkeypatch.setattr(tr, "_tensorboard_available", lambda: True)
+
+    # no --log-dir → SB3 keeps its stdout default (no configured logger)
+    a = _args(tmp_path)
+    tr._validate(a)
+    assert tr._make_logger(a) is None
+
+    # --log-dir → stdout + csv + tensorboard
+    b = _args(tmp_path, extra=["--log-dir", str(tmp_path / "runs")])
+    tr._validate(b)
+    assert tr._make_logger(b) == "LOGGER"
+    assert captured["sinks"] == ["stdout", "csv", "tensorboard"]
+
+    # --log-dir + --no-tensorboard → stdout + csv only
+    captured.clear()
+    c = _args(tmp_path, extra=["--log-dir", str(tmp_path / "runs"), "--no-tensorboard"])
+    tr._validate(c)
+    tr._make_logger(c)
+    assert captured["sinks"] == ["stdout", "csv"]
+
+    # --log-dir but tensorboard missing → degrade to csv only (no raise)
+    captured.clear()
+    monkeypatch.setattr(tr, "_tensorboard_available", lambda: False)
+    d = _args(tmp_path, extra=["--log-dir", str(tmp_path / "runs")])
+    tr._validate(d)
+    tr._make_logger(d)
+    assert captured["sinks"] == ["stdout", "csv"]

--- a/ml/tests/test_train_common_args.py
+++ b/ml/tests/test_train_common_args.py
@@ -1,0 +1,260 @@
+"""Torch-free unit tests for the shared PPO training core (``dicewars_ppo._train_common``).
+
+These run in the LEAN ``ml-test`` CI tier (gymnasium only, NO torch/sb3 — mirroring
+``test_env_server_argv.py``): ``_train_common`` is deliberately torch-free so a
+``SubprocVecEnv(forkserver)`` worker can import its env-thunk's module without dragging the
+learner stack into the worker's address space ([D-26] Q4). The torch/sb3-gated behavior of the
+drivers that consume this module lives in ``test_train_tracer_args.py`` (the tracer) and
+``test_train_args.py`` (``train.py``).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+# _train_common imports dicewars_ppo.env → gymnasium (pure-Python; installed in lean CI). It must
+# NOT import torch/sb3 (the whole point), so do NOT importorskip those.
+pytest.importorskip("gymnasium")
+
+import dicewars_ppo._train_common as tc  # noqa: E402
+
+ML_DIR = Path(__file__).resolve().parents[1]
+
+
+def _args(tmp_path, extra=None, **overrides):
+    """Parse a minimal valid argv (real checkpoint file) with optional knob overrides."""
+    ckpt = tmp_path / "ckpt.pt"
+    ckpt.write_bytes(b"x")
+    argv = ["--checkpoint", str(ckpt)]
+    for key, val in overrides.items():
+        argv += [f"--{key.replace('_', '-')}", str(val)]
+    argv += extra or []
+    return tc.build_parser().parse_args(argv)
+
+
+# --- the torch-free invariant (load-bearing for SubprocVecEnv forkserver workers) -------------
+
+
+def test_import_train_common_does_not_pull_torch_or_sb3():
+    # Assert in a FRESH interpreter: a shared pytest session has torch loaded by the BC tests, so
+    # checking THIS process's sys.modules would be meaningless. A SubprocVecEnv worker that imports
+    # the pickled env-thunk's module must not load the learner stack ([D-26] Q4) — guard it here.
+    code = (
+        "import sys, dicewars_ppo._train_common\n"
+        "leaked = [m for m in ('torch', 'sb3_contrib', 'stable_baselines3') if m in sys.modules]\n"
+        "assert not leaked, f'learner stack leaked into _train_common: {leaked}'\n"
+    )
+    env = {**os.environ, "PYTHONPATH": str(ML_DIR)}
+    r = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, env=env, cwd=str(ML_DIR)
+    )
+    assert r.returncode == 0, f"torch-free import invariant failed:\n{r.stdout}\n{r.stderr}"
+
+
+def test_env_thunk_closure_captures_only_primitives(tmp_path):
+    # The LOAD-BEARING invariant is not just "the module imports torch-free" but "the pickled
+    # env-thunk unpickles torch-free in a SubprocVecEnv worker". cloudpickle serializes the
+    # closure's captured cells, so if the thunk closed over the torch-ful ModelConfig the worker
+    # would import torch on unpickle. Assert structurally that every captured cell is a primitive /
+    # stdlib Namespace and that `cfg` is not a free var — FAILS if the thunk recaptures cfg.* .
+    # (A SimpleNamespace stand-in is fine: it is NOT in the allowlist, so a cfg-capturing thunk
+    # still trips the assertion — unlike a type-module check, which false-passes on 'types'.)
+    import argparse
+
+    cfg = SimpleNamespace(max_areas=32, player_count=7)
+    a = _args(tmp_path)
+    thunk = tc._make_env_thunk(cfg, a, 2)
+
+    freevars = thunk.__code__.co_freevars or ()
+    assert "cfg" not in freevars, f"thunk captured `cfg`; it must capture only scalars: {freevars}"
+    allowed = (int, float, str, bool, type(None), argparse.Namespace)
+    for cell in thunk.__closure__ or ():
+        val = cell.cell_contents
+        assert isinstance(val, allowed), (
+            f"thunk closure captured a non-primitive {type(val)!r}; a SubprocVecEnv worker would "
+            f"import its module on unpickle (torch-leak risk)"
+        )
+
+
+# --- parser defaults (must equal the Node makeLeague defaults / production) --------------------
+
+
+def test_parser_pfsp_defaults_match_makeleague(tmp_path):
+    # These argparse defaults govern production; drift here silently retunes runs and diverges from
+    # the Node makeLeague defaults (scripts/lib/ppo-league.mjs).
+    a = _args(tmp_path)
+    assert a.reserve_baselines == 3
+    assert a.pfsp_epsilon == 0.05
+    assert a.pfsp_k == 2.0
+
+
+def test_parser_core_defaults(tmp_path):
+    a = _args(tmp_path)
+    # The tracer-protective numeric defaults; train.py overrides --lr/--ent-coef to a None sentinel.
+    assert a.lr == 1e-4
+    assert a.ent_coef == 0.0
+    assert a.n_envs == 1
+    assert a.gamma == 0.999
+    assert a.opponents == tc.DEFAULT_OPPONENTS
+    assert "ai_lookahead" in tc.DEFAULT_OPPONENTS
+
+
+def test_build_parser_threads_description():
+    # Each driver stamps its own --help description through the shared parser.
+    p = tc.build_parser("MY DESCRIPTION")
+    assert p.description == "MY DESCRIPTION"
+
+
+# --- _validate_args bounds --------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "overrides,needle",
+    [
+        ({"reserve_baselines": -1}, "reserve-baselines"),
+        ({"pfsp_epsilon": 0}, "pfsp-epsilon"),
+        ({"pfsp_epsilon": 1.5}, "pfsp-epsilon"),
+        ({"pfsp_k": -1}, "pfsp-k"),
+        ({"pfsp_k": "nan"}, "pfsp-k"),  # math.isfinite mirrors Node's Number.isFinite
+        ({"pfsp_k": "inf"}, "pfsp-k"),
+    ],
+)
+def test_validate_args_rejects_bad_pfsp_knobs(tmp_path, overrides, needle):
+    a = _args(tmp_path, **overrides)
+    with pytest.raises(SystemExit, match=needle):
+        tc._validate_args(a)
+
+
+def test_validate_args_rejects_indivisible_batch(tmp_path):
+    a = _args(tmp_path, n_steps=512, n_envs=1, batch_size=100)
+    with pytest.raises(SystemExit, match="must divide"):
+        tc._validate_args(a)
+
+
+def test_validate_args_rejects_zero_envs(tmp_path):
+    a = _args(tmp_path, n_envs=0, batch_size=1)  # batch divides 0; the n_envs guard must still fire
+    with pytest.raises(SystemExit, match="n-envs"):
+        tc._validate_args(a)
+
+
+def test_validate_args_rejects_missing_checkpoint():
+    a = tc.build_parser().parse_args(["--checkpoint", "/no/such/file.pt"])
+    with pytest.raises(SystemExit, match="not found"):
+        tc._validate_args(a)
+
+
+def test_validate_args_absolutizes_and_creates_snapshot_dir(tmp_path):
+    rel = tmp_path / "league"
+    a = _args(tmp_path, snapshot_dir=str(rel))
+    tc._validate_args(a)
+    assert Path(a.snapshot_dir).is_absolute()
+    assert Path(a.snapshot_dir).is_dir()
+
+
+# --- _make_env_thunk forwards server_kwargs (PATCH _train_common.DiceWarsEnv, not a driver) ----
+
+
+def test_make_env_thunk_forwards_pfsp_into_server_kwargs(tmp_path, monkeypatch):
+    captured = {}
+
+    class FakeEnv:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(tc, "DiceWarsEnv", FakeEnv)
+    a = _args(tmp_path, reserve_baselines=4, pfsp_epsilon=0.2, pfsp_k=1.5)
+    cfg = SimpleNamespace(max_areas=32, player_count=7)
+    tc._make_env_thunk(cfg, a, 0)()  # invoke the zero-arg env factory
+
+    sk = captured["server_kwargs"]
+    assert sk["reserve_baselines"] == 4
+    assert sk["pfsp_epsilon"] == 0.2
+    assert sk["pfsp_k"] == 1.5
+    # dims come from cfg, not free flags (the env pins the server to the BC config's shape).
+    assert captured["max_areas"] == 32
+    assert captured["player_count"] == 7
+
+
+def test_make_env_thunk_offsets_seed_base_per_index(tmp_path, monkeypatch):
+    seeds = []
+
+    class FakeEnv:
+        def __init__(self, **kwargs):
+            seeds.append(kwargs["server_kwargs"]["seed_base"])
+
+    monkeypatch.setattr(tc, "DiceWarsEnv", FakeEnv)
+    a = _args(tmp_path, seed_base=5)
+    cfg = SimpleNamespace(max_areas=32, player_count=7)
+    tc._make_env_thunk(cfg, a, 0)()
+    tc._make_env_thunk(cfg, a, 3)()
+    # Disjoint per-worker blocks so parallel envs don't replay identical episodes AND each Node
+    # worker keys a distinct league-state-<seedBase>.json under SubprocVecEnv.
+    assert seeds == [5, 5 + 3 * 1_000_000]
+
+
+def test_make_env_thunk_snapshot_manifest_set_and_unset(tmp_path, monkeypatch):
+    captured = {}
+
+    class FakeEnv:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(tc, "DiceWarsEnv", FakeEnv)
+    cfg = SimpleNamespace(max_areas=32, player_count=7)
+
+    a = _args(tmp_path, snapshot_dir=str(tmp_path / "league"))
+    tc._validate_args(a)  # absolutizes + mkdir
+    tc._make_env_thunk(cfg, a, 0)()
+    assert captured["server_kwargs"]["snapshot_manifest"] == str(
+        Path(a.snapshot_dir) / "manifest.json"
+    )
+
+    captured.clear()
+    b = _args(tmp_path)  # no --snapshot-dir ⇒ fixed-field (empty-pool) mode
+    tc._make_env_thunk(cfg, b, 0)()
+    assert captured["server_kwargs"]["snapshot_manifest"] is None
+
+
+# --- resolve_from_scratch (mutex + per-mode LR/ent-coef relaxation, [D-26] Q6) ----------------
+
+
+def test_resolve_from_scratch_mutex_with_freeze_trunk():
+    args = SimpleNamespace(from_scratch=True, freeze_trunk=True, lr=None, ent_coef=None)
+    with pytest.raises(SystemExit, match="mutually exclusive"):
+        tc.resolve_from_scratch(args)
+
+
+def test_resolve_from_scratch_relaxes_when_omitted():
+    args = SimpleNamespace(from_scratch=True, freeze_trunk=False, lr=None, ent_coef=None)
+    tc.resolve_from_scratch(args)
+    assert args.lr == 1e-3
+    assert args.ent_coef == 0.01
+
+
+def test_resolve_warm_start_fills_protective_defaults_when_omitted():
+    args = SimpleNamespace(from_scratch=False, freeze_trunk=False, lr=None, ent_coef=None)
+    tc.resolve_from_scratch(args)
+    assert args.lr == 1e-4
+    assert args.ent_coef == 0.0
+
+
+def test_resolve_explicit_values_stick():
+    # An explicit --lr/--ent-coef must survive resolution (None is the "omitted" sentinel).
+    args = SimpleNamespace(from_scratch=True, freeze_trunk=False, lr=7e-4, ent_coef=0.05)
+    tc.resolve_from_scratch(args)
+    assert args.lr == 7e-4
+    assert args.ent_coef == 0.05
+
+
+def test_resolve_no_from_scratch_attr_is_noop_warm_start():
+    # The tracer's Namespace has no `from_scratch`; getattr defaults False ⇒ warm-start fill.
+    args = SimpleNamespace(freeze_trunk=False, lr=None, ent_coef=None)
+    tc.resolve_from_scratch(args)
+    assert args.lr == 1e-4
+    assert args.ent_coef == 0.0

--- a/ml/tests/test_train_common_args.py
+++ b/ml/tests/test_train_common_args.py
@@ -143,6 +143,30 @@ def test_validate_args_rejects_zero_envs(tmp_path):
         tc._validate_args(a)
 
 
+@pytest.mark.parametrize(
+    "overrides,needle",
+    [
+        ({"batch_size": 0}, "batch-size"),  # guarded BEFORE the modulo (no raw ZeroDivisionError)
+        ({"batch_size": -4}, "batch-size"),
+        ({"lr": 0}, "--lr"),  # lr<=0 ⇒ a no-op training run
+        ({"lr": -0.001}, "--lr"),  # lr<0 ⇒ gradient ASCENT
+        ({"ent_coef": -0.1}, "--ent-coef"),  # ent<0 ⇒ malformed objective
+    ],
+)
+def test_validate_args_rejects_bad_hp_bounds(tmp_path, overrides, needle):
+    # The costliest explicit misconfigs (silently wasted GPU runs) — each must fail loud, not slip
+    # through. ent_coef==0 stays VALID (the warm-start default), so only ent<0 is rejected.
+    a = _args(tmp_path, **overrides)
+    with pytest.raises(SystemExit, match=needle):
+        tc._validate_args(a)
+
+
+def test_validate_args_accepts_zero_ent_coef(tmp_path):
+    # ent_coef==0.0 is the protective warm-start default; the ent>=0 guard must NOT reject it.
+    a = _args(tmp_path, ent_coef=0)
+    tc._validate_args(a)  # no raise
+
+
 def test_validate_args_rejects_missing_checkpoint():
     a = tc.build_parser().parse_args(["--checkpoint", "/no/such/file.pt"])
     with pytest.raises(SystemExit, match="not found"):

--- a/ml/tests/test_train_tracer_args.py
+++ b/ml/tests/test_train_tracer_args.py
@@ -1,13 +1,15 @@
-"""train_tracer PFSP arg plumbing: parser defaults, _validate_args bounds, server_kwargs forwarding.
+"""train_tracer PFSP arg plumbing: re-export wiring + parser defaults, _validate_args, forwarding.
 
 Torch/SB3-gated (``train_tracer`` imports them at module scope), so this runs on shodan and skips in
-the lean ``ml-test`` CI job — same pattern as test_snapshot_callback.py / test_ppo_policy.py. It
-covers the layers the torch-free test_env_server_argv.py cannot reach:
-  - the argparse defaults that ACTUALLY govern production runs (a separate copy from the
-    EnvServerProcess constructor defaults), which must agree with the Node makeLeague defaults;
+the lean ``ml-test`` CI job — same pattern as test_snapshot_callback.py / test_ppo_policy.py. The
+parser/validate/thunk surface itself now lives in the torch-free ``_train_common`` (and is covered
+lean in test_train_common_args.py); this file's remaining job is to prove the TRACER still exposes
+that surface byte-identically after the extraction:
+  - the re-export wiring (``tt._make_env_thunk is tc._make_env_thunk`` etc.);
+  - the argparse defaults that ACTUALLY govern production runs, which must agree with the Node
+    makeLeague defaults, are unchanged through the tracer's thin build_parser wrapper;
   - the unconditional PFSP range guards in _validate_args (mirroring the always-on Node guards); and
-  - the args -> server_kwargs hop inside _make_env_thunk (a typo there would pass the argv test but
-    silently mis-tune a multi-env run).
+  - the args -> server_kwargs hop inside _make_env_thunk (patched in _train_common, where it lives).
 """
 
 from __future__ import annotations
@@ -19,7 +21,16 @@ import pytest
 pytest.importorskip("torch")
 pytest.importorskip("sb3_contrib")
 
+import dicewars_ppo._train_common as tc  # noqa: E402
 import dicewars_ppo.train_tracer as tt  # noqa: E402
+
+
+def test_tracer_reexports_shared_core():
+    # The env-thunk + validation moved to the torch-free _train_common; the tracer re-imports them
+    # so its body (and these tests) keep the same names. build_parser is a thin wrapper that stamps
+    # the tracer's __doc__, so it is NOT identity-equal — assert its surface matches instead.
+    assert tt._make_env_thunk is tc._make_env_thunk
+    assert tt._validate_args is tc._validate_args
 
 
 def _args(tmp_path, **overrides):
@@ -74,10 +85,12 @@ def test_make_env_thunk_forwards_pfsp_into_server_kwargs(tmp_path, monkeypatch):
         def __init__(self, **kwargs):
             captured.update(kwargs)
 
-    monkeypatch.setattr(tt, "DiceWarsEnv", FakeEnv)
+    # The thunk resolves DiceWarsEnv in _train_common's namespace now (that's where it lives), so
+    # patch THERE — patching tt.DiceWarsEnv would miss it (and the name no longer exists on tt).
+    monkeypatch.setattr(tc, "DiceWarsEnv", FakeEnv)
     a = _args(tmp_path, reserve_baselines=4, pfsp_epsilon=0.2, pfsp_k=1.5)
     cfg = SimpleNamespace(max_areas=32, player_count=7)
-    tt._make_env_thunk(cfg, a, 0)()  # invoke the zero-arg env factory
+    tt._make_env_thunk(cfg, a, 0)()  # invoke the zero-arg env factory (== tc._make_env_thunk)
 
     server_kwargs = captured["server_kwargs"]
     assert server_kwargs["reserve_baselines"] == 4

--- a/ml/tests/test_train_tracer_args.py
+++ b/ml/tests/test_train_tracer_args.py
@@ -52,6 +52,25 @@ def test_parser_pfsp_defaults_match_makeleague(tmp_path):
     assert a.pfsp_k == 2.0
 
 
+def test_tracer_parser_golden_defaults():
+    # The shared _train_common.build_parser body now governs BOTH drivers, so pin the tracer's FULL
+    # default surface: an edit made for train.py's benefit inside the shared parser can't silently
+    # drift the tracer ([D-26] Q1 byte-identical). --out is the load-bearing one — the tracer keeps
+    # ppo-tracer.pt vs train.py's overridden ppo.pt, so a bare run can't clobber the other's
+    # checkpoint. (Parse [] directly: parse-time defaults only, no validation, so no real file.)
+    a = tt.build_parser().parse_args([])
+    assert (a.checkpoint, a.out) == ("checkpoints/v2-base/bc_model.pt", "checkpoints/ppo-tracer.pt")
+    assert (a.learner_seat, a.n_envs, a.timesteps, a.n_steps) == (0, 1, 2048, 512)
+    assert (a.batch_size, a.n_epochs, a.lr, a.gamma) == (128, 4, 1e-4, 0.999)
+    assert (a.gae_lambda, a.ent_coef, a.vf_coef) == (0.95, 0.0, 0.5)
+    assert (a.max_turns, a.seed, a.seed_base, a.device) == (500, 0, 1, "cpu")
+    assert a.freeze_trunk is False
+    assert (a.snapshot_dir, a.snapshot_every, a.snapshot_pool_cap) == (None, 50_000, 40)
+    assert a.opponents == tc.DEFAULT_OPPONENTS
+    # the tracer threads its OWN __doc__ as the --help description (help-text wiring is preserved)
+    assert tt.build_parser().description == tt.__doc__
+
+
 @pytest.mark.parametrize(
     "overrides,needle",
     [


### PR DESCRIPTION
## What

PR-4 of Phase-3 task C/E ([D-26] build sequence), on top of the merged foundation **PR #70**. Builds the real PPO training driver and extracts its torch-free shared core.

- **NEW `ml/dicewars_ppo/_train_common.py`** — torch/sb3-free shared core: `DEFAULT_OPPONENTS`, `_make_env_thunk`, `build_parser(description)`, `_validate_args`, `resolve_from_scratch`. `ModelConfig` is `TYPE_CHECKING`-only under `from __future__ import annotations` so the module imports torch-free.
- **`train_tracer.py`** reuses the shared core and is **byte-identical** (`build_model` gained `venv=None` + a from-scratch warm-start gate that is always-off for the tracer).
- **NEW `ml/dicewars_ppo/train.py`** — the real driver:
  - `VecMonitor(SubprocVecEnv(start_method=forkserver))` constructed **before** `MaskablePPO` (CUDA inits after the env fork — [D-26] Q4).
  - TensorBoard + flat CSV via `set_logger(configure(...))` before `learn()`, with graceful CSV-only degradation + a loud warning if `tensorboard` is missing.
  - `--from-scratch` (mutually exclusive with `--freeze-trunk`, relaxed LR/ent-coef via a `None` sentinel, provenance stamped), `--log-dir`, `--no-tensorboard`, `--start-method`.
- `tensorboard>=2.12` added to the `[rl]` extra (lean CI unaffected — never installs `[rl]`).

## The load-bearing fix (from review)

The env-thunk originally closed over `cfg` (the torch-ful `ModelConfig`), so a `SubprocVecEnv(forkserver/spawn)` worker would import torch on cloudpickle-unpickle — silently defeating the whole point of the extraction. Fixed by hoisting `max_areas`/`player_count` to locals so the closure captures only primitives + the stdlib `Namespace`. **Cloudpickle-proven**: no `dicewars_bc`/`ModelConfig`/`torch` bytes in the serialized env-fn. Guarded by a lean-tier closure-capture test.

## Deferred by design (not in PR-4)

- Full idempotent checkpoint/resume core + B6 persistence flag wiring + CSV cross-session append → **PR-5** (HOLE-D left as an explicit `TODO(PR-5)`; PR-4 trains fresh runs only).
- Committed shodan launcher + schtasks runbook → **PR-6**.
- Live `SubprocVecEnv(forkserver)` smoke + env-server `main()` persistence integration test → **PR-7**.

## HP-default note (reversible)

`train.py` warm-start defaults stay protective (lr 1e-4 / ent 0.0); `--from-scratch` relaxes to lr 1e-3 / ent 0.01. The task-A BEAT config (`--lr 2.5e-4 --ent-coef 0.01`) is **not** baked as a default — production HPs belong to the PR-6 launcher.

## Review & test

- Built via an understand workflow (6 readers → blueprint), then an **adversarial review workflow** (6 dimensions, per-finding verification) → **SHIP-AFTER-FIXES, 0 blockers**; all 6 minor findings folded in.
- `ruff` clean; **29 lean torch-free** tests + **114 gated/ppo** tests green; both CLIs compose; tracer parser surface confirmed unchanged.
- Gated torch/sb3 tests run on shodan/CI-with-`[rl]` (skip in the lean `ml-test` job), matching the existing tiering.