### PR TITLE
feat(ml): Phase-3 task C/E PR-5 — idempotent checkpoint/resume core (+ B6 flag forwarding, per-session CSV)

### DIFF
--- a/docs/ml-bot/DECISIONS.md
+++ b/docs/ml-bot/DECISIONS.md
@@ -1579,3 +1579,24 @@ EVERY `--device cuda` resume (now CPU-pinned in `load_rng_sidecar`; CUDA-gated r
 `test_train_tracer_args.py`) runs on **shodan**. _Shodan checklist before the BEAT run: `MaskablePPO.load`
 needs no `custom_objects`; `--device cuda` RNG restore; `_setup_learn` caps at the absolute `--timesteps`;
 live forkserver two-half resume._
+
+**PR-5 review-hardening (2026-06-28).** A comprehensive 4-lens PR review (#72: code / silent-failure /
+tests / comments) + a 3-lens adversarial re-verify of the fixes refined the resume contract without
+changing its shape. Decisions folded in (each with regression coverage): (a) **nothing downstream of
+`MaskablePPO.load` may abort a resume** — a corrupt/torn RNG sidecar DEGRADES to a fresh stream with a
+loud warn (`restore_rng_sidecar`), since the recoverable state (policy+optimizer+`num_timesteps`) is
+already loaded and RNG continuity is already "bounded-skew, not bit-exact" (Q3); aborting would brick a
+fully-recoverable checkpoint (a PERMANENT crash-loop under the PR-6 auto-restart). (b) A
+present-but-rejected `latest.json` gets a **cause-specific, NON-destructive warning** — the decision is
+lifted into the torch-free, CI-testable `classify_latest_pointer` / `describe_pointer_rejection`
+(behavior-preserving for `read_latest_pointer` via a shared `_parse_latest`), steering the operator AWAY
+from deleting `latest.json` when the on-disk ckpt pairs are still loadable; but **NO blanket auto-fallback**
+to the retained `keep=2` pair (version/encoding-skew ckpts are genuinely incompatible, and a silent
+step-change is worse than a clear manual-recovery message). (c) The GPU-resume CPU-pinning invariant is now
+pinned in **lean CI** (a `map_location` spy), not only by the shodan-only CUDA test; GC enumeration unions
+`.zip`+`.rng.pt` so a half-failed unlink's orphan sidecar is swept. Also fixed prior comment-rot (the
+self-contradictory "load-bearing guard (unlike dump-every)" — Node DOES also check; "LISTENING
+timeout"→"exited before listening"; a line-ref → symbol). Verification: ruff clean; torch-free tier 66
+green; sb3 tier shodan-only. The verify workflow also caught a shodan-only `AttributeError`
+(`train.py` imported only `POINTER_ABSENT`/`POINTER_VALID` but a test referenced `tr.POINTER_CORRUPT_JSON`)
+→ tests now import the reason constants from `resume_state`, not through `tr`.

--- a/docs/ml-bot/DECISIONS.md
+++ b/docs/ml-bot/DECISIONS.md
@@ -1522,7 +1522,7 @@ producer GC, consumer `unlinkSync` removed (DONE, #70) · PR-4 `_train_common.py
   shodan launcher + schtasks runbook · PR-7 deferred test-hardening (env-server `main()` persistence
   integration test; live cross-worker `SharedDiskStore`).
 
-**Status: IN PROGRESS — foundation PR-1→PR-3 MERGED (#70); PR-4 DONE locally (branch `ml-bot/task-ce-pr4-train`). Next: PR-5 resume core.** PR-1:
+**Status: IN PROGRESS — foundation PR-1→PR-3 MERGED (#70); PR-4 MERGED (#71, `f1224ee`); PR-5 DONE locally (branch `ml-bot/task-ce-pr5-resume`). Next: PR-6 shodan launcher + runbook.** PR-1:
 `episodeCount` resume-cursor, `dumpLeagueState` state-then-flush order, `refresh()` ENOENT-tolerance +
 id-dedup + `refreshSkips` health counter (stderr DONE mirror), schema v1→v2. PR-2: `snapshot_store` /
 `league_state_dir` / `league_dump_every` forwarded by `EnvServerProcess` on their own gate (manifest-
@@ -1552,3 +1552,30 @@ New `train.py` = `VecMonitor(SubprocVecEnv(start_method=forkserver))` built BEFO
   lean torch-free tier (`test_train_common_args.py`, incl. a closure-capture guard) + gated torch/sb3
   tier (`test_train_args.py` build_model/logging/wrap-order, `test_train_tracer_args.py` re-export
   wiring) green. The torch-gated tests + the live SubprocVecEnv/shodan paths run on shodan.
+
+**PR-5 (DONE locally, branch `ml-bot/task-ce-pr5-resume`) — idempotent checkpoint/resume core.**
+Python-side only (the Node league half shipped in #70). Three deliverables: (1) **HOLE-D** — on resume
+`train.py` calls `learn(total_timesteps=_remaining_timesteps(args.timesteps, num_timesteps),
+reset_num_timesteps=False)` (torch-free helper in `_train_common`); `remaining==0` SKIPS `learn` but
+still re-exports. (2) **resume core** — split into a torch+sb3-FREE `resume_state.py` (RNG sidecar,
+atomic `latest.json` written LAST + dir-fsync, GC keep-N, pointer validation, `save_resume_checkpoint`)
+and an sb3 `resume.py` (`load_resume_checkpoint` via `MaskablePPO.load(env=venv)` = PATH A so
+`num_timesteps` is restored before `SnapshotCallback._on_training_start` reads it — HOLE-C; +
+`ResumeCheckpointCallback`). The split mirrors `snapshot_manifest`/`snapshot_callback` so the hinge logic
+is **CI-testable without sb3**. Resume **auto-detects** a valid `latest.json` (absent⇒fresh silent,
+corrupt/version/encoding-skew⇒loud warn+fresh); new `--state-dir`/`--checkpoint-every` (default 50k,
+distinct from the Node `--league-state-dir`). (3) **B6 flag forwarding** — `--snapshot-store`/
+`--league-state-dir`/`--league-dump-every` added to the shared torch-free parser + `server_kwargs`
+(`EnvServerProcess` already accepts/emits them since PR-2); Node-mirrored validation. CSV is per-session
+(`progress-<resumed_step>.csv`) via explicit `output_formats` (no more `configure()` truncation);
+`--freeze-trunk`+`--state-dir` rejected eagerly (load can't restore the build-time freeze).
+**Verification:** ruff clean; torch-free tier green locally (`test_resume_state.py` 13 incl. RNG
+`weights_only`/atomicity/GC + `test_train_common_args.py` league-flag/forwarding/`_remaining_timesteps`).
+Reviewed by a 13-agent blueprint workflow + a 4-lens implementation review → **2 blockers found & fixed:**
+(a) the RNG sidecar was mapped to the model device → `torch.set_rng_state` rejects a GPU tensor, crashing
+EVERY `--device cuda` resume (now CPU-pinned in `load_rng_sidecar`; CUDA-gated regression test added);
+(b) two `_make_logger` test sites 3-unpacked its 2-tuple → the sb3 tier was RED (fixed). The sb3 tier
+(`test_resume.py` load round-trip + `_setup_learn` HOLE-D + callback cadence; `test_train_args.py`;
+`test_train_tracer_args.py`) runs on **shodan**. _Shodan checklist before the BEAT run: `MaskablePPO.load`
+needs no `custom_objects`; `--device cuda` RNG restore; `_setup_learn` caps at the absolute `--timesteps`;
+live forkserver two-half resume._

--- a/docs/ml-bot/LOG.md
+++ b/docs/ml-bot/LOG.md
@@ -21,6 +21,35 @@ Entry template:
 
 ---
 
+## 2026-06-28 — Task C/E PR-5 review-hardening (corrupt-sidecar degrade, CI-testable resume decision, GC orphan-sweep)
+
+**Phase:** 3 · **Who:** Ivan + Claude
+
+**Did:**
+
+- Ran the comprehensive PR review (`/review-pr`) on the committed PR-5 diff (#72) — 4 parallel lenses (code / silent-failure / tests / comments). Implemented the actionable findings on the same branch (`ml-bot/task-ce-pr5-resume`), then adversarially re-verified the fixes with a 3-lens workflow over my own diff.
+- **Corrupt RNG sidecar now DEGRADES, not aborts** (`restore_rng_sidecar`): `MaskablePPO.load` has already restored policy+optimizer+`num_timesteps` before the sidecar is read, so a torn/bit-rotted sidecar warns + continues with a FRESH RNG stream instead of bricking a fully-recoverable resume (which under the PR-6 auto-restart would be a PERMANENT crash-loop). CI + shodan regression tests.
+- **GPU-resume blocker now locked in LEAN CI**: the CPU-pinning invariant is CPU-observable, so a `map_location` spy (`test_load_rng_sidecar_always_maps_to_cpu`) pins it without a GPU — the prior CUDA-gated test never ran in CI / on the Mac / on any CPU box.
+- **Resume decision lifted into torch-free, CI-testable logic**: `_parse_latest` → `classify_latest_pointer` + `describe_pointer_rejection` (behavior-preserving for `read_latest_pointer`). The present-but-rejected warning is now CAUSE-SPECIFIC and NON-DESTRUCTIVE — it steers AWAY from deleting `latest.json` when the on-disk ckpt pairs are still recoverable (the old "move it aside" wording pointed at the breadcrumb). 7 new CI tests.
+- **GC orphan-sweep**: `_checkpoint_steps` now unions `.zip`+`.rng.pt`, so a half-failed unlink's orphan sidecar is swept on the next pass; `_fsync_dir` macOS degrade now logs once. Tests incl. the ≥1e9 (10-digit) GC case.
+- **Comment fixes folded** (from the review's comment lens): the self-contradictory "load-bearing guard (unlike dump-every)" (Node DOES also check the disk-dir case); "LISTENING timeout"→"exited before listening"; `env_server.py:144-149` line-ref → symbol; `--checkpoint-every` help ("not dynamically coupled to `--snapshot-every`"); resume-provenance note.
+
+**Learned / decided:**
+
+- **The model zip is the expensive recoverable asset; nothing downstream of `MaskablePPO.load` may abort a resume.** A corrupt sidecar / a single-byte-corrupt pointer must degrade or warn-and-recover — never silently restart-from-0 or crash a multi-day checkpoint.
+- **No blanket auto-fallback to the retained `keep=2` checkpoint.** Version/encoding-skew on-disk ckpts are genuinely incompatible (fresh is correct), and a silent step-change is worse than a clear manual-recovery message — so the response is a cause-specific warning, not magic recovery. (Revisit only for the corrupt-pointer/dangling-ref cases if it ever bites.)
+
+**Dead ends / surprises:**
+
+- **The verification workflow caught a shodan-only bug I introduced**: `train.py` imported only `POINTER_ABSENT`/`POINTER_VALID`, but a shodan test referenced `tr.POINTER_CORRUPT_JSON` → `AttributeError` only on the box that runs it. Fixed by having the tests import the reason constants from their canonical module (`resume_state`) instead of reaching through `tr`, so they no longer depend on train.py's import list.
+- **Self-inflicted git hiccup, fully reversed**: a bare `git stash pop` during verification grabbed a pre-existing `lint-staged automatic backup` stash and left conflict markers across 9 unrelated files. Backed up the 7 changed files, restored the 9 paths to HEAD, md5-verified the work byte-identical. Lesson: never `git stash pop` with no arg when an unrelated stash may sit on top.
+
+**Next:**
+
+- The PR-5 shodan checklist still applies (the sb3 tier can't run locally): `MaskablePPO.load` needs no `custom_objects`; `--device cuda` RNG restore; `_setup_learn` caps at the absolute `--timesteps` (HOLE-D); the new corrupt-sidecar/CUDA regressions. Then **PR-6** = committed shodan launcher + schtasks runbook → the long BEAT run.
+
+---
+
 ## 2026-06-27 — Task C/E PR-5 — idempotent checkpoint/resume core (+ B6 flag forwarding, per-session CSV)
 
 **Phase:** 3 · **Who:** Ivan + Claude

--- a/docs/ml-bot/LOG.md
+++ b/docs/ml-bot/LOG.md
@@ -21,6 +21,34 @@ Entry template:
 
 ---
 
+## 2026-06-27 — Task C/E PR-5 — idempotent checkpoint/resume core (+ B6 flag forwarding, per-session CSV)
+
+**Phase:** 3 · **Who:** Ivan + Claude
+
+**Did:**
+
+- **Built PR-5** ([D-26] build sequence; branch `ml-bot/task-ce-pr5-resume` off master @ PR #71 `f1224ee`). Python-side only — the Node league resume half shipped in #70.
+- **Grounding workflow** mapped the _current_ code + the SB3 resume API + test seams, then adversarially verified the blueprint. Surfaced 3 genuine forks → Ivan chose: dedicated `--state-dir`+`--checkpoint-every` (50k); auto-detect a valid `latest.json`; land per-session CSV now.
+- **Three deliverables:** (1) **HOLE-D** budget cap — torch-free `_remaining_timesteps` + `learn(..., reset_num_timesteps=False)`; `remaining==0` skips `learn` but still re-exports. (2) **Resume core** split into torch+sb3-FREE `resume_state.py` (RNG sidecar, atomic `latest.json` written LAST + dir-fsync, GC keep-N, pointer validation, `save_resume_checkpoint`) + sb3 `resume.py` (`load_resume_checkpoint` via `MaskablePPO.load(env=venv)` = PATH A/HOLE-C; `ResumeCheckpointCallback`). (3) **B6 flag forwarding** — `--snapshot-store`/`--league-state-dir`/`--league-dump-every` into the shared parser + `server_kwargs` (`EnvServerProcess` already emitted them since PR-2); Node-mirrored validation. Plus: per-session CSV via explicit `output_formats`; auto-detect resume (corrupt `latest.json`⇒loud warn+fresh); `--freeze-trunk`+`--state-dir` rejected eagerly.
+- **4-lens implementation review** (idempotency / torch-free / SB3-API / tests+contract) on the real diff.
+
+**Learned / decided:**
+
+- **Split `resume_state.py` (torch, sb3-FREE) from `resume.py` (sb3)** mirroring `snapshot_manifest`/`snapshot_callback`: the lean CI tier has torch but no sb3, so keeping the riskiest hinge logic (atomic `latest.json`, GC, RNG `weights_only` round-trip) sb3-free makes it **CI-testable** (`test_resume_state.py` 13 green locally) instead of shodan-only.
+- **Test-tier topology (Phase-3 PPO):** torch+sb3-free → runs anywhere w/ torch; torch-free-but-gymnasium (lean CI: `test_train_common_args`) → needs gymnasium; torch+sb3 (`test_resume`, `test_train_args`, …) → SHODAN-ONLY. Captured in the mini-env memory.
+
+**Dead ends / surprises:**
+
+- **Review caught 2 blockers I introduced** (both untested by the green tiers): (a) the RNG sidecar was loaded with `map_location=device`, so a `--device cuda` resume relocates the CPU RNG ByteTensor to GPU and `torch.set_rng_state` raises `TypeError` — **crashed EVERY GPU resume** (the shodan BEAT target). Fixed: `load_rng_sidecar` is CPU-pinned (no device param) + a CUDA-gated regression test. (b) two `_make_logger` test sites 3-unpacked its 2-tuple → the **sb3 tier was RED** and the per-session-CSV/TB-degrade branches had zero coverage. Fixed. Both folded with regression coverage.
+- Also folded: eager `--freeze-trunk`+`--state-dir` rejection (else every checkpoint is un-resumable, discovered only after a crash); dir-fsync after `os.replace` (the pair is the only model copy); width-agnostic `_CKPT_RE` (`:09d` is a min-width → 10-digit leak at ≥1e9 steps); softened the CSV docstring (a same-step crash-loop still truncates — bounded, observability-only).
+
+**Next:**
+
+- **Shodan validation before merge** (sb3 tier can't run locally): `MaskablePPO.load` needs no `custom_objects`; `--device cuda` RNG restore; `_setup_learn` caps at the absolute `--timesteps` (HOLE-D); live forkserver two-half resume. Then commit + open the PR-5 PR.
+- **PR-6** = committed shodan launcher + schtasks runbook → then the long BEAT run.
+
+---
+
 ## 2026-06-27 — Task C/E PR-4 — `train.py` + torch-free `_train_common.py` (SubprocVecEnv + TB/CSV + `--from-scratch`)
 
 **Phase:** 3 · **Who:** Ivan + Claude

--- a/docs/ml-bot/PLAN.md
+++ b/docs/ml-bot/PLAN.md
@@ -540,13 +540,20 @@ ppo:gate` over **3040 seat-fair games**: PPO **11.5 ± 1.3%** vs Lookahead **15.
   ENOENT-tolerance then producer-single-writer GC; `--from-scratch` control. **Foundation PR-1→PR-3
   MERGED (PR #70, `97de4e4`):** Node crash-safety + GC-race floor + `episodeCount` resume-cursor (PR-1);
   `EnvServerProcess` B6-flag forwarding (PR-2); SnapshotCallback rehydration + single-writer producer
-  GC, consumer `unlinkSync` removed (PR-3). **PR-4 landed locally** (branch `ml-bot/task-ce-pr4-train`):
+  GC, consumer `unlinkSync` removed (PR-3). **PR-4 MERGED (PR #71, `f1224ee`):**
   new torch-free `_train_common.py` (shared env-thunk/parser/validation + `resolve_from_scratch`) reused
   by a byte-identical `train_tracer.py`; new `train.py` = `VecMonitor(SubprocVecEnv(forkserver))` +
-  TensorBoard/CSV logging + `--from-scratch`; `tensorboard` added to `[rl]`. Adversarially reviewed
-  (6-dimension workflow, SHIP-AFTER-FIXES → all 6 minor findings folded, incl. the load-bearing
-  thunk-capture fix that makes the torch-free-worker invariant genuinely true — cloudpickle-proven).
-  ruff clean; lean torch-free tier + gated torch/sb3 tier green.
+  TensorBoard/CSV logging + `--from-scratch`; `tensorboard` added to `[rl]`. **PR-5 landed locally**
+  (branch `ml-bot/task-ce-pr5-resume`) — idempotent checkpoint/resume core: HOLE-D budget cap
+  (`_remaining_timesteps` + `reset_num_timesteps=False`); NEW torch+sb3-FREE `resume_state.py` (RNG
+  sidecar, atomic `latest.json`-written-last + dir-fsync, GC keep-N, pointer validation) + sb3
+  `resume.py` (`load_resume_checkpoint` = `MaskablePPO.load` PATH A so num_timesteps restores before
+  `SnapshotCallback` reads it = HOLE-C; `ResumeCheckpointCallback`); auto-detect resume (corrupt
+  `latest.json`⇒loud warn+fresh); per-session CSV; B6 flags (`--snapshot-store`/`--league-state-dir`/
+  `--league-dump-every`) forwarded from the shared parser into `server_kwargs`; `--state-dir`/
+  `--checkpoint-every`. 4-lens impl review → **2 blockers found & fixed** (GPU-resume RNG `set_rng_state`
+  crash → CPU-pinned; sb3-tier RED from a 2-tuple 3-unpack). ruff clean; torch-free tier green locally;
+  the sb3 tier runs on shodan. See [D-26].
 - [~] **(C)** Scale envs across cores; add the short **from-scratch control** run ([D-19] decision 1).
   **PR-4 landed locally** (branch `ml-bot/task-ce-pr4-train`): `train.py` swaps `DummyVecEnv` →
   `VecMonitor(SubprocVecEnv(start_method=forkserver))` (env fork before `MaskablePPO`/CUDA init)
@@ -559,10 +566,10 @@ ppo:gate` over **3040 seat-fair games**: PPO **11.5 ± 1.3%** vs Lookahead **15.
       (the only disconnect-surviving pattern); idempotent checkpoint/resume of policy + optimizer +
       RNG + step + league pool/book (**NOT VecNormalize** — dropped per [D-26]); TensorBoard + a flat
       CSV that survives sessions; swap `DummyVecEnv` → `SubprocVecEnv` for real cross-core parallelism.
-      _Slices: **PR-4 `train.py` + TB/CSV + SubprocVecEnv + `--from-scratch` — landed locally** (branch
-      `ml-bot/task-ce-pr4-train`; the cross-session CSV append is explicitly PR-5's resume seam, not
-      PR-4's), PR-5 (checkpoint/resume core), PR-6 (committed shodan launcher + schtasks runbook),
-      PR-7 (deferred test-hardening). See [D-26]._
+      _Slices: **PR-4 MERGED** (PR #71 `f1224ee` — `train.py` + TB/CSV + SubprocVecEnv +
+      `--from-scratch`); **PR-5 landed locally** (branch `ml-bot/task-ce-pr5-resume` — checkpoint/resume
+      core + per-session CSV + B6 flag forwarding, 2 review blockers fixed); PR-6 (committed shodan
+      launcher + schtasks runbook), PR-7 (deferred test-hardening). See [D-26]._
 
 **Acceptance criteria.**
 

--- a/ml/dicewars_ppo/_train_common.py
+++ b/ml/dicewars_ppo/_train_common.py
@@ -196,8 +196,9 @@ def build_parser(description: str | None = None) -> argparse.ArgumentParser:
     )
     # League persistence (B6 / task E, [D-26]). The Node env-server's resume half: each worker
     # checkpoints its PFSP pool + win-rate book. All default None so an unset value yields argv
-    # byte-identical to B5 (EnvServerProcess None-gates each, env_server.py:144-149) — the tracer's
-    # golden surface is unchanged. Forwarded to the env-server via _make_env_thunk's server_kwargs.
+    # byte-identical to B5 (EnvServerProcess.__init__ None-gates each league-persistence flag) — the
+    # tracer's golden surface is unchanged. Forwarded to the env-server via _make_env_thunk's
+    # server_kwargs.
     p.add_argument(
         "--snapshot-store",
         choices=("memory", "disk"),
@@ -271,7 +272,8 @@ def _validate_args(args: argparse.Namespace) -> None:
         Path(args.snapshot_dir).mkdir(parents=True, exist_ok=True)
     # League persistence (B6 / task E, [D-26]). Front-run the Node guards (resolveLeaguePersistence
     # + the dump-every guard, scripts/ppo-env-server.mjs) so a misconfig fails HERE at launch with a
-    # clear message instead of as an opaque env-server LISTENING timeout after the worker spawns.
+    # clear message instead of as an opaque "exited before listening" env-server startup failure
+    # after the worker spawns (Node throws BEFORE it prints PPO_ENV_SERVER LISTENING).
     if args.league_dump_every is not None and args.league_dump_every < 1:
         # Node validates this unconditionally (Number.isInteger || <1 throws); we just fail faster.
         raise SystemExit(
@@ -279,8 +281,9 @@ def _validate_args(args: argparse.Namespace) -> None:
         )
     if args.snapshot_store == "disk" and not (args.league_state_dir or args.snapshot_dir):
         # Node derives the disk dir from --league-state-dir, else the snapshot manifest's dir; with
-        # neither it throws at spawn (resolveLeaguePersistence), seen only as a startup timeout.
-        # This is the load-bearing guard (unlike dump-every, which Node also checks).
+        # neither, resolveLeaguePersistence throws at spawn (before LISTENING, so it surfaces as an
+        # "exited before listening" startup failure). Like the dump-every guard above, Node ALSO
+        # enforces this — we front-run both only to fail at launch with a clearer message.
         raise SystemExit(
             "--snapshot-store=disk needs a shared directory: pass --league-state-dir=<dir> "
             "or --snapshot-dir=<dir>."

--- a/ml/dicewars_ppo/_train_common.py
+++ b/ml/dicewars_ppo/_train_common.py
@@ -81,6 +81,13 @@ def _make_env_thunk(cfg: ModelConfig, args: argparse.Namespace, env_index: int):
                 "reserve_baselines": args.reserve_baselines,
                 "pfsp_epsilon": args.pfsp_epsilon,
                 "pfsp_k": args.pfsp_k,
+                # League persistence (B6 / task E). Read off `args` (already captured) — no new
+                # closure free-var, so the torch-free thunk stays primitive-only. The SAME
+                # league_state_dir goes to every env_index: per-worker uniqueness is the Node-side
+                # `league-state-<seedBase>.json` filename (the seed_base offset above).
+                "snapshot_store": args.snapshot_store,
+                "league_state_dir": args.league_state_dir,
+                "league_dump_every": args.league_dump_every,
             },
         )
 
@@ -187,6 +194,32 @@ def build_parser(description: str | None = None) -> argparse.ArgumentParser:
         help="PFSP weight exponent k (>= 0) for w(S)=max(eps,1-winRate)**k. Only used with "
         "--snapshot-dir.",
     )
+    # League persistence (B6 / task E, [D-26]). The Node env-server's resume half: each worker
+    # checkpoints its PFSP pool + win-rate book. All default None so an unset value yields argv
+    # byte-identical to B5 (EnvServerProcess None-gates each, env_server.py:144-149) — the tracer's
+    # golden surface is unchanged. Forwarded to the env-server via _make_env_thunk's server_kwargs.
+    p.add_argument(
+        "--snapshot-store",
+        choices=("memory", "disk"),
+        default=None,
+        help="League win-rate backend: 'disk' = cross-worker store, 'memory' = per-worker "
+        "(the env-server default). Needs a shared dir (--league-state-dir or --snapshot-dir) when "
+        "'disk'. Unset ⇒ not forwarded (env-server default).",
+    )
+    p.add_argument(
+        "--league-state-dir",
+        default=None,
+        help="Directory each Node worker dumps its league pool+book into "
+        "(league-state-<seedBase>.json) — enables the league-side resume half ([D-26] Q3). Unset ⇒ "
+        "league persistence off.",
+    )
+    p.add_argument(
+        "--league-dump-every",
+        type=int,
+        default=None,
+        help="Node worker league-state dump cadence in BOOKED episodes (only used with league "
+        "persistence). Unset ⇒ the env-server default (50).",
+    )
     return p
 
 
@@ -236,6 +269,27 @@ def _validate_args(args: argparse.Namespace) -> None:
         # resolve the same manifest path; create it now so env-servers can stat() it from ep 0.
         args.snapshot_dir = str(Path(args.snapshot_dir).resolve())
         Path(args.snapshot_dir).mkdir(parents=True, exist_ok=True)
+    # League persistence (B6 / task E, [D-26]). Front-run the Node guards (resolveLeaguePersistence
+    # + the dump-every guard, scripts/ppo-env-server.mjs) so a misconfig fails HERE at launch with a
+    # clear message instead of as an opaque env-server LISTENING timeout after the worker spawns.
+    if args.league_dump_every is not None and args.league_dump_every < 1:
+        # Node validates this unconditionally (Number.isInteger || <1 throws); we just fail faster.
+        raise SystemExit(
+            f"--league-dump-every must be a positive integer (got {args.league_dump_every})."
+        )
+    if args.snapshot_store == "disk" and not (args.league_state_dir or args.snapshot_dir):
+        # Node derives the disk dir from --league-state-dir, else the snapshot manifest's dir; with
+        # neither it throws at spawn (resolveLeaguePersistence), seen only as a startup timeout.
+        # This is the load-bearing guard (unlike dump-every, which Node also checks).
+        raise SystemExit(
+            "--snapshot-store=disk needs a shared directory: pass --league-state-dir=<dir> "
+            "or --snapshot-dir=<dir>."
+        )
+    if args.league_state_dir is not None:
+        # Absolutize + create so this process and the Node consumers (cwd=repo-root) agree on the
+        # path, mirroring the snapshot_dir handling above.
+        args.league_state_dir = str(Path(args.league_state_dir).resolve())
+        Path(args.league_state_dir).mkdir(parents=True, exist_ok=True)
 
 
 def resolve_from_scratch(args: argparse.Namespace) -> None:
@@ -271,3 +325,18 @@ def resolve_from_scratch(args: argparse.Namespace) -> None:
         args.lr = 1e-3 if from_scratch else 1e-4
     if getattr(args, "ent_coef", None) is None:
         args.ent_coef = 0.01 if from_scratch else 0.0
+
+
+def _remaining_timesteps(total: int, num_timesteps: int) -> int:
+    """Env steps left in an absolute ``--timesteps`` budget after a resume ([D-26] HOLE-D).
+
+    On resume ``train.py`` calls ``model.learn(total_timesteps=_remaining_timesteps(args.timesteps,
+    model.num_timesteps), reset_num_timesteps=False)``. Under ``reset_num_timesteps=False`` SB3's
+    ``_setup_learn`` adds ``num_timesteps`` back internally, so the run stops at the ABSOLUTE
+    ``--timesteps`` rather than an extra ``num_timesteps`` per relaunch — without this cap a
+    crash-loop makes ``--timesteps`` additive and trains unbounded. Clamped at 0 so an already-met
+    budget is a clean no-op (``learn`` is skipped), never a negative SB3 would reject.
+
+    Torch-free (pure arithmetic) so the lean CI tier proves the cap without importing the learner.
+    """
+    return max(int(total) - int(num_timesteps), 0)

--- a/ml/dicewars_ppo/resume.py
+++ b/ml/dicewars_ppo/resume.py
@@ -10,7 +10,8 @@ env-thunk's module — so the [D-26] Q4 torch-free invariant for ``_train_common
 
 This is the **Python half** of the two-half resume ([D-26] Q3): it owns the policy + optimizer +
 ``num_timesteps`` + process RNG. The other half is the Node league's per-worker
-``league-state-<seedBase>.json`` (see ``scripts/lib/ppo-league-store.mjs``); the two resume
+``league-state-<seedBase>.json`` (whose filename is built in ``scripts/ppo-env-server.mjs``'s
+``resolveLeaguePersistence``; serialized via ``scripts/lib/ppo-league-store.mjs``); the two resume
 INDEPENDENTLY (no two-phase commit), so resume is "statistically consistent, bounded-skew," NOT
 bit-exact.
 """
@@ -25,11 +26,19 @@ from stable_baselines3.common.callbacks import BaseCallback
 
 from .resume_state import (
     LATEST_NAME,
+    POINTER_ABSENT,
+    POINTER_CORRUPT_JSON,
+    POINTER_DANGLING_REF,
+    POINTER_ENCODING_SKEW,
+    POINTER_VALID,
+    POINTER_VERSION_SKEW,
     RESUME_FORMAT_VERSION,
+    classify_latest_pointer,
+    describe_pointer_rejection,
     has_resume_checkpoint,
     latest_pointer_exists,
-    load_rng_sidecar,
     read_latest_pointer,
+    restore_rng_sidecar,
     save_resume_checkpoint,
 )
 
@@ -37,12 +46,21 @@ from .resume_state import (
 # even though the implementation lives in the sb3-free sibling.
 __all__ = [
     "LATEST_NAME",
+    "POINTER_ABSENT",
+    "POINTER_CORRUPT_JSON",
+    "POINTER_DANGLING_REF",
+    "POINTER_ENCODING_SKEW",
+    "POINTER_VALID",
+    "POINTER_VERSION_SKEW",
     "RESUME_FORMAT_VERSION",
     "ResumeCheckpointCallback",
+    "classify_latest_pointer",
+    "describe_pointer_rejection",
     "has_resume_checkpoint",
     "latest_pointer_exists",
     "load_resume_checkpoint",
     "read_latest_pointer",
+    "restore_rng_sidecar",
     "save_resume_checkpoint",
 ]
 
@@ -55,7 +73,8 @@ def load_resume_checkpoint(state_dir: str | Path, venv: Any, device: str) -> Mas
     snapshot producer rehydrates against the RESUMED step, not 0 — HOLE-C). Building a fresh model +
     ``set_parameters`` instead would leave ``num_timesteps`` at 0 and the snapshot producer would
     classify the entire on-disk pool as "future" and delete it — so the resume MUST go through
-    ``load``. Then the RNG sidecar is restored.
+    ``load``. Then the RNG sidecar is restored — but a corrupt sidecar DEGRADES to a fresh stream
+    (``restore_rng_sidecar``) rather than aborting: the recoverable state is already loaded.
     """
     pointer = read_latest_pointer(state_dir)
     if pointer is None:
@@ -65,8 +84,10 @@ def load_resume_checkpoint(state_dir: str | Path, venv: Any, device: str) -> Mas
     rng_path = state_dir / pointer["rng"]
     model = MaskablePPO.load(zip_path, env=venv, device=device)
     # The MODEL load honors `device`, but the RNG sidecar must NOT — RNG states are CPU ByteTensors
-    # and set_rng_state rejects a GPU-mapped tensor (would crash every --device cuda resume).
-    load_rng_sidecar(rng_path)
+    # and set_rng_state rejects a GPU-mapped tensor (would crash every --device cuda resume). And a
+    # torn/bit-rotted sidecar degrades to a fresh RNG stream (loud warn), not bricking the resume
+    # whose model/optimizer/num_timesteps are already restored above.
+    restore_rng_sidecar(rng_path)
     return model
 
 

--- a/ml/dicewars_ppo/resume.py
+++ b/ml/dicewars_ppo/resume.py
@@ -1,0 +1,117 @@
+"""SB3 learner glue for idempotent resume (Phase 3, task C/E, PR-5, [D-26]).
+
+This is the ``sb3``-coupled half of the resume machinery — ``MaskablePPO.load`` and the
+``BaseCallback`` subclass that drives periodic checkpoints. The ``sb3``-free core (RNG sidecar,
+atomic ``latest.json``, GC, ``save_resume_checkpoint``, pointer validation) lives in the sibling
+``resume_state.py`` so it can be CI-tested without ``sb3`` (mirroring ``snapshot_callback.py`` ↔
+``snapshot_manifest.py``). Imported ONLY by ``train.py`` (already torch-ful), never by the
+env-thunk's module — so the [D-26] Q4 torch-free invariant for ``_train_common`` /
+``SubprocVecEnv`` workers holds.
+
+This is the **Python half** of the two-half resume ([D-26] Q3): it owns the policy + optimizer +
+``num_timesteps`` + process RNG. The other half is the Node league's per-worker
+``league-state-<seedBase>.json`` (see ``scripts/lib/ppo-league-store.mjs``); the two resume
+INDEPENDENTLY (no two-phase commit), so resume is "statistically consistent, bounded-skew," NOT
+bit-exact.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from sb3_contrib import MaskablePPO
+from stable_baselines3.common.callbacks import BaseCallback
+
+from .resume_state import (
+    LATEST_NAME,
+    RESUME_FORMAT_VERSION,
+    has_resume_checkpoint,
+    latest_pointer_exists,
+    load_rng_sidecar,
+    read_latest_pointer,
+    save_resume_checkpoint,
+)
+
+# Re-export the pointer helpers train.py uses, so it imports its whole resume surface from one place
+# even though the implementation lives in the sb3-free sibling.
+__all__ = [
+    "LATEST_NAME",
+    "RESUME_FORMAT_VERSION",
+    "ResumeCheckpointCallback",
+    "has_resume_checkpoint",
+    "latest_pointer_exists",
+    "load_resume_checkpoint",
+    "read_latest_pointer",
+    "save_resume_checkpoint",
+]
+
+
+def load_resume_checkpoint(state_dir: str | Path, venv: Any, device: str) -> MaskablePPO:
+    """Load the learner from the latest valid checkpoint (PATH A — restores num_timesteps, [D-26]).
+
+    Uses ``MaskablePPO.load(env=venv)`` so policy + optimizer + ``num_timesteps`` are restored in
+    ONE call BEFORE ``learn`` and BEFORE ``SnapshotCallback._on_training_start`` reads it (so the
+    snapshot producer rehydrates against the RESUMED step, not 0 — HOLE-C). Building a fresh model +
+    ``set_parameters`` instead would leave ``num_timesteps`` at 0 and the snapshot producer would
+    classify the entire on-disk pool as "future" and delete it — so the resume MUST go through
+    ``load``. Then the RNG sidecar is restored.
+    """
+    pointer = read_latest_pointer(state_dir)
+    if pointer is None:
+        raise FileNotFoundError(f"no valid resume checkpoint in {state_dir}")
+    state_dir = Path(state_dir)
+    zip_path = state_dir / pointer["ckpt"]
+    rng_path = state_dir / pointer["rng"]
+    model = MaskablePPO.load(zip_path, env=venv, device=device)
+    # The MODEL load honors `device`, but the RNG sidecar must NOT — RNG states are CPU ByteTensors
+    # and set_rng_state rejects a GPU-mapped tensor (would crash every --device cuda resume).
+    load_rng_sidecar(rng_path)
+    return model
+
+
+class ResumeCheckpointCallback(BaseCallback):
+    """Periodically checkpoint the learner for crash-safe resume (every ``checkpoint_every`` steps).
+
+    Mirrors :class:`SnapshotCallback`'s cadence + resume-cursor discipline: ``_on_training_start``
+    seeds the cursor to the RESUMED step (so the first post-resume checkpoint waits a full cadence
+    instead of firing immediately), ``_on_step`` fires on each cadence crossing, and
+    ``_on_training_end`` writes a final checkpoint so a clean finish is always resumable at the true
+    end step (a subsequent same-budget relaunch then resumes, computes ``remaining == 0``, and just
+    re-exports).
+    """
+
+    def __init__(
+        self,
+        state_dir: str | Path,
+        checkpoint_every: int,
+        *,
+        keep: int = 2,
+        verbose: int = 0,
+    ) -> None:
+        super().__init__(verbose)
+        if int(checkpoint_every) <= 0:
+            raise ValueError(f"checkpoint_every must be a positive int, got {checkpoint_every!r}")
+        self.state_dir = Path(state_dir)
+        self.checkpoint_every = int(checkpoint_every)
+        self._keep = int(keep)
+        self._last = 0
+
+    def _on_training_start(self) -> None:
+        # self.model.num_timesteps is the resumed env-step count (SB3 restores it under
+        # learn(reset_num_timesteps=False)); the callback's own num_timesteps is not synced at
+        # training-start, so read the model's — same reason as SnapshotCallback._on_training_start.
+        self._last = int(self.model.num_timesteps)
+
+    def _on_step(self) -> bool:
+        if self.num_timesteps - self._last >= self.checkpoint_every:
+            self._last = self.num_timesteps
+            save_resume_checkpoint(self.model, self.state_dir, self.num_timesteps, keep=self._keep)
+        return True
+
+    def _on_training_end(self) -> None:
+        # Final checkpoint at the true end step (skip if a cadence save already landed there) so a
+        # clean finish is resumable even if the process dies between learn() and the repack/export.
+        if self.num_timesteps != self._last:
+            save_resume_checkpoint(self.model, self.state_dir, self.num_timesteps, keep=self._keep)
+            self._last = self.num_timesteps

--- a/ml/dicewars_ppo/resume_state.py
+++ b/ml/dicewars_ppo/resume_state.py
@@ -1,0 +1,271 @@
+"""Checkpoint-state core for idempotent resume (Phase 3, task C/E, PR-5, [D-26]) — sb3-FREE.
+
+This is the torch-but-``sb3``-free half of the resume machinery: the RNG sidecar, the atomic
+``latest.json`` pointer (the crash hinge), pointer validation, the checkpoint GC, and
+``save_resume_checkpoint`` (which takes a duck-typed model with ``.save(path)`` — no ``sb3`` symbol
+appears here). The ``sb3`` learner glue (``MaskablePPO.load`` + the ``BaseCallback`` subclass) lives
+in the sibling ``resume.py``.
+
+**Why the split** mirrors ``snapshot_manifest.py`` (torch-free) vs ``snapshot_callback.py`` (sb3):
+the lean ``ml-test`` CI tier has CPU ``torch`` but NOT ``stable_baselines3`` / ``sb3_contrib``, so
+keeping the riskiest logic (atomic ``latest.json`` written LAST, pointer rejection, GC keep-N, the
+RNG ``weights_only`` round-trip) out of any ``sb3`` import lets it run in CI
+(``test_resume_state.py`` gates on ``torch`` only) instead of shodan-only.
+
+**Crash hinge ([D-26] Q3).** ``save_resume_checkpoint`` writes, in order: (1) the model zip (policy
++ optimizer + ``num_timesteps``) fsync'd durable, (2) the RNG sidecar fsync'd durable, then (3)
+``latest.json`` LAST via temp-file + fsync + ``os.replace``. A torn write before step 3 leaves the
+PREVIOUS ``latest.json`` (or none) intact, so a resume never references a half-written payload.
+Older pairs are GC'd only AFTER ``latest.json`` is durable, and the referenced pair is never deleted
+(same ordering discipline as the snapshot GC / HOLE-B).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import re
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+
+from .constants import ENCODING_VERSION
+
+# Bump if the on-disk resume layout (latest.json schema / the sidecar set) changes incompatibly, so
+# an old pointer is rejected (→ a loud fresh-start) rather than mis-loaded.
+RESUME_FORMAT_VERSION = 1
+LATEST_NAME = "latest.json"
+
+# Width-agnostic (``\d+``) on purpose: the filename uses ``:09d`` (a MINIMUM width), so at >= 1e9
+# env steps the step is 10 digits. A fixed ``\d{9}`` would stop matching there and the GC would
+# silently leak those files (resume still works — latest.json carries the name, not this regex).
+_CKPT_RE = re.compile(r"^ckpt-(\d+)\.zip$")
+
+
+def _fsync_path(path: Path) -> None:
+    """``fsync`` a written file so its bytes are durable before anything references it."""
+    fd = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _fsync_dir(path: Path) -> None:
+    """Best-effort fsync of a DIRECTORY so a rename/unlink within it survives a power loss.
+
+    ``os.replace`` gives torn-write atomicity but not crash-durability of the directory ENTRY:
+    without this, a hard crash could lose the ``latest.json`` rename while a GC unlink of the prior
+    pair already reached disk, leaving ``latest.json`` dangling — and the checkpoint pair is the
+    ONLY copy of model state. Some platforms (notably macOS) don't support fsync on a directory fd;
+    it degrades to a no-op rather than crashing, since this is a hardening, not a correctness
+    requirement (Linux / the shodan WSL box get the guarantee).
+    """
+    try:
+        fd = os.open(path, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass  # directory fsync unsupported here (e.g. macOS) — degrade, don't crash the run
+    finally:
+        os.close(fd)
+
+
+# --- RNG sidecar (de-randomize the Python half across a save/load) ----------------------------
+
+
+def _capture_rng() -> dict[str, Any]:
+    """Snapshot the process RNG so a resume continues the SAME stream ([D-26] Q3, bounded-skew).
+
+    Captures torch (CPU), numpy, and python ``random`` state — plus per-device CUDA state when a GPU
+    is present (the long run trains on shodan's GPU; CPU-only CI exercises the rest). This is all
+    the Python half can de-randomize; the Node env half can't replay trajectories, so the overall
+    resume is statistically consistent, not bit-exact.
+    """
+    state: dict[str, Any] = {
+        "torch": torch.get_rng_state(),
+        "numpy": np.random.get_state(),
+        "python": random.getstate(),
+    }
+    if torch.cuda.is_available():
+        state["cuda"] = torch.cuda.get_rng_state_all()
+    return state
+
+
+def _restore_rng(state: dict[str, Any]) -> None:
+    """Inverse of :func:`_capture_rng`. CUDA state is restored only when a GPU is present."""
+    torch.set_rng_state(state["torch"])
+    np.random.set_state(state["numpy"])
+    random.setstate(state["python"])
+    cuda = state.get("cuda")
+    if cuda is not None and torch.cuda.is_available():
+        torch.cuda.set_rng_state_all(cuda)
+
+
+def load_rng_sidecar(rng_path: str | Path) -> dict[str, Any]:
+    """Load + restore an RNG sidecar written by :func:`save_resume_checkpoint`.
+
+    Always loads to CPU — there is intentionally NO device parameter. RNG generator states are CPU
+    ByteTensors (``torch.get_rng_state`` and even ``torch.cuda.get_rng_state_all`` return CPU
+    tensors), and ``torch.set_rng_state`` / ``torch.cuda.set_rng_state_all`` REQUIRE CPU tensors.
+    Mapping the sidecar onto a GPU device (e.g. forwarding the model's ``--device cuda``) makes
+    ``torch.set_rng_state`` raise ``TypeError: RNG state must be a torch.ByteTensor`` — which would
+    crash EVERY GPU resume (the shodan BEAT run). So the device is deliberately not threaded here.
+
+    ``weights_only=False`` is REQUIRED: the sidecar bundles numpy's ``('MT19937', ndarray, …)``
+    tuple + python's ``random`` state, which ``weights_only=True`` (the ``torch>=2.6`` default)
+    cannot deserialize — it would crash EVERY resume. The sidecar is a trusted, locally-produced
+    file, so this is safe; a deliberate, narrow deviation from the repo's ``weights_only=True``
+    convention (which guards UNTRUSTED-shaped checkpoints, e.g. ``policy.load_bc_checkpoint``).
+    """
+    state = torch.load(rng_path, weights_only=False, map_location="cpu")
+    _restore_rng(state)
+    return state
+
+
+# --- atomic latest.json pointer ----------------------------------------------------------------
+
+
+def _write_latest_atomic(state_dir: Path, step: int, ckpt_name: str, rng_name: str) -> None:
+    """Write ``latest.json`` LAST via temp-file + fsync + ``os.replace`` (atomic; never torn)."""
+    payload = {
+        "version": RESUME_FORMAT_VERSION,
+        "encodingVersion": ENCODING_VERSION,
+        "step": int(step),
+        "ckpt": ckpt_name,
+        "rng": rng_name,
+    }
+    latest = state_dir / LATEST_NAME
+    tmp = latest.with_name(latest.name + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2) + "\n")
+    _fsync_path(tmp)
+    os.replace(tmp, latest)  # atomic rename on POSIX
+    # Make the rename durable BEFORE save_resume_checkpoint's GC unlinks the prior pair — else a
+    # power-loss crash could drop the latest.json rename yet keep the GC unlink → dangling pointer.
+    _fsync_dir(state_dir)
+
+
+def read_latest_pointer(state_dir: str | Path) -> dict[str, Any] | None:
+    """Return the parsed+validated ``latest.json`` dict, or ``None`` if unusable.
+
+    ``None`` means "no usable resume point": the file is absent, torn (bad JSON), version- or
+    encoding-skewed, or references a missing ckpt/rng file. The caller distinguishes ABSENT (a legit
+    fresh run) from PRESENT-but-rejected (corrupt — warn loudly, do NOT silently restart from 0) via
+    :func:`latest_pointer_exists`.
+    """
+    state_dir = Path(state_dir)
+    latest = state_dir / LATEST_NAME
+    try:
+        raw = latest.read_text()
+    except (FileNotFoundError, NotADirectoryError):
+        return None
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    if data.get("version") != RESUME_FORMAT_VERSION:
+        return None
+    # Match the snapshot manifest's encoding gate: a resume must not load a checkpoint from a
+    # different observation encoding (it would silently mismatch the live obs).
+    if data.get("encodingVersion") != ENCODING_VERSION:
+        return None
+    ckpt, rng = data.get("ckpt"), data.get("rng")
+    if not ckpt or not (state_dir / ckpt).is_file():
+        return None
+    if not rng or not (state_dir / rng).is_file():
+        return None
+    return data
+
+
+def latest_pointer_exists(state_dir: str | Path) -> bool:
+    """Does a ``latest.json`` file exist at all (regardless of whether it is valid)?
+
+    Lets the caller tell ABSENT (silent fresh) from PRESENT-but-rejected (loud warning) when
+    :func:`read_latest_pointer` returns ``None``.
+    """
+    return (Path(state_dir) / LATEST_NAME).exists()
+
+
+def has_resume_checkpoint(state_dir: str | Path) -> bool:
+    """True iff ``state_dir`` holds a valid, loadable resume checkpoint."""
+    return read_latest_pointer(state_dir) is not None
+
+
+# --- save / GC ---------------------------------------------------------------------------------
+
+
+def _checkpoint_steps(state_dir: Path) -> list[int]:
+    """Steps of the ``ckpt-*.zip`` files on disk (ascending), parsed from the filenames."""
+    steps = []
+    for p in state_dir.glob("ckpt-*.zip"):
+        m = _CKPT_RE.match(p.name)
+        if m:
+            steps.append(int(m.group(1)))
+    return sorted(steps)
+
+
+def _safe_unlink(path: Path) -> None:
+    """Best-effort unlink of an aged-out checkpoint file — never crash a multi-day run on disk I/O.
+
+    Deleting an unreferenced file is pure hygiene; a transient FS error leaves it on disk and a
+    later run's GC reclaims it. ``missing_ok`` makes it idempotent for the single writer.
+    """
+    try:
+        path.unlink(missing_ok=True)
+    except OSError as err:
+        print(f"[resume] GC: could not unlink {path.name} ({err}); leaving on disk")
+
+
+def _gc_old_checkpoints(state_dir: Path, *, keep: int, keep_step: int) -> None:
+    """Delete checkpoint pairs (``.zip`` + ``.rng.pt``) older than the newest ``keep``.
+
+    Called only AFTER ``latest.json`` is durable, so the referenced (newest) pair is always within
+    ``keep`` (``keep >= 1``); ``keep_step`` is also force-retained as a belt-and-suspenders guard so
+    the GC can never remove the pair ``latest.json`` currently names (the HOLE-B ordering hazard).
+    Removes the ``.zip`` and ``.rng.pt`` together so a half-pair is never left behind.
+    """
+    steps = _checkpoint_steps(state_dir)
+    survivors = set(steps[-keep:]) | {int(keep_step)}
+    for s in steps:
+        if s in survivors:
+            continue
+        _safe_unlink(state_dir / f"ckpt-{s:09d}.zip")
+        _safe_unlink(state_dir / f"ckpt-{s:09d}.rng.pt")
+
+
+def save_resume_checkpoint(model: Any, state_dir: str | Path, step: int, *, keep: int = 2) -> None:
+    """Atomically checkpoint the learner for resume; ``latest.json`` written LAST ([D-26] Q3).
+
+    :param model: the (Maskable)PPO model — needs ``.save(path)`` (SB3 persists policy + optimizer +
+        ``num_timesteps``). Duck-typed so this module stays ``sb3``-free.
+    :param state_dir: directory the checkpoint pair + ``latest.json`` live in.
+    :param step: ``num_timesteps`` at this checkpoint (names the files: ``ckpt-<step>.zip``).
+    :param keep: newest checkpoint pairs kept on disk (``>= 1``; default 2 = current + one back).
+    """
+    state_dir = Path(state_dir)
+    state_dir.mkdir(parents=True, exist_ok=True)
+    step = int(step)
+    tag = f"ckpt-{step:09d}"
+    zip_path = state_dir / f"{tag}.zip"
+    rng_path = state_dir / f"{tag}.rng.pt"
+
+    # 1) model zip (policy + optimizer + num_timesteps), durable FIRST. (SB3 .save would append
+    #    .zip; we pass it explicitly so _fsync_path opens the exact file.)
+    model.save(zip_path)
+    _fsync_path(zip_path)
+    # 2) RNG sidecar, durable SECOND (torch.save: numpy/python RNG state is not JSON-able).
+    torch.save(_capture_rng(), rng_path)
+    _fsync_path(rng_path)
+    # 3) latest.json LAST — only now does a resume see this checkpoint. A crash before here leaves
+    #    the prior latest.json intact (bounded loss, not a torn pointer).
+    _write_latest_atomic(state_dir, step, zip_path.name, rng_path.name)
+    # 4) GC older pairs (the newest `keep`, plus this step, always survive — never delete the pair
+    #    latest.json now references).
+    _gc_old_checkpoints(state_dir, keep=max(int(keep), 1), keep_step=step)

--- a/ml/dicewars_ppo/resume_state.py
+++ b/ml/dicewars_ppo/resume_state.py
@@ -26,6 +26,7 @@ import json
 import os
 import random
 import re
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -39,10 +40,26 @@ from .constants import ENCODING_VERSION
 RESUME_FORMAT_VERSION = 1
 LATEST_NAME = "latest.json"
 
-# Width-agnostic (``\d+``) on purpose: the filename uses ``:09d`` (a MINIMUM width), so at >= 1e9
+# Width-agnostic (``\d+``) on purpose: the filenames use ``:09d`` (a MINIMUM width), so at >= 1e9
 # env steps the step is 10 digits. A fixed ``\d{9}`` would stop matching there and the GC would
-# silently leak those files (resume still works — latest.json carries the name, not this regex).
+# silently leak those files (resume still works — latest.json carries the name, not these regexes).
 _CKPT_RE = re.compile(r"^ckpt-(\d+)\.zip$")
+_RNG_RE = re.compile(r"^ckpt-(\d+)\.rng\.pt$")
+
+# Why ``classify_latest_pointer`` rejected (or accepted) ``latest.json`` — a torch-free, sb3-free
+# decision the resume caller branches on, so the highest-consequence "do we restart from 0?" logic
+# is unit-testable in lean CI (not only behind the sb3-gated ``train.py`` tier). The reasons split
+# by the operator's recovery action (see :func:`describe_pointer_rejection`).
+POINTER_VALID = "valid"
+POINTER_ABSENT = "absent"
+POINTER_CORRUPT_JSON = "corrupt-json"
+POINTER_VERSION_SKEW = "version-skew"
+POINTER_ENCODING_SKEW = "encoding-skew"
+POINTER_DANGLING_REF = "dangling-ref"
+
+# Module-level so the macOS dir-fsync degrade (in _fsync_dir) warns once per process, not once per
+# checkpoint.
+_DIR_FSYNC_WARNED = False
 
 
 def _fsync_path(path: Path) -> None:
@@ -62,7 +79,9 @@ def _fsync_dir(path: Path) -> None:
     pair already reached disk, leaving ``latest.json`` dangling — and the checkpoint pair is the
     ONLY copy of model state. Some platforms (notably macOS) don't support fsync on a directory fd;
     it degrades to a no-op rather than crashing, since this is a hardening, not a correctness
-    requirement (Linux / the shodan WSL box get the guarantee).
+    requirement (Linux / the shodan WSL box get the guarantee). The degrade is logged ONCE (not on
+    every checkpoint) so the reduced-durability mode is visible on the box it's running on rather
+    than silent — the whole point of this run is crash-safety.
     """
     try:
         fd = os.open(path, os.O_RDONLY)
@@ -71,7 +90,14 @@ def _fsync_dir(path: Path) -> None:
     try:
         os.fsync(fd)
     except OSError:
-        pass  # directory fsync unsupported here (e.g. macOS) — degrade, don't crash the run
+        global _DIR_FSYNC_WARNED
+        if not _DIR_FSYNC_WARNED:
+            print(
+                f"WARNING: directory fsync unsupported on this platform ({path}); checkpoint "
+                "durability is best-effort (os.replace torn-write atomicity still holds).",
+                file=sys.stderr,
+            )
+            _DIR_FSYNC_WARNED = True
     finally:
         os.close(fd)
 
@@ -128,6 +154,33 @@ def load_rng_sidecar(rng_path: str | Path) -> dict[str, Any]:
     return state
 
 
+def restore_rng_sidecar(rng_path: str | Path) -> bool:
+    """Restore the RNG sidecar, degrading to a FRESH RNG stream (loud warn) if it is unreadable.
+
+    Returns ``True`` if the saved stream was restored, ``False`` if it was unreadable and we
+    fell back to the live RNG. **This must never abort a resume.** By the time it runs,
+    ``MaskablePPO.load`` has ALREADY restored the policy + optimizer + ``num_timesteps`` — the
+    expensive, recoverable state. A torn / bit-rotted sidecar (``torch.load`` with
+    ``weights_only=False`` can raise ``UnpicklingError`` / ``EOFError`` / ``BadZipFile`` /
+    ``RuntimeError`` …) contributes ONLY statistical continuity of the random stream, which the
+    resume contract already declares "bounded-skew, not bit-exact" ([D-26] Q3). So losing it is
+    exactly the degradation the design permits — raising here would brick a fully-recoverable
+    checkpoint, and under the PR-6 schtasks auto-restart that becomes a PERMANENT crash-loop (every
+    relaunch reads the same bad byte and dies). Hence: warn loudly, continue with a fresh stream.
+    """
+    try:
+        load_rng_sidecar(rng_path)
+        return True
+    except Exception as err:  # noqa: BLE001 — corrupt sidecar can raise many torch/pickle types
+        print(
+            f"WARNING: RNG sidecar {Path(rng_path).name} is unreadable ({err!r}); resuming with a "
+            "FRESH RNG stream. The model, optimizer, and num_timesteps were restored — only "
+            "random-stream continuity is lost (statistically consistent, bounded-skew per [D-26]).",
+            file=sys.stderr,
+        )
+        return False
+
+
 # --- atomic latest.json pointer ----------------------------------------------------------------
 
 
@@ -150,38 +203,85 @@ def _write_latest_atomic(state_dir: Path, step: int, ckpt_name: str, rng_name: s
     _fsync_dir(state_dir)
 
 
-def read_latest_pointer(state_dir: str | Path) -> dict[str, Any] | None:
-    """Return the parsed+validated ``latest.json`` dict, or ``None`` if unusable.
+def _parse_latest(state_dir: str | Path) -> tuple[str, dict[str, Any] | None]:
+    """Parse + validate ``latest.json`` ONCE; return ``(reason, data-or-None)``.
 
-    ``None`` means "no usable resume point": the file is absent, torn (bad JSON), version- or
-    encoding-skewed, or references a missing ckpt/rng file. The caller distinguishes ABSENT (a legit
-    fresh run) from PRESENT-but-rejected (corrupt — warn loudly, do NOT silently restart from 0) via
-    :func:`latest_pointer_exists`.
+    The single source of truth for both :func:`classify_latest_pointer` (reason only) and
+    :func:`read_latest_pointer` (data only), so the two can never drift. ``data`` is non-``None``
+    only when ``reason == POINTER_VALID``.
     """
     state_dir = Path(state_dir)
     latest = state_dir / LATEST_NAME
     try:
         raw = latest.read_text()
     except (FileNotFoundError, NotADirectoryError):
-        return None
+        return POINTER_ABSENT, None
     try:
         data = json.loads(raw)
     except ValueError:
-        return None
+        return POINTER_CORRUPT_JSON, None
     if not isinstance(data, dict):
-        return None
+        return POINTER_CORRUPT_JSON, None
     if data.get("version") != RESUME_FORMAT_VERSION:
-        return None
+        return POINTER_VERSION_SKEW, None
     # Match the snapshot manifest's encoding gate: a resume must not load a checkpoint from a
     # different observation encoding (it would silently mismatch the live obs).
     if data.get("encodingVersion") != ENCODING_VERSION:
-        return None
+        return POINTER_ENCODING_SKEW, None
     ckpt, rng = data.get("ckpt"), data.get("rng")
     if not ckpt or not (state_dir / ckpt).is_file():
-        return None
+        return POINTER_DANGLING_REF, None
     if not rng or not (state_dir / rng).is_file():
-        return None
-    return data
+        return POINTER_DANGLING_REF, None
+    return POINTER_VALID, data
+
+
+def classify_latest_pointer(state_dir: str | Path) -> str:
+    """Why ``latest.json`` is (un)usable — one of the ``POINTER_*`` reasons (torch-free, CI-tested).
+
+    Lets the resume caller branch the three-way decision (resume / loud-fresh / silent-fresh) AND
+    tailor the operator warning to the cause, without an sb3 import — so the highest-consequence
+    "should we restart from 0?" logic is unit-testable in lean CI.
+    """
+    return _parse_latest(state_dir)[0]
+
+
+def describe_pointer_rejection(reason: str) -> str:
+    """Operator-facing explanation for a rejected pointer (caller prefixes ``WARNING: <dir>:``).
+
+    A pure ``reason → message`` map (no I/O), so the resume warning is unit-testable in lean CI. It
+    splits by the right recovery action: VERSION / ENCODING skew mean the on-disk ckpt pairs are
+    THEMSELVES from an incompatible build (a fresh start is correct, and deleting them is fine),
+    whereas CORRUPT_JSON / DANGLING_REF mean only the POINTER broke while the ``ckpt-*.zip`` pairs
+    are likely still loadable — so it steers AWAY from deleting them. (The prior wording only told
+    the operator to move ``latest.json`` aside, framing recovery around the pointer rather than the
+    still-loadable ckpt pairs.)
+    """
+    recoverable = (
+        "the ckpt-*.zip/.rng.pt pairs on disk are likely still loadable — inspect them BEFORE "
+        "deleting latest.json (it is the breadcrumb to them)"
+    )
+    incompatible = "the on-disk checkpoints are from an incompatible build and cannot be resumed"
+    return {
+        POINTER_CORRUPT_JSON: f"latest.json is corrupt (unreadable JSON); {recoverable}.",
+        POINTER_DANGLING_REF: f"latest.json points at a missing checkpoint file; {recoverable}.",
+        POINTER_VERSION_SKEW: f"latest.json is from an incompatible resume-format version; "
+        f"{incompatible}.",
+        POINTER_ENCODING_SKEW: f"latest.json is from a different observation encoding; "
+        f"{incompatible}.",
+    }.get(reason, f"latest.json is unusable (reason: {reason}).")
+
+
+def read_latest_pointer(state_dir: str | Path) -> dict[str, Any] | None:
+    """Return the parsed+validated ``latest.json`` dict, or ``None`` if unusable.
+
+    ``None`` means "no usable resume point": the file is absent, torn (bad JSON), version- or
+    encoding-skewed, or references a missing ckpt/rng file. Use :func:`classify_latest_pointer` (or
+    :func:`latest_pointer_exists`) to distinguish ABSENT (a fresh run) from PRESENT-but-rejected
+    (corrupt — warn loudly, do NOT silently restart from 0).
+    """
+    reason, data = _parse_latest(state_dir)
+    return data if reason == POINTER_VALID else None
 
 
 def latest_pointer_exists(state_dir: str | Path) -> bool:
@@ -202,12 +302,19 @@ def has_resume_checkpoint(state_dir: str | Path) -> bool:
 
 
 def _checkpoint_steps(state_dir: Path) -> list[int]:
-    """Steps of the ``ckpt-*.zip`` files on disk (ascending), parsed from the filenames."""
-    steps = []
-    for p in state_dir.glob("ckpt-*.zip"):
-        m = _CKPT_RE.match(p.name)
+    """Steps with a checkpoint file on disk (ascending), unioned over BOTH the ``.zip`` and the
+    ``.rng.pt`` names.
+
+    Unioning both halves means an ORPHANED ``.rng.pt`` — e.g. a prior GC whose ``.zip`` unlink
+    succeeded but whose paired ``.rng.pt`` unlink hit a transient ``OSError`` (see
+    :func:`_safe_unlink`) — is still enumerated and swept by a later GC pass, so no half-pair leaks
+    past one cadence. (A ``.zip``-only orphan self-heals the same way.)
+    """
+    steps: set[int] = set()
+    for p in state_dir.glob("ckpt-*"):
+        m = _CKPT_RE.match(p.name) or _RNG_RE.match(p.name)
         if m:
-            steps.append(int(m.group(1)))
+            steps.add(int(m.group(1)))
     return sorted(steps)
 
 
@@ -229,7 +336,10 @@ def _gc_old_checkpoints(state_dir: Path, *, keep: int, keep_step: int) -> None:
     Called only AFTER ``latest.json`` is durable, so the referenced (newest) pair is always within
     ``keep`` (``keep >= 1``); ``keep_step`` is also force-retained as a belt-and-suspenders guard so
     the GC can never remove the pair ``latest.json`` currently names (the HOLE-B ordering hazard).
-    Removes the ``.zip`` and ``.rng.pt`` together so a half-pair is never left behind.
+    Unlinks the ``.zip`` and ``.rng.pt`` of each aged-out step together; if a transient
+    :func:`_safe_unlink` failure leaves one half behind, ``_checkpoint_steps`` (which unions both
+    suffixes) re-enumerates that step on the next pass and sweeps the orphan — no half-pair survives
+    past one GC cycle.
     """
     steps = _checkpoint_steps(state_dir)
     survivors = set(steps[-keep:]) | {int(keep_step)}

--- a/ml/dicewars_ppo/train.py
+++ b/ml/dicewars_ppo/train.py
@@ -70,9 +70,11 @@ from stable_baselines3.common.vec_env import SubprocVecEnv, VecMonitor
 from . import _train_common
 from .policy import load_bc_checkpoint, repack_to_bc_checkpoint
 from .resume import (
+    POINTER_ABSENT,
+    POINTER_VALID,
     ResumeCheckpointCallback,
-    has_resume_checkpoint,
-    latest_pointer_exists,
+    classify_latest_pointer,
+    describe_pointer_rejection,
     load_resume_checkpoint,
 )
 from .snapshot_callback import SnapshotCallback
@@ -128,7 +130,8 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=50_000,
         help="Resume-checkpoint cadence in total env steps (only with --state-dir). Defaults to "
-        "match --snapshot-every.",
+        "50000 (the same default as --snapshot-every, but NOT dynamically coupled to it — set this "
+        "explicitly if you change --snapshot-every and want checkpoints to follow).",
     )
     return p
 
@@ -168,10 +171,11 @@ def _make_logger(args: argparse.Namespace, resumed_step: int = 0):
     ``VecMonitor`` (not this logger) is what populates the ``rollout/ep_rew_mean`` / ``ep_len_mean``
     keys these sinks then record.
 
-    Cross-session continuation (PR-5, [D-26]). SB3's ``CSVOutputFormat`` opens ``progress.csv`` with
-    mode ``"w+t"`` (TRUNCATING it), so a resume into the same ``--log-dir`` would erase the prior
-    session's rows. So we build the output formats EXPLICITLY (instead of ``configure()``) and point
-    the CSV at a per-session ``progress-<resumed_step>.csv`` — so a session that REACHED A LATER
+    Cross-session continuation (PR-5, [D-26]). SB3's ``CSVOutputFormat`` opens its target file with
+    mode ``"w+t"`` (TRUNCATING it) — under ``configure()`` it is ``progress.csv``, so a resume
+    into the same ``--log-dir`` would erase the prior session's rows. So we build the output formats
+    EXPLICITLY (instead of ``configure()``) and point the CSV at a per-session
+    ``progress-<resumed_step>.csv`` — so a session that REACHED A LATER
     CHECKPOINT (and thus resumes at a higher step) never truncates an earlier one (concatenate
     offline). The one residual collision is a crash-loop *within* a single ``--checkpoint-every``
     window: it resumes from the SAME step and re-truncates that step's CSV — bounded, observability-
@@ -211,18 +215,21 @@ def train(args: argparse.Namespace) -> Path:
         f"max_areas={cfg.max_areas} player_count={cfg.player_count} "
         f"context_hidden={cfg.context_hidden}"
     )
-    # Resume detection ([D-26] Q3, auto-detect). A VALID latest.json in --state-dir continues the
-    # run; an ABSENT one is a fresh run; a PRESENT-but-corrupt / version- or encoding-skewed one
-    # warns LOUDLY and falls back to fresh — never a silent restart-from-0 that would discard days
-    # of progress (and would make the absolute --timesteps budget train from scratch again).
+    # Resume detection ([D-26] Q3, auto-detect). classify_latest_pointer (torch-free, CI-tested)
+    # says WHY the pointer is (un)usable: VALID ⇒ continue the run; ABSENT ⇒ a fresh run; any other
+    # reason ⇒ warn LOUDLY with a CAUSE-SPECIFIC message and fall back to fresh — never a silent
+    # restart-from-0 that would discard days of progress (and re-trains the absolute --timesteps
+    # budget from scratch). describe_pointer_rejection steers AWAY from deleting latest.json when
+    # on-disk ckpt pairs are still recoverable (corrupt-pointer / dangling-ref).
     resuming = False
     if args.state_dir:
-        if has_resume_checkpoint(args.state_dir):
+        reason = classify_latest_pointer(args.state_dir)
+        if reason == POINTER_VALID:
             resuming = True
-        elif latest_pointer_exists(args.state_dir):
+        elif reason != POINTER_ABSENT:
             print(
-                f"WARNING: {args.state_dir}/latest.json is unreadable or version/encoding-"
-                "mismatched — starting a FRESH run (NO resume). Move it aside to silence this.",
+                f"WARNING: {args.state_dir}: {describe_pointer_rejection(reason)} "
+                "Starting a FRESH run (NO resume).",
                 file=sys.stderr,
             )
     if resuming and args.freeze_trunk:
@@ -338,6 +345,11 @@ def train(args: argparse.Namespace) -> Path:
 
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
+    # Provenance from `args` (the relaunch flags). On a RESUME these reflect this invocation, not
+    # necessarily the original training run — MaskablePPO.load restores the model's own optimizer/HP
+    # state, so a changed --lr/--gamma/--ent-coef on the relaunch is ignored but still
+    # stamped here. Metadata-only (no training impact); kept simple to avoid lr-schedule-callable
+    # extraction MaskablePPO would otherwise require.
     repacked = repack_to_bc_checkpoint(
         model.policy,
         extra={

--- a/ml/dicewars_ppo/train.py
+++ b/ml/dicewars_ppo/train.py
@@ -37,11 +37,17 @@ not fixed-field BC exploitation. It still loads ``--checkpoint`` for the archite
 (``ModelConfig``), is mutually exclusive with ``--freeze-trunk``, and relaxes the
 ``--lr``/``--ent-coef`` defaults (see ``_train_common.resolve_from_scratch``).
 
-Scope (PR-4). Fresh runs only. Full idempotent checkpoint/resume (policy + optimizer +
-RNG + ``num_timesteps`` + league pool/book, ``reset_num_timesteps=False``, CSV
-continuation) is PR-5; the committed shodan launcher + schtasks runbook is PR-6. See the
-``TODO(PR-5)`` at ``model.learn`` and ``_train_common.resolve_from_scratch``'s note on
-production HPs.
+Idempotent checkpoint/resume (PR-5, [D-26] Q3). Pass ``--state-dir`` to make a run resumable:
+``ResumeCheckpointCallback`` checkpoints policy + optimizer + ``num_timesteps`` + process RNG every
+``--checkpoint-every`` steps (atomic ``latest.json`` written LAST, the crash hinge — see
+``resume.py``). A relaunch of the SAME command auto-resumes from a valid ``latest.json`` (a
+corrupt/version-skewed one warns and starts fresh), going through ``MaskablePPO.load`` and
+``learn(reset_num_timesteps=False, total_timesteps=_remaining_timesteps(...))`` so the absolute
+``--timesteps`` budget is honored across crashes (HOLE-D), not made additive. The Node league's own
+resume half (``--league-state-dir`` etc.) is independent ([D-26] Q3) and forwarded via
+``_train_common``. CSV is per-session (``progress-<resumed_step>.csv``) so a resume never truncates
+a prior session; TensorBoard stays one continuous run (merged by ``num_timesteps``). The committed
+shodan launcher + schtasks runbook is PR-6.
 """
 
 from __future__ import annotations
@@ -52,11 +58,23 @@ import sys
 from pathlib import Path
 
 import torch
-from stable_baselines3.common.logger import configure
+from stable_baselines3.common.callbacks import CallbackList
+from stable_baselines3.common.logger import (
+    CSVOutputFormat,
+    HumanOutputFormat,
+    Logger,
+    TensorBoardOutputFormat,
+)
 from stable_baselines3.common.vec_env import SubprocVecEnv, VecMonitor
 
 from . import _train_common
 from .policy import load_bc_checkpoint, repack_to_bc_checkpoint
+from .resume import (
+    ResumeCheckpointCallback,
+    has_resume_checkpoint,
+    latest_pointer_exists,
+    load_resume_checkpoint,
+)
 from .snapshot_callback import SnapshotCallback
 from .train_tracer import _verify_repack_exportable, build_model
 
@@ -95,12 +113,45 @@ def build_parser() -> argparse.ArgumentParser:
         help="SubprocVecEnv worker start method (CUDA inits at MaskablePPO construction, AFTER the "
         "envs fork — [D-26] Q4). forkserver is the safe default; spawn is the portable fallback.",
     )
+    # Idempotent resume (PR-5, [D-26] Q3). --state-dir holds the SB3 zip + RNG sidecar + latest.json
+    # (the crash hinge). Set it to make the run resumable: a relaunch of the SAME command resumes
+    # from a valid latest.json (a corrupt/stale one warns and starts fresh). This is the PYTHON
+    # resume half; it is INDEPENDENT of the Node league's --league-state-dir (the other half).
+    p.add_argument(
+        "--state-dir",
+        default=None,
+        help="Directory for the Python resume checkpoint (SB3 zip + RNG sidecar + latest.json). "
+        "Unset ⇒ no checkpointing/resume. Independent of --league-state-dir ([D-26] Q3).",
+    )
+    p.add_argument(
+        "--checkpoint-every",
+        type=int,
+        default=50_000,
+        help="Resume-checkpoint cadence in total env steps (only with --state-dir). Defaults to "
+        "match --snapshot-every.",
+    )
     return p
 
 
 def _validate(args: argparse.Namespace) -> None:
     _train_common._validate_args(args)
     _train_common.resolve_from_scratch(args)
+    if args.checkpoint_every <= 0:
+        raise SystemExit(f"--checkpoint-every must be > 0 (got {args.checkpoint_every}).")
+    if args.freeze_trunk and args.state_dir is not None:
+        # Reject EAGERLY (not only at resume time): MaskablePPO.load does not restore the build-time
+        # requires_grad freeze, so a resumed --freeze-trunk run would train the trunk it should
+        # freeze. If we let the run START, every checkpoint it writes is un-resumable and the user
+        # only finds out after the first crash. So fail at launch. (train() keeps a backstop guard.)
+        raise SystemExit(
+            "--freeze-trunk + --state-dir (resume) is unsupported: load does not restore the "
+            "build-time trunk freeze, so the run could never resume. Drop one of the two flags."
+        )
+    if args.state_dir is not None:
+        # Absolutize so resume detection (parent) and the callback agree on the path regardless of
+        # cwd. Do NOT mkdir here — save_resume_checkpoint creates it, and a missing dir reads as
+        # "no resume point" (fresh), which is correct.
+        args.state_dir = str(Path(args.state_dir).resolve())
 
 
 def _tensorboard_available() -> bool:
@@ -108,25 +159,41 @@ def _tensorboard_available() -> bool:
     return importlib.util.find_spec("tensorboard") is not None
 
 
-def _make_logger(args: argparse.Namespace):
-    """Configure the SB3 logger sinks for ``--log-dir``; returns ``(logger, sinks)``.
+def _make_logger(args: argparse.Namespace, resumed_step: int = 0):
+    """Build the SB3 logger for ``--log-dir`` with a PER-SESSION CSV; returns ``(logger, sinks)``.
 
-    Returns ``(configured Logger, [sink names])`` — the caller passes the logger to
-    ``model.set_logger`` BEFORE ``learn`` and reports the ACTUAL ``sinks`` (so the status line
-    can't claim a sink the degradation path dropped) — or ``(None, [])`` when ``--log-dir`` is
-    unset (SB3 keeps its stdout default). ``VecMonitor`` (not this logger) is what populates the
-    ``rollout/ep_rew_mean`` / ``ep_len_mean`` keys these sinks then record.
+    Returns ``(Logger, [sink names])`` — the caller passes the logger to ``model.set_logger`` BEFORE
+    ``learn`` and reports the ACTUAL ``sinks`` (so the status line can't claim a sink the
+    degradation path dropped) — or ``(None, [])`` when ``--log-dir`` is unset (SB3 keeps stdout).
+    ``VecMonitor`` (not this logger) is what populates the ``rollout/ep_rew_mean`` / ``ep_len_mean``
+    keys these sinks then record.
 
-    SB3's ``TensorBoardOutputFormat`` HARD-imports the ``tensorboard`` package and RAISES if it
-    is absent (it does NOT silently no-op). ``tensorboard`` is in the ``[rl]`` extra, so the normal
-    path has it; but rather than crash a long run on a partial env, degrade to CSV-only with a loud
-    warning (on stderr) when it is missing (``--no-tensorboard`` opts out of the TB sink entirely).
+    Cross-session continuation (PR-5, [D-26]). SB3's ``CSVOutputFormat`` opens ``progress.csv`` with
+    mode ``"w+t"`` (TRUNCATING it), so a resume into the same ``--log-dir`` would erase the prior
+    session's rows. So we build the output formats EXPLICITLY (instead of ``configure()``) and point
+    the CSV at a per-session ``progress-<resumed_step>.csv`` — so a session that REACHED A LATER
+    CHECKPOINT (and thus resumes at a higher step) never truncates an earlier one (concatenate
+    offline). The one residual collision is a crash-loop *within* a single ``--checkpoint-every``
+    window: it resumes from the SAME step and re-truncates that step's CSV — bounded, observability-
+    only loss (TB still merges by ``num_timesteps``). The single ``TensorBoardOutputFormat`` over
+    ``--log-dir`` keeps ONE continuous TB run because, under ``learn(reset_num_timesteps=False)``,
+    events merge by ``num_timesteps``.
+
+    ``TensorBoardOutputFormat.__init__`` HARD-imports ``tensorboard`` and RAISES if absent (it does
+    NOT silently no-op); ``tensorboard`` is in the ``[rl]`` extra, so the normal path has it, but
+    rather than crash a long run on a partial env we degrade to CSV-only with a loud stderr warning
+    when it is missing (``--no-tensorboard`` opts out of the TB sink entirely).
     """
     if args.log_dir is None:
         return None, []
+    log_dir = Path(args.log_dir)
+    log_dir.mkdir(parents=True, exist_ok=True)
     sinks = ["stdout", "csv"]
+    csv_path = log_dir / f"progress-{int(resumed_step):09d}.csv"
+    output_formats = [HumanOutputFormat(sys.stdout), CSVOutputFormat(str(csv_path))]
     if not args.no_tensorboard:
         if _tensorboard_available():
+            output_formats.append(TensorBoardOutputFormat(str(log_dir)))
             sinks.append("tensorboard")
         else:
             print(
@@ -134,11 +201,7 @@ def _make_logger(args: argparse.Namespace):
                 "CSV only. Install the [rl] extra for TensorBoard, or pass --no-tensorboard.",
                 file=sys.stderr,
             )
-    # NOTE: SB3's CSVOutputFormat opens <log_dir>/progress.csv with mode "w+t", TRUNCATING it on
-    # each run, and configure() starts a FRESH TB event file (old events.out.tfevents.* are left in
-    # place, so re-running the same --log-dir accumulates overlapping curves). PR-4 is fresh-run
-    # only; cross-session continuation (re-set_logger after a resume load) is PR-5's resume work.
-    return configure(str(Path(args.log_dir)), sinks), sinks
+    return Logger(folder=str(log_dir), output_formats=output_formats), sinks
 
 
 def train(args: argparse.Namespace) -> Path:
@@ -148,7 +211,31 @@ def train(args: argparse.Namespace) -> Path:
         f"max_areas={cfg.max_areas} player_count={cfg.player_count} "
         f"context_hidden={cfg.context_hidden}"
     )
-    mode = "from-scratch" if args.from_scratch else "warm-start"
+    # Resume detection ([D-26] Q3, auto-detect). A VALID latest.json in --state-dir continues the
+    # run; an ABSENT one is a fresh run; a PRESENT-but-corrupt / version- or encoding-skewed one
+    # warns LOUDLY and falls back to fresh — never a silent restart-from-0 that would discard days
+    # of progress (and would make the absolute --timesteps budget train from scratch again).
+    resuming = False
+    if args.state_dir:
+        if has_resume_checkpoint(args.state_dir):
+            resuming = True
+        elif latest_pointer_exists(args.state_dir):
+            print(
+                f"WARNING: {args.state_dir}/latest.json is unreadable or version/encoding-"
+                "mismatched — starting a FRESH run (NO resume). Move it aside to silence this.",
+                file=sys.stderr,
+            )
+    if resuming and args.freeze_trunk:
+        # MaskablePPO.load restores weights+optimizer but NOT the build-time requires_grad freeze
+        # (it lives in build_model, which resume SKIPS), so a resumed --freeze-trunk run would
+        # silently train the trunk it was meant to freeze. Reject rather than change the regime.
+        raise SystemExit(
+            "--freeze-trunk + resume is unsupported: MaskablePPO.load does not restore the "
+            "build-time requires_grad freeze, so a resumed run would silently train the trunk. "
+            "Re-run without --freeze-trunk, or from a fresh --state-dir."
+        )
+
+    mode = "resume" if resuming else ("from-scratch" if args.from_scratch else "warm-start")
     print(
         f"train config: mode={mode} n_envs={args.n_envs} start_method={args.start_method} "
         f"opponents=[{args.opponents}] timesteps={args.timesteps} n_steps={args.n_steps} "
@@ -180,11 +267,33 @@ def train(args: argparse.Namespace) -> Path:
     )
     venv = VecMonitor(venv)
 
-    # build_model constructs MaskablePPO on this venv (CUDA inits here, after the fork) and either
-    # warm-starts or, with --from-scratch, leaves the fresh init.
-    model, venv = build_model(cfg, ckpt, args, venv=venv)
+    if resuming:
+        # PATH A ([D-26] HOLE-C/D): MaskablePPO.load restores policy + optimizer + num_timesteps in
+        # one call (BEFORE learn, so SnapshotCallback rehydrates against the resumed step, not 0) +
+        # the RNG sidecar. SKIP build_model entirely — load brings back the trained weights, so
+        # a warm-start would clobber them.
+        model = load_resume_checkpoint(args.state_dir, venv, args.device)
+        print(f"resumed from {args.state_dir} at num_timesteps={model.num_timesteps}")
+    else:
+        # build_model constructs MaskablePPO on this venv (CUDA inits here, after the fork) and
+        # either warm-starts or, with --from-scratch, leaves the fresh init.
+        model, venv = build_model(cfg, ckpt, args, venv=venv)
 
-    logger, sinks = _make_logger(args)
+    # Assemble the callbacks: the PFSP snapshot publisher (if any) + the resume checkpointer (if
+    # --state-dir). CallbackList only when both fire; a single callback / None otherwise.
+    callbacks = []
+    if callback is not None:
+        callbacks.append(callback)
+    if args.state_dir:
+        callbacks.append(ResumeCheckpointCallback(args.state_dir, args.checkpoint_every))
+        print(f"resume checkpointer: every {args.checkpoint_every} steps → {args.state_dir}")
+    learn_callback = (
+        CallbackList(callbacks) if len(callbacks) > 1 else (callbacks[0] if callbacks else None)
+    )
+
+    # Per-session CSV keyed on the resumed step (0 for a fresh run) so a resume never truncates a
+    # prior session's progress.csv ([D-26]); TensorBoard stays one continuous run.
+    logger, sinks = _make_logger(args, resumed_step=int(model.num_timesteps))
     if logger is not None:
         model.set_logger(logger)  # must precede learn()
         # Report the ACTUAL sinks (the TB-missing degradation path drops "tensorboard"), so this
@@ -192,11 +301,30 @@ def train(args: argparse.Namespace) -> Path:
         print(f"logging: {' + '.join(sinks)} → {args.log_dir}")
 
     try:
-        # PR-4 trains FRESH runs only: reset_num_timesteps defaults True ⇒ num_timesteps starts at 0
-        # and --timesteps is the absolute budget. TODO(PR-5 / [D-26] HOLE-D): resume must pass
-        # reset_num_timesteps=False AND cap remaining = max(timesteps - num_timesteps, 0), else a
-        # crash-loop makes --timesteps additive and trains unbounded.
-        model.learn(total_timesteps=args.timesteps, progress_bar=False, callback=callback)
+        if resuming:
+            # [D-26] HOLE-D: cap the run at the ABSOLUTE --timesteps. Under reset_num_timesteps=
+            # False SB3 adds num_timesteps back internally, so passing `remaining` makes it stop at
+            # --timesteps rather than training an extra num_timesteps per relaunch (an unbounded
+            # crash-loop). remaining==0 ⇒ the budget is already met: skip learn(), just re-export.
+            remaining = _train_common._remaining_timesteps(args.timesteps, model.num_timesteps)
+            if remaining > 0:
+                model.learn(
+                    total_timesteps=remaining,
+                    reset_num_timesteps=False,
+                    progress_bar=False,
+                    callback=learn_callback,
+                )
+            else:
+                print(
+                    f"resume: budget already met (num_timesteps={model.num_timesteps} >= "
+                    f"--timesteps={args.timesteps}); skipping learn(), re-exporting."
+                )
+        else:
+            # Fresh run: reset_num_timesteps defaults True ⇒ num_timesteps starts at 0 and
+            # --timesteps is the absolute budget.
+            model.learn(
+                total_timesteps=args.timesteps, progress_bar=False, callback=learn_callback
+            )
     finally:
         # Always reap the env workers (each owns a Node child) even on error. Guard the close: when
         # learn() raised because a SubprocVecEnv worker already died (the common failure here), the

--- a/ml/tests/test_resume.py
+++ b/ml/tests/test_resume.py
@@ -132,6 +132,30 @@ def test_load_resume_restores_num_timesteps_and_policy(tmp_path):
     assert all(torch.equal(src[k], dst[k]) for k in src)
 
 
+def test_load_resume_survives_corrupt_rng_sidecar(tmp_path, capsys):
+    # A torn/bit-rotted RNG sidecar must NOT brick a resume: MaskablePPO.load has already restored
+    # policy + optimizer + num_timesteps, so load_resume_checkpoint degrades to a fresh RNG stream
+    # (loud warn) rather than raising (which would crash-loop under the PR-6 auto-restart).
+    cfg = _v2_config()
+    model = _build_model(cfg)
+    model.num_timesteps = 999
+    rz.save_resume_checkpoint(model, tmp_path, model.num_timesteps)
+    ptr = rz.read_latest_pointer(tmp_path)
+    (tmp_path / ptr["rng"]).write_bytes(b"not a torch checkpoint")  # corrupt ONLY the sidecar
+
+    loaded = rz.load_resume_checkpoint(tmp_path, _build_venv(cfg), "cpu")  # must NOT raise
+
+    assert loaded.num_timesteps == 999  # model/optimizer/step still restored
+    assert "FRESH RNG stream" in capsys.readouterr().err
+
+
+def test_callback_rejects_nonpositive_cadence(tmp_path):
+    with pytest.raises(ValueError, match="checkpoint_every"):
+        rz.ResumeCheckpointCallback(tmp_path, checkpoint_every=0)
+    with pytest.raises(ValueError, match="checkpoint_every"):
+        rz.ResumeCheckpointCallback(tmp_path, checkpoint_every=-1)
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="GPU RNG path needs CUDA (shodan)")
 def test_load_resume_on_cuda_restores_rng_without_crash(tmp_path):
     # Regression for the GPU-resume blocker: even when the MODEL is on cuda, the RNG sidecar must be

--- a/ml/tests/test_resume.py
+++ b/ml/tests/test_resume.py
@@ -1,0 +1,202 @@
+"""SB3-coupled resume tests (``dicewars_ppo.resume``, PR-5, [D-26]) — SHODAN-ONLY.
+
+Gates on ``sb3_contrib`` (absent in lean CI), so these run on shodan alongside the other torch/sb3
+tiers (test_train_args / test_ppo_policy). They cover the parts the sb3-free
+``test_resume_state.py`` cannot: the real ``MaskablePPO.load`` round-trip (restores
+``num_timesteps`` + optimizer + policy in one call — PATH A, HOLE-C) and the HOLE-D budget cap at
+SB3's own ``_setup_learn`` seam (the absolute ``--timesteps`` is honored across a resume, not made
+additive).
+
+Hermetic: builds a tiny v2-shaped ``MaskablePPO`` over a no-Node stub env (the real DiceWars Dict
+spaces; ``reset`` returns one valid masked obs — enough to construct the model + run
+``_setup_learn``, which resets but does NOT roll out, so no live env-server is needed).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+gym = pytest.importorskip("gymnasium")
+pytest.importorskip("sb3_contrib")
+
+from sb3_contrib import MaskablePPO  # noqa: E402
+
+import dicewars_ppo.resume as rz  # noqa: E402
+from dicewars_bc.model import ModelConfig  # noqa: E402
+from dicewars_ppo._train_common import _remaining_timesteps  # noqa: E402
+from dicewars_ppo.constants import (  # noqa: E402
+    BOARD_W,
+    EDGE_W,
+    MAX_EDGES,
+    NODE_W,
+    PLAYER_W,
+)
+from dicewars_ppo.env import DiceWarsEnv  # noqa: E402
+from dicewars_ppo.policy import MaskableEdgePolicy  # noqa: E402
+
+
+def _v2_config(**overrides) -> ModelConfig:
+    base = dict(
+        max_areas=32,
+        node_features=NODE_W,
+        player_features=PLAYER_W,
+        board_features=BOARD_W,
+        edge_features=EDGE_W,
+        player_count=7,
+        node_hidden=16,
+        player_hidden=8,
+        context_hidden=24,
+        edge_hidden=16,
+    )
+    base.update(overrides)
+    return ModelConfig(**base)
+
+
+class _StubEnv(gym.Env):
+    """No-Node env with the REAL DiceWars Dict spaces; reset returns one valid masked obs.
+
+    Enough to BUILD MaskablePPO and run _setup_learn (which resets but does not roll out). step() is
+    a trivial terminal so the env is well-formed, but the resume tests never collect a rollout.
+    """
+
+    def __init__(self, cfg: ModelConfig) -> None:
+        real = DiceWarsEnv(max_areas=cfg.max_areas, player_count=cfg.player_count)
+        self.observation_space = real.observation_space
+        self.action_space = real.action_space
+        self._cfg = cfg
+        self._mask = np.zeros(MAX_EDGES, dtype=np.int8)
+        self._mask[0] = 1  # at least one legal action
+
+    def _obs(self):
+        a, p = self._cfg.max_areas, self._cfg.player_count
+        return {
+            "nodes": np.zeros((a, NODE_W), np.float32),
+            "players": np.zeros((p, PLAYER_W), np.float32),
+            "board": np.zeros((BOARD_W,), np.float32),
+            "edge_feat": np.zeros((MAX_EDGES, EDGE_W), np.float32),
+            "edge_from": np.zeros((MAX_EDGES,), np.int32),
+            "edge_to": np.zeros((MAX_EDGES,), np.int32),
+            "edge_mask": self._mask.copy(),
+        }
+
+    def reset(self, *, seed=None, options=None):
+        super().reset(seed=seed)
+        return self._obs(), {}
+
+    def step(self, action):
+        return self._obs(), 0.0, True, False, {}
+
+    def action_masks(self):
+        return self._mask.astype(bool)
+
+
+def _build_model(cfg: ModelConfig, device: str = "cpu") -> MaskablePPO:
+    from stable_baselines3.common.vec_env import DummyVecEnv
+
+    venv = DummyVecEnv([lambda: _StubEnv(cfg)])
+    return MaskablePPO(
+        MaskableEdgePolicy,
+        venv,
+        policy_kwargs={"bc_config": cfg},
+        n_steps=16,
+        batch_size=8,
+        device=device,
+        seed=0,
+    )
+
+
+def _build_venv(cfg: ModelConfig):
+    from stable_baselines3.common.vec_env import DummyVecEnv
+
+    return DummyVecEnv([lambda: _StubEnv(cfg)])
+
+
+# --- MaskablePPO.load round-trip (PATH A, HOLE-C) ----------------------------------------------
+
+
+def test_load_resume_restores_num_timesteps_and_policy(tmp_path):
+    cfg = _v2_config()
+    model = _build_model(cfg)
+    model.num_timesteps = 12_345  # simulate a partly-trained model
+    rz.save_resume_checkpoint(model, tmp_path, model.num_timesteps)
+
+    loaded = rz.load_resume_checkpoint(tmp_path, _build_venv(cfg), "cpu")
+
+    # num_timesteps restored in the load (so SnapshotCallback rehydrates the resumed step, not 0)
+    assert loaded.num_timesteps == 12_345
+    # policy weights byte-identical
+    src, dst = model.policy.state_dict(), loaded.policy.state_dict()
+    assert src.keys() == dst.keys()
+    assert all(torch.equal(src[k], dst[k]) for k in src)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="GPU RNG path needs CUDA (shodan)")
+def test_load_resume_on_cuda_restores_rng_without_crash(tmp_path):
+    # Regression for the GPU-resume blocker: even when the MODEL is on cuda, the RNG sidecar must be
+    # restored to CPU — torch.set_rng_state rejects a GPU-mapped tensor ("RNG state must be a
+    # torch.ByteTensor"), which crashed every --device cuda resume before load_rng_sidecar was
+    # pinned to CPU. This must NOT raise.
+    cfg = _v2_config()
+    model = _build_model(cfg, device="cuda")
+    model.num_timesteps = 7
+    rz.save_resume_checkpoint(model, tmp_path, model.num_timesteps)
+    loaded = rz.load_resume_checkpoint(tmp_path, _build_venv(cfg), "cuda")
+    assert loaded.num_timesteps == 7
+
+
+# --- HOLE-D: the absolute --timesteps budget is honored across a resume ------------------------
+
+
+def test_resume_setup_learn_caps_at_absolute_budget(tmp_path):
+    cfg = _v2_config()
+    model = _build_model(cfg)
+    K, T = 400, 1000
+    model.num_timesteps = K
+    # Mirror train()'s resume call: total_timesteps=remaining + reset_num_timesteps=False.
+    model._setup_learn(_remaining_timesteps(T, K), reset_num_timesteps=False)
+    # SB3 re-adds num_timesteps under reset_num_timesteps=False, so the absolute stop point is T,
+    # NOT T + K — the unbounded crash-loop HOLE-D kills. (Passing the naive T would yield T + K.)
+    assert model._total_timesteps == T
+
+
+def test_fresh_setup_learn_uses_absolute_budget(tmp_path):
+    cfg = _v2_config()
+    model = _build_model(cfg)
+    model._setup_learn(2048, reset_num_timesteps=True)  # the fresh-run call
+    assert model.num_timesteps == 0
+    assert model._total_timesteps == 2048
+
+
+# --- ResumeCheckpointCallback cadence + resume cursor -----------------------------------------
+
+
+def test_resume_callback_seeds_cursor_and_fires_on_cadence(tmp_path):
+    cfg = _v2_config()
+    model = _build_model(cfg)
+    cb = rz.ResumeCheckpointCallback(tmp_path, checkpoint_every=100)
+    cb.init_callback(model)
+
+    model.num_timesteps = 500
+    cb._on_training_start()
+    assert cb._last == 500  # seeded to the resumed step, not 0 (no immediate re-checkpoint)
+
+    cb.num_timesteps = 550  # below cadence ⇒ no checkpoint yet
+    assert cb._on_step() is True
+    assert not rz.has_resume_checkpoint(tmp_path)
+
+    cb.num_timesteps = 600  # crosses the 100-step cadence ⇒ checkpoint at the current step
+    cb._on_step()
+    assert rz.read_latest_pointer(tmp_path)["step"] == 600
+
+
+def test_resume_callback_final_checkpoint_on_training_end(tmp_path):
+    cfg = _v2_config()
+    model = _build_model(cfg)
+    cb = rz.ResumeCheckpointCallback(tmp_path, checkpoint_every=100)
+    cb.init_callback(model)
+    cb._on_training_start()  # _last = 0
+    cb.num_timesteps = 2048  # a clean finish below the next cadence boundary
+    cb._on_training_end()
+    assert rz.read_latest_pointer(tmp_path)["step"] == 2048  # resumable at the true end step

--- a/ml/tests/test_resume_state.py
+++ b/ml/tests/test_resume_state.py
@@ -58,6 +58,48 @@ def test_load_rng_sidecar_uses_weights_only_false(tmp_path):
     assert torch.equal(torch.rand(3), before)
 
 
+def test_load_rng_sidecar_always_maps_to_cpu(tmp_path, monkeypatch):
+    # GPU-resume blocker regression, CPU-observable: the sidecar must load to CPU regardless of the
+    # model's device. RNG generator states are CPU ByteTensors and torch.(cuda.)set_rng_state reject
+    # a GPU-mapped tensor — forwarding the model's --device cuda into map_location crashed EVERY GPU
+    # resume. The CUDA smoke test in test_resume.py never runs in CI / on the Mac; this pins the
+    # exact invariant (load goes to CPU) without a GPU, so a map_location=device regression fails
+    # HERE instead of only on a live shodan BEAT run.
+    torch.save(rs._capture_rng(), tmp_path / "x.rng.pt")
+    seen = {}
+    real_load = rs.torch.load
+
+    def spy(path, *a, **k):
+        # map_location is torch.load's 2nd positional; capture either form so the assertion is
+        # form-agnostic (kwarg today, but a positional refactor must still be pinned to CPU).
+        seen["map_location"] = k.get("map_location", a[0] if a else None)
+        return real_load(path, *a, **k)
+
+    monkeypatch.setattr(rs.torch, "load", spy)
+    rs.load_rng_sidecar(tmp_path / "x.rng.pt")
+    assert seen["map_location"] == "cpu"  # never a CUDA device
+
+
+def test_restore_rng_sidecar_restores_good_stream(tmp_path):
+    torch.manual_seed(11)
+    rng_path = tmp_path / "g.rng.pt"
+    torch.save(rs._capture_rng(), rng_path)
+    before = torch.rand(3)
+    torch.rand(40)
+    assert rs.restore_rng_sidecar(rng_path) is True  # restored
+    assert torch.equal(torch.rand(3), before)
+
+
+def test_restore_rng_sidecar_degrades_on_corrupt(tmp_path, capsys):
+    # A torn/bit-rotted sidecar must NOT abort: restore_rng_sidecar returns False + warns, so a
+    # resume whose model/optimizer/num_timesteps are already loaded continues with a fresh stream
+    # rather than crash-looping under the PR-6 auto-restart.
+    bad = tmp_path / "bad.rng.pt"
+    bad.write_bytes(b"not a torch checkpoint")
+    assert rs.restore_rng_sidecar(bad) is False  # degraded, did not raise
+    assert "FRESH RNG stream" in capsys.readouterr().err
+
+
 # --- save + atomic latest.json -----------------------------------------------------------------
 
 
@@ -147,6 +189,59 @@ def test_has_resume_checkpoint(tmp_path):
     assert rs.has_resume_checkpoint(tmp_path) is True
 
 
+def test_read_latest_pointer_none_on_non_dict_json(tmp_path):
+    # Valid JSON that isn't an object (e.g. a list) is still unusable — the isinstance(dict) gate.
+    (tmp_path / rs.LATEST_NAME).write_text("[1, 2, 3]")
+    assert rs.read_latest_pointer(tmp_path) is None
+    assert rs.classify_latest_pointer(tmp_path) == rs.POINTER_CORRUPT_JSON
+
+
+# --- classify_latest_pointer (the CI-testable resume decision) ---------------------------------
+
+
+def test_classify_absent_and_valid(tmp_path):
+    assert rs.classify_latest_pointer(tmp_path) == rs.POINTER_ABSENT
+    rs.save_resume_checkpoint(FakeModel(), tmp_path, 10)
+    assert rs.classify_latest_pointer(tmp_path) == rs.POINTER_VALID
+
+
+def test_classify_corrupt_json(tmp_path):
+    (tmp_path / rs.LATEST_NAME).write_text("{ not valid json")
+    assert rs.classify_latest_pointer(tmp_path) == rs.POINTER_CORRUPT_JSON
+
+
+def test_classify_version_skew(tmp_path):
+    rs.save_resume_checkpoint(FakeModel(), tmp_path, 10)
+    p = tmp_path / rs.LATEST_NAME
+    data = json.loads(p.read_text())
+    data["version"] = rs.RESUME_FORMAT_VERSION + 1
+    p.write_text(json.dumps(data))
+    assert rs.classify_latest_pointer(tmp_path) == rs.POINTER_VERSION_SKEW
+
+
+def test_classify_encoding_skew(tmp_path):
+    rs.save_resume_checkpoint(FakeModel(), tmp_path, 10)
+    p = tmp_path / rs.LATEST_NAME
+    data = json.loads(p.read_text())
+    data["encodingVersion"] = 999
+    p.write_text(json.dumps(data))
+    assert rs.classify_latest_pointer(tmp_path) == rs.POINTER_ENCODING_SKEW
+
+
+def test_classify_dangling_ref(tmp_path):
+    rs.save_resume_checkpoint(FakeModel(), tmp_path, 10)
+    (tmp_path / "ckpt-000000010.zip").unlink()
+    assert rs.classify_latest_pointer(tmp_path) == rs.POINTER_DANGLING_REF
+
+
+def test_describe_pointer_rejection_splits_by_recovery_action():
+    # Pointer-only breakage ⇒ steer AWAY from deleting; build skew ⇒ incompatible.
+    for recoverable in (rs.POINTER_CORRUPT_JSON, rs.POINTER_DANGLING_REF):
+        assert "BEFORE deleting latest.json" in rs.describe_pointer_rejection(recoverable)
+    for incompatible in (rs.POINTER_VERSION_SKEW, rs.POINTER_ENCODING_SKEW):
+        assert "incompatible build" in rs.describe_pointer_rejection(incompatible)
+
+
 # --- GC ----------------------------------------------------------------------------------------
 
 
@@ -171,3 +266,27 @@ def test_gc_never_removes_referenced_even_at_keep_one(tmp_path):
     assert _steps_on_disk(tmp_path) == [200]
     assert rs.has_resume_checkpoint(tmp_path)
     assert rs.read_latest_pointer(tmp_path)["step"] == 200
+
+
+def test_gc_sweeps_orphaned_rng_without_zip(tmp_path):
+    # Simulate a prior half-failed GC (a transient _safe_unlink error left a lone .rng.pt at an old
+    # step). Because _checkpoint_steps unions .zip AND .rng.pt names, the next GC re-enumerates that
+    # step and sweeps the orphan — no half-pair leaks past one cadence.
+    m = FakeModel()
+    rs.save_resume_checkpoint(m, tmp_path, 100, keep=2)
+    rs.save_resume_checkpoint(m, tmp_path, 200, keep=2)
+    (tmp_path / "ckpt-000000050.rng.pt").write_bytes(b"orphan")  # a .zip-less sidecar from step 50
+    rs.save_resume_checkpoint(m, tmp_path, 300, keep=2)  # survivors = newest 2 ⇒ {200, 300}
+    assert not (tmp_path / "ckpt-000000050.rng.pt").exists()  # orphan swept
+    assert _steps_on_disk(tmp_path) == [200, 300]
+
+
+def test_gc_handles_10_digit_steps_above_1e9(tmp_path):
+    # The :09d filename is a MINIMUM width, so >= 1e9 steps are 10 digits. _CKPT_RE/_RNG_RE use \d+
+    # (not \d{9}); a fixed width would silently leak these pairs over a multi-day BEAT run.
+    m = FakeModel()
+    rs.save_resume_checkpoint(m, tmp_path, 1_500_000_000, keep=1)
+    rs.save_resume_checkpoint(m, tmp_path, 1_600_000_000, keep=1)
+    assert _steps_on_disk(tmp_path) == [1_600_000_000]  # old 10-digit pair GC'd
+    assert rs.read_latest_pointer(tmp_path)["step"] == 1_600_000_000
+    assert not (tmp_path / "ckpt-1500000000.rng.pt").exists()  # both halves of the old pair gone

--- a/ml/tests/test_resume_state.py
+++ b/ml/tests/test_resume_state.py
@@ -1,0 +1,173 @@
+"""Tests for the sb3-FREE resume core (``dicewars_ppo.resume_state``, PR-5, [D-26]).
+
+Gates on ``torch`` ONLY (the lean CI tier has CPU torch but no ``sb3``), so these RUN IN CI — the
+riskiest hinge logic (atomic ``latest.json`` written LAST, pointer rejection, GC keep-N, the RNG
+``weights_only`` round-trip) is covered without a GPU/sb3. The ``sb3`` learner glue (``MaskablePPO``
+load + callback) is exercised separately, shodan-only, in ``test_resume.py``.
+
+``save_resume_checkpoint`` takes a duck-typed model with ``.save(path)``, so a tiny ``FakeModel``
+(no sb3) drives the full save/GC path here.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+import dicewars_ppo.resume_state as rs  # noqa: E402
+
+
+class FakeModel:
+    """A stand-in for the SB3 model: ``.save(path)`` writes a tiny file at the exact path."""
+
+    def save(self, path):
+        from pathlib import Path
+
+        Path(str(path)).write_bytes(b"zip-bytes")
+
+
+def _steps_on_disk(state_dir):
+    return sorted(int(p.stem.split("-")[1]) for p in state_dir.glob("ckpt-*.zip"))
+
+
+# --- RNG sidecar -------------------------------------------------------------------------------
+
+
+def test_capture_restore_rng_roundtrips():
+    torch.manual_seed(123)
+    state = rs._capture_rng()
+    before = torch.rand(4)
+    torch.rand(100)  # advance the stream so we're somewhere else
+    rs._restore_rng(state)
+    assert torch.equal(torch.rand(4), before)  # restored ⇒ same draw as right after capture
+
+
+def test_load_rng_sidecar_uses_weights_only_false(tmp_path):
+    # The sidecar bundles numpy's MT19937 tuple + python random state, which weights_only=True (the
+    # torch>=2.6 default) CANNOT deserialize. load_rng_sidecar must pass weights_only=False, else
+    # every resume crashes on a modern torch — this round-trip via that exact path is the guard.
+    torch.manual_seed(7)
+    rng_path = tmp_path / "x.rng.pt"
+    torch.save(rs._capture_rng(), rng_path)
+    before = torch.rand(3)
+    torch.rand(50)
+    rs.load_rng_sidecar(rng_path)  # restores via weights_only=False
+    assert torch.equal(torch.rand(3), before)
+
+
+# --- save + atomic latest.json -----------------------------------------------------------------
+
+
+def test_save_writes_pair_and_latest_points_at_step(tmp_path):
+    rs.save_resume_checkpoint(FakeModel(), tmp_path, 50_000)
+    assert (tmp_path / "ckpt-000050000.zip").is_file()
+    assert (tmp_path / "ckpt-000050000.rng.pt").is_file()
+    ptr = rs.read_latest_pointer(tmp_path)
+    assert ptr["step"] == 50_000
+    assert ptr["ckpt"] == "ckpt-000050000.zip"
+    assert ptr["rng"] == "ckpt-000050000.rng.pt"
+    assert ptr["version"] == rs.RESUME_FORMAT_VERSION
+
+
+def test_latest_written_last_failure_before_pointer_leaves_no_latest(tmp_path, monkeypatch):
+    # The FIRST checkpoint: if the RNG save fails before latest.json is written, there must be NO
+    # torn pointer (a resume would see "no usable point" → fresh, not a dangling reference).
+    def boom(obj, path, *a, **k):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(rs.torch, "save", boom)
+    with pytest.raises(RuntimeError):
+        rs.save_resume_checkpoint(FakeModel(), tmp_path, 100)
+    assert not rs.latest_pointer_exists(tmp_path)
+    assert rs.read_latest_pointer(tmp_path) is None
+
+
+def test_failed_checkpoint_leaves_prior_latest_intact(tmp_path, monkeypatch):
+    # A LATER checkpoint torn mid-write must leave the PREVIOUS durable pointer untouched (bounded
+    # loss, not corruption) — the crash hinge.
+    rs.save_resume_checkpoint(FakeModel(), tmp_path, 100)  # durable
+    real_save = rs.torch.save
+
+    def boom(obj, path, *a, **k):
+        if str(path).endswith(".rng.pt"):
+            raise RuntimeError("disk full")
+        return real_save(obj, path, *a, **k)
+
+    monkeypatch.setattr(rs.torch, "save", boom)
+    with pytest.raises(RuntimeError):
+        rs.save_resume_checkpoint(FakeModel(), tmp_path, 200)
+    assert rs.read_latest_pointer(tmp_path)["step"] == 100  # still the durable one
+
+
+# --- pointer rejection -------------------------------------------------------------------------
+
+
+def test_read_latest_pointer_none_when_absent(tmp_path):
+    assert rs.read_latest_pointer(tmp_path) is None
+    assert rs.latest_pointer_exists(tmp_path) is False
+
+
+def test_read_latest_pointer_none_on_torn_json(tmp_path):
+    (tmp_path / rs.LATEST_NAME).write_text("{ not valid json")
+    assert rs.read_latest_pointer(tmp_path) is None
+    assert rs.latest_pointer_exists(tmp_path) is True  # present-but-corrupt ⇒ caller warns
+
+
+def test_read_latest_pointer_none_on_version_skew(tmp_path):
+    rs.save_resume_checkpoint(FakeModel(), tmp_path, 10)
+    p = tmp_path / rs.LATEST_NAME
+    data = json.loads(p.read_text())
+    data["version"] = rs.RESUME_FORMAT_VERSION + 1
+    p.write_text(json.dumps(data))
+    assert rs.read_latest_pointer(tmp_path) is None
+    assert rs.latest_pointer_exists(tmp_path) is True
+
+
+def test_read_latest_pointer_none_on_encoding_skew(tmp_path):
+    rs.save_resume_checkpoint(FakeModel(), tmp_path, 10)
+    p = tmp_path / rs.LATEST_NAME
+    data = json.loads(p.read_text())
+    data["encodingVersion"] = 999
+    p.write_text(json.dumps(data))
+    assert rs.read_latest_pointer(tmp_path) is None
+
+
+def test_read_latest_pointer_none_when_referenced_file_missing(tmp_path):
+    rs.save_resume_checkpoint(FakeModel(), tmp_path, 10)
+    (tmp_path / "ckpt-000000010.zip").unlink()
+    assert rs.read_latest_pointer(tmp_path) is None  # dangling reference ⇒ not usable
+
+
+def test_has_resume_checkpoint(tmp_path):
+    assert rs.has_resume_checkpoint(tmp_path) is False
+    rs.save_resume_checkpoint(FakeModel(), tmp_path, 5)
+    assert rs.has_resume_checkpoint(tmp_path) is True
+
+
+# --- GC ----------------------------------------------------------------------------------------
+
+
+def test_gc_keeps_newest_keep_and_removes_pairs_together(tmp_path):
+    m = FakeModel()
+    for step in (100, 200, 300, 400):
+        rs.save_resume_checkpoint(m, tmp_path, step, keep=2)
+    assert _steps_on_disk(tmp_path) == [300, 400]  # newest 2 survive
+    for s in (300, 400):
+        assert (tmp_path / f"ckpt-{s:09d}.zip").is_file()
+        assert (tmp_path / f"ckpt-{s:09d}.rng.pt").is_file()
+    # aged-out pairs removed ENTIRELY (no orphan half)
+    assert not (tmp_path / "ckpt-000000100.zip").exists()
+    assert not (tmp_path / "ckpt-000000100.rng.pt").exists()
+    assert rs.read_latest_pointer(tmp_path)["step"] == 400  # pointer still resolves
+
+
+def test_gc_never_removes_referenced_even_at_keep_one(tmp_path):
+    m = FakeModel()
+    rs.save_resume_checkpoint(m, tmp_path, 100, keep=1)
+    rs.save_resume_checkpoint(m, tmp_path, 200, keep=1)
+    assert _steps_on_disk(tmp_path) == [200]
+    assert rs.has_resume_checkpoint(tmp_path)
+    assert rs.read_latest_pointer(tmp_path)["step"] == 200

--- a/ml/tests/test_train_args.py
+++ b/ml/tests/test_train_args.py
@@ -19,6 +19,10 @@ pytest.importorskip("torch")
 pytest.importorskip("sb3_contrib")
 
 import dicewars_ppo.train as tr  # noqa: E402
+from dicewars_ppo.resume_state import (  # noqa: E402
+    POINTER_CORRUPT_JSON,
+    POINTER_VALID,
+)
 
 
 def _args(tmp_path, extra=None):
@@ -360,7 +364,7 @@ def test_resume_passes_remaining_and_skips_build_model(tmp_path, monkeypatch):
                 ("learn", kwargs.get("total_timesteps"), kwargs.get("reset_num_timesteps"))
             )
 
-    monkeypatch.setattr(tr, "has_resume_checkpoint", lambda d: True)
+    monkeypatch.setattr(tr, "classify_latest_pointer", lambda d: POINTER_VALID)
     monkeypatch.setattr(tr, "load_resume_checkpoint", lambda d, venv, device: FakeModel())
 
     def _no_build(*a, **k):
@@ -398,7 +402,7 @@ def test_resume_zero_remaining_skips_learn_but_exports(tmp_path, monkeypatch):
         def learn(self, **kwargs):
             calls.append(("learn",))
 
-    monkeypatch.setattr(tr, "has_resume_checkpoint", lambda d: True)
+    monkeypatch.setattr(tr, "classify_latest_pointer", lambda d: POINTER_VALID)
     monkeypatch.setattr(tr, "load_resume_checkpoint", lambda d, venv, device: FakeModel())
     monkeypatch.setattr(
         tr, "build_model", lambda *a, **k: (_ for _ in ()).throw(AssertionError("no build"))
@@ -449,7 +453,7 @@ def test_fresh_run_when_state_dir_empty(tmp_path, monkeypatch):
             "--out", str(tmp_path / "o.pt"),
         ],
     )
-    tr._validate(a)  # state_dir is empty (no latest.json) ⇒ has_resume_checkpoint reads False
+    tr._validate(a)  # state_dir is empty (no latest.json) ⇒ classify_latest_pointer reads ABSENT
     tr.train(a)
 
     assert ("learn", 2048, None) in calls  # absolute budget, default reset (fresh)
@@ -461,6 +465,15 @@ def test_freeze_trunk_plus_state_dir_rejected_eagerly(tmp_path):
     wrote would be un-resumable. Fail at launch, before any checkpoint is written."""
     a = _args(tmp_path, extra=["--state-dir", str(tmp_path / "state"), "--freeze-trunk"])
     with pytest.raises(SystemExit, match="freeze-trunk"):
+        tr._validate(a)
+
+
+@pytest.mark.parametrize("bad", ["0", "-1"])
+def test_validate_rejects_nonpositive_checkpoint_every(tmp_path, bad):
+    a = _args(
+        tmp_path, extra=["--state-dir", str(tmp_path / "state"), "--checkpoint-every", bad]
+    )
+    with pytest.raises(SystemExit, match="checkpoint-every"):
         tr._validate(a)
 
 
@@ -478,8 +491,8 @@ def test_corrupt_latest_warns_and_runs_fresh(tmp_path, monkeypatch, capsys):
             calls.append(("learn",))
 
     monkeypatch.setattr(tr, "build_model", lambda cfg, ckpt, args, venv=None: (FakeModel(), venv))
-    monkeypatch.setattr(tr, "has_resume_checkpoint", lambda d: False)  # invalid ⇒ no usable point
-    monkeypatch.setattr(tr, "latest_pointer_exists", lambda d: True)  # but a file IS present
+    # A present-but-rejected pointer (here: corrupt JSON) ⇒ classify returns a non-ABSENT reason.
+    monkeypatch.setattr(tr, "classify_latest_pointer", lambda d: POINTER_CORRUPT_JSON)
 
     a = _args(
         tmp_path, extra=["--state-dir", str(tmp_path / "state"), "--out", str(tmp_path / "o.pt")]
@@ -487,7 +500,9 @@ def test_corrupt_latest_warns_and_runs_fresh(tmp_path, monkeypatch, capsys):
     tr._validate(a)
     tr.train(a)
 
-    assert "FRESH run" in capsys.readouterr().err
+    err = capsys.readouterr().err
+    assert "FRESH run" in err  # warned + ran fresh, never a silent restart
+    assert "BEFORE deleting latest.json" in err  # non-destructive: recoverable ckpts, don't delete
     assert ("learn",) in calls  # ran fresh (did not abort)
 
 

--- a/ml/tests/test_train_args.py
+++ b/ml/tests/test_train_args.py
@@ -37,6 +37,9 @@ def test_parser_adds_from_scratch_and_sentinels(tmp_path):
     # distinct output so a bare train.py run can't clobber a tracer checkpoint
     assert a.out == "checkpoints/ppo.pt"
     assert a.start_method == "forkserver"
+    # resume off by default; cadence matches --snapshot-every (PR-5)
+    assert a.state_dir is None
+    assert a.checkpoint_every == 50_000
 
 
 def test_validate_rejects_from_scratch_with_freeze_trunk(tmp_path):
@@ -94,9 +97,12 @@ def test_train_wraps_subproc_then_vecmonitor(tmp_path, monkeypatch, from_scratch
     class FakeModel:
         def __init__(self):
             self.policy = object()
+            self.num_timesteps = 0  # train() reads this for the per-session CSV name (PR-5)
 
         def learn(self, **kwargs):
-            calls.append(("learn",))
+            calls.append(
+                ("learn", kwargs.get("total_timesteps"), kwargs.get("reset_num_timesteps"))
+            )
 
         def set_logger(self, logger):
             calls.append(("set_logger",))
@@ -128,6 +134,9 @@ def test_train_wraps_subproc_then_vecmonitor(tmp_path, monkeypatch, from_scratch
     assert calls.index(subproc) < calls.index(("VecMonitor", True))  # SubprocVecEnv FIRST
     assert captured["venv_is_monitor"] is True  # build_model got the monitored venv
     assert ("close",) in calls  # env workers reaped in finally
+    # Fresh run: learn() gets the ABSOLUTE --timesteps and the default reset (reset_num_timesteps
+    # not passed ⇒ None here), NOT the resume path's remaining/reset_num_timesteps=False.
+    assert ("learn", a.timesteps, None) in calls
 
     assert captured["extra"]["teacher"] == "ppo"
     assert captured["extra"]["from_scratch"] is from_scratch
@@ -173,15 +182,23 @@ def test_build_model_warm_start_gated_on_from_scratch(tmp_path, monkeypatch, fro
     assert warm_calls == ([] if from_scratch else [True])
 
 
+def _patch_logger_formats(monkeypatch):
+    """Stub the SB3 output-format classes + Logger so _make_logger does no real file/TB I/O.
+
+    Each fake records a tagged tuple; Logger captures its output_formats so a test can assert which
+    sinks were wired and the per-session CSV filename — all without opening files or importing
+    tensorboard (PR-5 builds output_formats explicitly instead of configure()).
+    """
+    monkeypatch.setattr(tr, "HumanOutputFormat", lambda stream: ("human",))
+    monkeypatch.setattr(tr, "CSVOutputFormat", lambda path: ("csv", path))
+    monkeypatch.setattr(tr, "TensorBoardOutputFormat", lambda d: ("tb", d))
+    monkeypatch.setattr(
+        tr, "Logger", lambda folder, output_formats: ("LOGGER", folder, output_formats)
+    )
+
+
 def test_make_logger_sink_selection(tmp_path, monkeypatch):
-    captured = {}
-
-    def fake_configure(folder, sinks):
-        captured["folder"] = folder
-        captured["sinks"] = list(sinks)
-        return "LOGGER"
-
-    monkeypatch.setattr(tr, "configure", fake_configure)
+    _patch_logger_formats(monkeypatch)
     monkeypatch.setattr(tr, "_tensorboard_available", lambda: True)
 
     # no --log-dir → SB3 keeps its stdout default (no configured logger, empty sink list)
@@ -189,32 +206,49 @@ def test_make_logger_sink_selection(tmp_path, monkeypatch):
     tr._validate(a)
     assert tr._make_logger(a) == (None, [])
 
-    # --log-dir → stdout + csv + tensorboard; the RETURNED sinks mirror what configure() got, so
-    # train()'s status line is built from reality rather than from the --no-tensorboard flag.
+    # --log-dir → stdout + csv + tensorboard; the RETURNED sinks mirror the actual output_formats,
+    # so train()'s status line is built from reality rather than from the --no-tensorboard flag.
     b = _args(tmp_path, extra=["--log-dir", str(tmp_path / "runs")])
     tr._validate(b)
     logger, sinks = tr._make_logger(b)
-    assert logger == "LOGGER"
     assert sinks == ["stdout", "csv", "tensorboard"]
-    assert captured["sinks"] == ["stdout", "csv", "tensorboard"]
+    tag, folder, formats = logger
+    assert tag == "LOGGER"
+    assert [f[0] for f in formats] == ["human", "csv", "tb"]
 
-    # --log-dir + --no-tensorboard → stdout + csv only
-    captured.clear()
+    # --log-dir + --no-tensorboard → stdout + csv only (no TB output format wired)
     c = _args(tmp_path, extra=["--log-dir", str(tmp_path / "runs"), "--no-tensorboard"])
     tr._validate(c)
-    _, sinks = tr._make_logger(c)
+    # _make_logger returns (logger, sinks); the fake Logger IS the ("LOGGER", folder, formats).
+    (_, _, formats), sinks = tr._make_logger(c)
     assert sinks == ["stdout", "csv"]
-    assert captured["sinks"] == ["stdout", "csv"]
+    assert [f[0] for f in formats] == ["human", "csv"]
 
     # --log-dir but tensorboard missing → degrade to csv only (no raise); the returned sinks reflect
     # the drop, so train() reports "csv" not "csv+tensorboard" (the contradiction this guards).
-    captured.clear()
     monkeypatch.setattr(tr, "_tensorboard_available", lambda: False)
     d = _args(tmp_path, extra=["--log-dir", str(tmp_path / "runs")])
     tr._validate(d)
     _, sinks = tr._make_logger(d)
     assert sinks == ["stdout", "csv"]
-    assert captured["sinks"] == ["stdout", "csv"]
+
+
+def test_make_logger_csv_is_per_session(tmp_path, monkeypatch):
+    # PR-5: the CSV is progress-<resumed_step>.csv so a resume never truncates a prior session's
+    # rows. resumed_step=0 (fresh) and a non-zero resume step name distinct files.
+    _patch_logger_formats(monkeypatch)
+    monkeypatch.setattr(tr, "_tensorboard_available", lambda: True)
+    a = _args(tmp_path, extra=["--log-dir", str(tmp_path / "runs")])
+    tr._validate(a)
+
+    # _make_logger returns (logger, sinks); the fake Logger IS the ("LOGGER", folder, formats).
+    (_, _, fresh_formats), _ = tr._make_logger(a, resumed_step=0)
+    (_, _, resumed_formats), _ = tr._make_logger(a, resumed_step=123_456)
+    fresh_csv = next(f[1] for f in fresh_formats if f[0] == "csv")
+    resumed_csv = next(f[1] for f in resumed_formats if f[0] == "csv")
+    assert fresh_csv.endswith("progress-000000000.csv")
+    assert resumed_csv.endswith("progress-000123456.csv")
+    assert fresh_csv != resumed_csv  # a resume never reuses (and truncates) the prior session's CSV
 
 
 def test_train_wires_snapshot_callback_and_logger(tmp_path, monkeypatch):
@@ -239,6 +273,7 @@ def test_train_wires_snapshot_callback_and_logger(tmp_path, monkeypatch):
     class FakeModel:
         def __init__(self):
             self.policy = object()
+            self.num_timesteps = 0  # train() reads this for the per-session CSV name (PR-5)
 
         def set_logger(self, logger):
             calls.append(("set_logger", logger))
@@ -248,7 +283,12 @@ def test_train_wires_snapshot_callback_and_logger(tmp_path, monkeypatch):
             calls.append(("learn", type(kwargs.get("callback")).__name__))
 
     monkeypatch.setattr(tr, "build_model", lambda cfg, ckpt, args, venv=None: (FakeModel(), venv))
-    monkeypatch.setattr(tr, "configure", lambda folder, sinks: "LOGGER")
+    # PR-5 builds output_formats explicitly (no configure()); stub them so set_logger gets "LOGGER"
+    # without real file/TB I/O.
+    monkeypatch.setattr(tr, "HumanOutputFormat", lambda stream: ("human",))
+    monkeypatch.setattr(tr, "CSVOutputFormat", lambda path: ("csv", path))
+    monkeypatch.setattr(tr, "TensorBoardOutputFormat", lambda d: ("tb", d))
+    monkeypatch.setattr(tr, "Logger", lambda folder, output_formats: "LOGGER")
     monkeypatch.setattr(tr, "_tensorboard_available", lambda: True)
     monkeypatch.setattr(
         tr,
@@ -281,3 +321,213 @@ def test_train_wires_snapshot_callback_and_logger(tmp_path, monkeypatch):
     # set_logger fired, and BEFORE learn() (the "must precede learn()" invariant)
     assert ("set_logger", "LOGGER") in calls
     assert calls.index(("set_logger", "LOGGER")) < calls.index(("learn", "FakeSnapshotCallback"))
+
+
+# --- idempotent resume wiring (PR-5, [D-26] HOLE-C/D) -----------------------------------------
+
+
+def _stub_train_io(monkeypatch, calls):
+    """Stub train()'s I/O boundary (ckpt load, vec-env, repack/save/verify) for the resume tests."""
+    fake_cfg = SimpleNamespace(max_areas=32, player_count=7, context_hidden=64)
+    monkeypatch.setattr(tr, "load_bc_checkpoint", lambda ckpt: (fake_cfg, {"k": "v"}))
+    monkeypatch.setattr(tr, "SubprocVecEnv", lambda thunks, start_method=None: SimpleNamespace())
+    monkeypatch.setattr(
+        tr, "VecMonitor", lambda venv: SimpleNamespace(close=lambda: calls.append(("close",)))
+    )
+    monkeypatch.setattr(
+        tr,
+        "repack_to_bc_checkpoint",
+        lambda policy, *, extra=None: {"state_dict": {}, "config": {}, "encoding_version": 2},
+    )
+    monkeypatch.setattr(tr.torch, "save", lambda obj, path: calls.append(("save",)))
+    monkeypatch.setattr(tr, "_verify_repack_exportable", lambda out, cfg: calls.append(("verify",)))
+    return fake_cfg
+
+
+def test_resume_passes_remaining_and_skips_build_model(tmp_path, monkeypatch):
+    """A resumed run loads the checkpoint and calls learn(total_timesteps=remaining,
+    reset_num_timesteps=False) — the HOLE-D budget cap — and must NOT warm-start via build_model."""
+    calls = []
+    _stub_train_io(monkeypatch, calls)
+
+    class FakeModel:
+        def __init__(self):
+            self.policy = object()
+            self.num_timesteps = 400  # already trained 400 of the 1000 budget
+
+        def learn(self, **kwargs):
+            calls.append(
+                ("learn", kwargs.get("total_timesteps"), kwargs.get("reset_num_timesteps"))
+            )
+
+    monkeypatch.setattr(tr, "has_resume_checkpoint", lambda d: True)
+    monkeypatch.setattr(tr, "load_resume_checkpoint", lambda d, venv, device: FakeModel())
+
+    def _no_build(*a, **k):
+        raise AssertionError("build_model must not run on a resume (load brings back the weights)")
+
+    monkeypatch.setattr(tr, "build_model", _no_build)
+
+    a = _args(
+        tmp_path,
+        extra=[
+            "--state-dir", str(tmp_path / "state"),
+            "--timesteps", "1000",
+            "--out", str(tmp_path / "o.pt"),
+        ],
+    )
+    tr._validate(a)
+    tr.train(a)
+
+    # remaining = 1000 - 400 = 600; reset_num_timesteps=False so SB3 stops at the ABSOLUTE 1000.
+    assert ("learn", 600, False) in calls
+    assert ("save",) in calls and ("verify",) in calls  # still re-exports the repacked artifact
+
+
+def test_resume_zero_remaining_skips_learn_but_exports(tmp_path, monkeypatch):
+    """When the budget is already met, learn() is skipped entirely but the repack/export still runs
+    (so a same-budget relaunch is a clean no-op re-export, not an overshoot)."""
+    calls = []
+    _stub_train_io(monkeypatch, calls)
+
+    class FakeModel:
+        def __init__(self):
+            self.policy = object()
+            self.num_timesteps = 1000
+
+        def learn(self, **kwargs):
+            calls.append(("learn",))
+
+    monkeypatch.setattr(tr, "has_resume_checkpoint", lambda d: True)
+    monkeypatch.setattr(tr, "load_resume_checkpoint", lambda d, venv, device: FakeModel())
+    monkeypatch.setattr(
+        tr, "build_model", lambda *a, **k: (_ for _ in ()).throw(AssertionError("no build"))
+    )
+
+    a = _args(
+        tmp_path,
+        extra=[
+            "--state-dir", str(tmp_path / "state"),
+            "--timesteps", "1000",
+            "--out", str(tmp_path / "o.pt"),
+        ],
+    )
+    tr._validate(a)
+    tr.train(a)
+
+    assert ("learn",) not in calls  # budget met ⇒ learn skipped
+    assert ("save",) in calls and ("verify",) in calls
+
+
+def test_fresh_run_when_state_dir_empty(tmp_path, monkeypatch):
+    """--state-dir with no valid latest.json ⇒ a fresh run (build_model, absolute --timesteps)."""
+    calls = []
+    _stub_train_io(monkeypatch, calls)
+
+    class FakeModel:
+        def __init__(self):
+            self.policy = object()
+            self.num_timesteps = 0
+
+        def learn(self, **kwargs):
+            calls.append(
+                ("learn", kwargs.get("total_timesteps"), kwargs.get("reset_num_timesteps"))
+            )
+
+    monkeypatch.setattr(tr, "build_model", lambda cfg, ckpt, args, venv=None: (FakeModel(), venv))
+
+    def _no_load(*a, **k):
+        raise AssertionError("load_resume_checkpoint must not run for a fresh --state-dir")
+
+    monkeypatch.setattr(tr, "load_resume_checkpoint", _no_load)
+
+    a = _args(
+        tmp_path,
+        extra=[
+            "--state-dir", str(tmp_path / "fresh-state"),
+            "--timesteps", "2048",
+            "--out", str(tmp_path / "o.pt"),
+        ],
+    )
+    tr._validate(a)  # state_dir is empty (no latest.json) ⇒ has_resume_checkpoint reads False
+    tr.train(a)
+
+    assert ("learn", 2048, None) in calls  # absolute budget, default reset (fresh)
+
+
+def test_freeze_trunk_plus_state_dir_rejected_eagerly(tmp_path):
+    """--freeze-trunk + --state-dir is rejected EAGERLY at _validate (not only after a crash): load
+    doesn't restore the build-time freeze, so the run could never resume and every checkpoint it
+    wrote would be un-resumable. Fail at launch, before any checkpoint is written."""
+    a = _args(tmp_path, extra=["--state-dir", str(tmp_path / "state"), "--freeze-trunk"])
+    with pytest.raises(SystemExit, match="freeze-trunk"):
+        tr._validate(a)
+
+
+def test_corrupt_latest_warns_and_runs_fresh(tmp_path, monkeypatch, capsys):
+    """A PRESENT-but-invalid latest.json warns loudly and starts fresh — never a silent restart."""
+    calls = []
+    _stub_train_io(monkeypatch, calls)
+
+    class FakeModel:
+        def __init__(self):
+            self.policy = object()
+            self.num_timesteps = 0
+
+        def learn(self, **kwargs):
+            calls.append(("learn",))
+
+    monkeypatch.setattr(tr, "build_model", lambda cfg, ckpt, args, venv=None: (FakeModel(), venv))
+    monkeypatch.setattr(tr, "has_resume_checkpoint", lambda d: False)  # invalid ⇒ no usable point
+    monkeypatch.setattr(tr, "latest_pointer_exists", lambda d: True)  # but a file IS present
+
+    a = _args(
+        tmp_path, extra=["--state-dir", str(tmp_path / "state"), "--out", str(tmp_path / "o.pt")]
+    )
+    tr._validate(a)
+    tr.train(a)
+
+    assert "FRESH run" in capsys.readouterr().err
+    assert ("learn",) in calls  # ran fresh (did not abort)
+
+
+def test_both_callbacks_wrapped_in_callbacklist(tmp_path, monkeypatch):
+    """With both --state-dir and --snapshot-dir, learn() gets a CallbackList of BOTH callbacks."""
+    calls = []
+    _stub_train_io(monkeypatch, calls)
+
+    class FakeModel:
+        def __init__(self):
+            self.policy = object()
+            self.num_timesteps = 0
+
+        def learn(self, **kwargs):
+            calls.append(("learn", kwargs.get("callback")))
+
+    monkeypatch.setattr(tr, "build_model", lambda cfg, ckpt, args, venv=None: (FakeModel(), venv))
+
+    class FakeSnap:
+        def __init__(self, *a, **k):
+            pass
+
+    class FakeResume:
+        def __init__(self, *a, **k):
+            pass
+
+    monkeypatch.setattr(tr, "SnapshotCallback", FakeSnap)
+    monkeypatch.setattr(tr, "ResumeCheckpointCallback", FakeResume)
+
+    a = _args(
+        tmp_path,
+        extra=[
+            "--state-dir", str(tmp_path / "fresh-state"),
+            "--snapshot-dir", str(tmp_path / "league"),
+            "--out", str(tmp_path / "o.pt"),
+        ],
+    )
+    tr._validate(a)
+    tr.train(a)
+
+    cb = next(c[1] for c in calls if c[0] == "learn")
+    assert isinstance(cb, tr.CallbackList)
+    assert {type(x).__name__ for x in cb.callbacks} == {"FakeSnap", "FakeResume"}

--- a/ml/tests/test_train_common_args.py
+++ b/ml/tests/test_train_common_args.py
@@ -282,3 +282,128 @@ def test_resolve_no_from_scratch_attr_is_noop_warm_start():
     tc.resolve_from_scratch(args)
     assert args.lr == 1e-4
     assert args.ent_coef == 0.0
+
+
+# --- B6 league-persistence flag forwarding (PR-5 / task E, [D-26]) -----------------------------
+
+
+def test_league_persistence_flags_default_none(tmp_path):
+    # All three default None ⇒ the OFF path is byte-identical to B5 (EnvServerProcess None-gates
+    # each in the Node argv), and the tracer's golden surface is unchanged.
+    a = _args(tmp_path)
+    assert a.snapshot_store is None
+    assert a.league_state_dir is None
+    assert a.league_dump_every is None
+
+
+def test_snapshot_store_choices_reject_bogus(tmp_path):
+    # argparse `choices=("memory","disk")` rejects anything else at parse time.
+    with pytest.raises(SystemExit):
+        _args(tmp_path, snapshot_store="bogus")
+
+
+@pytest.mark.parametrize("bad", [0, -1])
+def test_validate_rejects_nonpositive_league_dump_every(tmp_path, bad):
+    a = _args(tmp_path, league_dump_every=bad)
+    with pytest.raises(SystemExit, match="league-dump-every"):
+        tc._validate_args(a)
+
+
+def test_validate_rejects_disk_store_without_a_dir(tmp_path):
+    # --snapshot-store=disk needs a derivable shared dir (--league-state-dir or --snapshot-dir);
+    # with neither, fail HERE (Node would otherwise throw at spawn → opaque startup timeout).
+    a = _args(tmp_path, snapshot_store="disk")
+    with pytest.raises(SystemExit, match="shared directory"):
+        tc._validate_args(a)
+
+
+def test_validate_accepts_disk_store_with_league_state_dir(tmp_path):
+    rel = tmp_path / "league"
+    a = _args(tmp_path, snapshot_store="disk", league_state_dir=str(rel))
+    tc._validate_args(a)  # no raise
+    assert Path(a.league_state_dir).is_absolute()
+    assert Path(a.league_state_dir).is_dir()
+
+
+def test_validate_accepts_disk_store_with_snapshot_dir(tmp_path):
+    # --snapshot-dir alone satisfies the disk-store dir requirement (Node derives the league dir
+    # from the manifest's dir), even without an explicit --league-state-dir.
+    a = _args(tmp_path, snapshot_store="disk", snapshot_dir=str(tmp_path / "snaps"))
+    tc._validate_args(a)  # no raise
+
+
+def test_validate_absolutizes_and_creates_league_state_dir(tmp_path):
+    rel = tmp_path / "lstate"
+    a = _args(tmp_path, league_state_dir=str(rel))
+    tc._validate_args(a)
+    assert Path(a.league_state_dir).is_absolute()
+    assert Path(a.league_state_dir).is_dir()
+
+
+def test_make_env_thunk_forwards_league_persistence(tmp_path, monkeypatch):
+    captured = {}
+
+    class FakeEnv:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(tc, "DiceWarsEnv", FakeEnv)
+    a = _args(
+        tmp_path,
+        snapshot_store="disk",
+        league_state_dir=str(tmp_path / "lstate"),
+        league_dump_every=20,
+    )
+    tc._validate_args(a)  # absolutizes league_state_dir
+    cfg = SimpleNamespace(max_areas=32, player_count=7)
+    tc._make_env_thunk(cfg, a, 0)()
+
+    sk = captured["server_kwargs"]
+    assert sk["snapshot_store"] == "disk"
+    assert sk["league_state_dir"] == a.league_state_dir  # the absolutized value
+    assert sk["league_dump_every"] == 20
+
+
+def test_make_env_thunk_shares_league_state_dir_across_workers(tmp_path, monkeypatch):
+    # Per-worker uniqueness is the Node-side league-state-<seedBase>.json filename, NOT a per-env
+    # subdir: every env_index gets the SAME league_state_dir.
+    dirs = []
+
+    class FakeEnv:
+        def __init__(self, **kwargs):
+            dirs.append(kwargs["server_kwargs"]["league_state_dir"])
+
+    monkeypatch.setattr(tc, "DiceWarsEnv", FakeEnv)
+    a = _args(tmp_path, league_state_dir=str(tmp_path / "lstate"))
+    tc._validate_args(a)
+    cfg = SimpleNamespace(max_areas=32, player_count=7)
+    tc._make_env_thunk(cfg, a, 0)()
+    tc._make_env_thunk(cfg, a, 3)()
+    assert dirs == [a.league_state_dir, a.league_state_dir]
+
+
+def test_make_env_thunk_league_persistence_none_when_unset(tmp_path, monkeypatch):
+    captured = {}
+
+    class FakeEnv:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(tc, "DiceWarsEnv", FakeEnv)
+    a = _args(tmp_path)  # no league flags ⇒ trio None (byte-identical OFF path)
+    cfg = SimpleNamespace(max_areas=32, player_count=7)
+    tc._make_env_thunk(cfg, a, 0)()
+    sk = captured["server_kwargs"]
+    assert sk["snapshot_store"] is None
+    assert sk["league_state_dir"] is None
+    assert sk["league_dump_every"] is None
+
+
+# --- _remaining_timesteps (HOLE-D budget cap, [D-26]) -----------------------------------------
+
+
+def test_remaining_timesteps_caps_absolute_budget():
+    assert tc._remaining_timesteps(1000, 0) == 1000  # fresh
+    assert tc._remaining_timesteps(1000, 400) == 600  # mid-run resume
+    assert tc._remaining_timesteps(1000, 1000) == 0  # budget exactly met ⇒ no-op
+    assert tc._remaining_timesteps(1000, 1500) == 0  # overshoot clamps to 0, never negative

--- a/ml/tests/test_train_tracer_args.py
+++ b/ml/tests/test_train_tracer_args.py
@@ -66,6 +66,9 @@ def test_tracer_parser_golden_defaults():
     assert (a.max_turns, a.seed, a.seed_base, a.device) == (500, 0, 1, "cpu")
     assert a.freeze_trunk is False
     assert (a.snapshot_dir, a.snapshot_every, a.snapshot_pool_cap) == (None, 50_000, 40)
+    # B6 league-persistence flags (PR-5) live in the SHARED parser now, so pin them OFF here too:
+    # the tracer must never carry them set, or its byte-identical Node argv would drift.
+    assert (a.snapshot_store, a.league_state_dir, a.league_dump_every) == (None, None, None)
     assert a.opponents == tc.DEFAULT_OPPONENTS
     # the tracer threads its OWN __doc__ as the --help description (help-text wiring is preserved)
     assert tt.build_parser().description == tt.__doc__


### PR DESCRIPTION
## Phase-3 task C/E PR-5 — idempotent checkpoint/resume core

Python-side checkpoint/resume for the long PPO run ([D-26] Q3; the Node league resume half shipped in #70). **Python-only — no JS/build/vitest impact.** Follows PR-4 (#71).

### Three deliverables

1. **HOLE-D budget cap** — on resume, `learn(total_timesteps=_remaining_timesteps(args.timesteps, num_timesteps), reset_num_timesteps=False)`, so the absolute `--timesteps` is honored across crashes (not made additive). `remaining==0` skips `learn` but still re-exports. The helper is torch-free.
2. **Resume core**, split for CI-testability (mirrors `snapshot_manifest`/`snapshot_callback`):
   - **`resume_state.py`** *(new, torch + sb3-FREE)* — RNG sidecar (CPU-pinned), atomic `latest.json` **written LAST** + dir-fsync, GC keep-N, pointer validation, `save_resume_checkpoint`.
   - **`resume.py`** *(new, sb3)* — `load_resume_checkpoint` via `MaskablePPO.load(env=venv)` = **PATH A** so `num_timesteps` restores *before* `SnapshotCallback._on_training_start` reads it (**HOLE-C**); `ResumeCheckpointCallback`.
   - Resume **auto-detects** a valid `latest.json` (absent ⇒ fresh silent; corrupt / version- / encoding-skew ⇒ **loud warn + fresh**, never a silent restart-from-0). New `--state-dir`/`--checkpoint-every` (default 50k), distinct from the Node `--league-state-dir`.
3. **B6 flag forwarding** — `--snapshot-store`/`--league-state-dir`/`--league-dump-every` into the shared torch-free parser + `server_kwargs` (`EnvServerProcess` already emits them since PR-2); Node-mirrored validation. Per-session CSV (`progress-<resumed_step>.csv`) via explicit `output_formats` (no more `configure()` truncation). `--freeze-trunk`+`--state-dir` rejected eagerly.

### Review

A 4-lens adversarial review of the implementation **caught 2 blockers that all green tiers missed**, both fixed with regression coverage:

- 🔴 the RNG sidecar was loaded with `map_location=device` → `torch.set_rng_state` rejects a GPU tensor, **crashing every `--device cuda` resume** (the shodan BEAT target). Now CPU-pinned in `load_rng_sidecar` + a CUDA-gated regression test.
- 🔴 two `_make_logger` test sites 3-unpacked its 2-tuple → the **sb3 test tier was RED** with the per-session-CSV branch uncovered. Fixed.

Plus folded: eager freeze+resume reject, dir-fsync durability, width-agnostic GC regex (`:09d` is a min-width), honest CSV docstring.

### Verification

- ✅ ruff clean (`dicewars_ppo/` + all tests); `py_compile` all
- ✅ **torch-free tier green locally** — `test_resume_state.py` 13 (RNG `weights_only` / atomicity / GC) + `test_train_common_args.py` (B6 flags / forwarding / `_remaining_timesteps`)
- ⏳ **sb3 tier is shodan-only** (no sb3 in CI/locally) — `test_resume.py`, `test_train_args.py`, `test_train_tracer_args.py` skip cleanly here
- ✅ docs updated (D-26 / PLAN / LOG, prettier-clean)

### Shodan checklist before the BEAT run

- [ ] `MaskablePPO.load(env=venv)` restores `num_timesteps` + needs **no `custom_objects`**
- [ ] `--device cuda` resume restores RNG without the `set_rng_state` crash
- [ ] `_setup_learn(remaining, reset_num_timesteps=False)` caps at the absolute `--timesteps` (HOLE-D)
- [ ] live forkserver two-half resume end-to-end (Python load + Node `league-state-<seedBase>.json`)

Next: **PR-6** = committed shodan launcher + schtasks runbook → the long BEAT run.
