### PR TITLE
feat(ml): Phase-3 task C/E PR-6 — committed shodan launcher + schtasks runbook + auto-restart safety guard

### DIFF
--- a/docs/ml-bot/DECISIONS.md
+++ b/docs/ml-bot/DECISIONS.md
@@ -1518,11 +1518,11 @@ PR-2 `EnvServerProcess` B6-flag forwarding (DONE, #70) · PR-3 SnapshotCallback 
 producer GC, consumer `unlinkSync` removed (DONE, #70) · PR-4 `_train_common.py` + `train.py`
 (SubprocVecEnv + VecMonitor
 
-- TB/CSV + `--from-scratch`) (DONE locally) · PR-5 idempotent checkpoint/resume core · PR-6 committed
-  shodan launcher + schtasks runbook · PR-7 deferred test-hardening (env-server `main()` persistence
-  integration test; live cross-worker `SharedDiskStore`).
+- TB/CSV + `--from-scratch`) (MERGED #71) · PR-5 idempotent checkpoint/resume core (MERGED #72) · PR-6
+  committed shodan launcher + schtasks runbook + auto-restart safety guard · PR-7 deferred test-hardening
+  (env-server `main()` persistence integration test; live cross-worker `SharedDiskStore`).
 
-**Status: IN PROGRESS — foundation PR-1→PR-3 MERGED (#70); PR-4 MERGED (#71, `f1224ee`); PR-5 DONE locally (branch `ml-bot/task-ce-pr5-resume`). Next: PR-6 shodan launcher + runbook.** PR-1:
+**Status: IN PROGRESS — foundation PR-1→PR-3 MERGED (#70); PR-4 MERGED (#71, `f1224ee`); PR-5 MERGED (#72, `b554cd7`); PR-6 (this PR) = committed shodan launcher + schtasks runbook + auto-restart safety guard.** PR-1:
 `episodeCount` resume-cursor, `dumpLeagueState` state-then-flush order, `refresh()` ENOENT-tolerance +
 id-dedup + `refreshSkips` health counter (stderr DONE mirror), schema v1→v2. PR-2: `snapshot_store` /
 `league_state_dir` / `league_dump_every` forwarded by `EnvServerProcess` on their own gate (manifest-
@@ -1533,7 +1533,7 @@ independent), byte-identical when unset. PR-3: NEW torch-free `snapshot_manifest
   (`test_snapshot_manifest.py` 12, `test_env_server_argv.py` 6), eslint + ruff clean. **Foundation
   PR-1→PR-3 MERGED as PR #70 (`97de4e4`).**
 
-**PR-4 (DONE locally, branch `ml-bot/task-ce-pr4-train`).** New torch-free `_train_common.py` holds the
+**PR-4 (MERGED, PR #71 `f1224ee`).** New torch-free `_train_common.py` holds the
 shared env-thunk (`_make_env_thunk`), CLI surface (`build_parser(description)`), validation
 (`_validate_args`), and `resolve_from_scratch` (the `--from-scratch`↔`--freeze-trunk` mutex + per-mode
 LR/ent-coef relaxation via a `None` sentinel); `train_tracer.py` re-imports them and is byte-identical
@@ -1553,7 +1553,7 @@ New `train.py` = `VecMonitor(SubprocVecEnv(start_method=forkserver))` built BEFO
   tier (`test_train_args.py` build_model/logging/wrap-order, `test_train_tracer_args.py` re-export
   wiring) green. The torch-gated tests + the live SubprocVecEnv/shodan paths run on shodan.
 
-**PR-5 (DONE locally, branch `ml-bot/task-ce-pr5-resume`) — idempotent checkpoint/resume core.**
+**PR-5 (MERGED, PR #72 `b554cd7`) — idempotent checkpoint/resume core.**
 Python-side only (the Node league half shipped in #70). Three deliverables: (1) **HOLE-D** — on resume
 `train.py` calls `learn(total_timesteps=_remaining_timesteps(args.timesteps, num_timesteps),
 reset_num_timesteps=False)` (torch-free helper in `_train_common`); `remaining==0` SKIPS `learn` but
@@ -1600,3 +1600,45 @@ timeout"→"exited before listening"; a line-ref → symbol). Verification: ruff
 green; sb3 tier shodan-only. The verify workflow also caught a shodan-only `AttributeError`
 (`train.py` imported only `POINTER_ABSENT`/`POINTER_VALID` but a test referenced `tr.POINTER_CORRUPT_JSON`)
 → tests now import the reason constants from `resume_state`, not through `tr`.
+
+**PR-6 (this PR) — committed shodan launcher + schtasks runbook + auto-restart safety guard.** The last
+task C/E ops slice before the long BEAT run. Three parts:
+
+1. **Launcher** `scripts/shodan/ppo-train.sh` (+ the Windows→WSL bridge `ppo-train.cmd` and an
+   importable Task Scheduler `ppo-train-task.xml`, + operator `RUNBOOK.md`). It owns the **production
+   HPs** (the task-A BEAT `--lr 2.5e-4 --ent-coef 0.01`, deliberately not a `train.py` default), sizes
+   `--n-envs` to cores under `SubprocVecEnv(forkserver)`, wires **both** resume halves with matching
+   dirs (`--state-dir`/`--checkpoint-every` + `--league-state-dir`/`--snapshot-store=disk`/
+   `--league-dump-every`, `R=3` locked), pins `ENCODING_VERSION=2` + the commit for the whole campaign
+   (halts on drift of either), and runs a **bounded auto-restart loop**: relaunch the SAME command
+   (same `--timesteps`, so HOLE-D caps the absolute budget) on a transient crash, but HALT+alert on
+   `EXIT_POINTER_REJECTED` or on N consecutive **no-progress** failures (a checkpoint-step advance
+   resets the counter, so a long-progressing run that dies once is not killed by a stale count).
+   **Launch model resolved:** schtasks-wrapped WSL (D-26/task-E), NOT the bare ssh-driven loop D-24
+   decision 1 mentioned — only the scheduled `wsl.exe` path survives an SSH teardown AND a box reboot.
+
+2. **Auto-restart safety guard** (the code half — folds into PR-6 because PR-6 is what makes the
+   restart _unattended_). `train.py` now **HALTs** with a distinct exit code `EXIT_POINTER_REJECTED=3`
+   on a present-but-rejected `latest.json`, instead of PR-5's loud-warn+**fresh** restart. This is a
+   deliberate evolution of PR-5 review-decision (b): warn+fresh is fine when an operator watches, but
+   under the schtasks loop a fresh start silently re-trains the WHOLE `--timesteps` budget from step 0
+   (days of GPU) and could overwrite the still-recoverable on-disk pairs — so the unattended path must
+   stop and alert. The three-way **resume / fresh / HALT** policy is a pure, torch-free
+   `resume_action(reason)` in `resume_state.py` (CI-tested via `test_resume_state.py`), keeping the
+   highest-consequence decision out of the sb3-gated tier — mirroring `classify_latest_pointer`.
+
+3. **Corrupt-`.zip` fallback** — distinct from, and consistent with, PR-5 (b)'s "no blanket
+   auto-fallback to keep=2". `classify_latest_pointer` validates the pointer JSON + that the referenced
+   files EXIST but not that the `.zip` BYTES are intact; a bit-rotted/half-flushed newest `.zip` at a
+   VALID pointer would crash `MaskablePPO.load` → a PERMANENT crash-loop. So `load_resume_checkpoint`
+   now tries the pointer pair, then the retained `keep=N` **same-build OLDER** pairs (newest-first, via
+   the torch-free, CI-tested `resume_candidate_pairs`), rolling back at most one cadence; only when ALL
+   retained pairs fail does it raise `ResumeCheckpointError` → the same HALT. The key distinction from
+   (b): we fall back across SAME-build older steps when the bytes are torn, but still **HALT** (never
+   skip) on version/encoding-skew — those ckpts are genuinely incompatible, exactly the case (b)
+   refused to silently paper over. `latest.json` is NOT rewritten on fallback (it is the crash hinge;
+   the next checkpoint moves the pointer forward). **Verification:** ruff clean; torch-free tier green
+   locally (new `resume_candidate_pairs` ordering/newer-orphan/zipless-orphan + `resume_action`
+   resume/fresh/halt tests in `test_resume_state.py`); the sb3 corrupt-`.zip` fallback +
+   all-corrupt→`ResumeCheckpointError` tests in `test_resume.py` run on **shodan**. The PR-5 shodan
+   validation checklist is the BLOCKING gate before the long run actually launches (see `RUNBOOK.md`).

--- a/docs/ml-bot/LOG.md
+++ b/docs/ml-bot/LOG.md
@@ -21,6 +21,34 @@ Entry template:
 
 ---
 
+## 2026-06-28 — Task C/E PR-6 review + hardening pass (PR #73)
+
+**Phase:** 3 · **Who:** Ivan + Claude
+
+**Did:**
+
+- **Multi-agent review of PR #73** — 6 specialist reviewers (code/silent-failure/tests/comments/types) + a 4-slice adversarial-verification workflow (bash launcher / Windows `.cmd`+XML / Python error-handling / test+docs). No critical/important defects in the core logic; the verifiers re-derived it correct (empirical `bash -n` on bash 3.2 **and** 5, hand-traced the restart loop, `py_compile`, full `FileNotFoundError`-path analysis). Findings were a high-value silent-failure + a set of accuracy/observability minors.
+- **Fixes applied (all landed):**
+  - **Preflight now asserts `torch.cuda.is_available()` when `DEVICE=cuda`** — SB3's `get_device('cuda')` SILENTLY falls back to CPU when CUDA isn't visible, so a `cuda` run could burn the whole budget on CPU while logging `device=cuda`. The RUNBOOK/XML already PROMISED this halt; now it's real. (The single true silent budget-burner the review found.)
+  - **`log()` got `|| true`** so a `tee` failure (broken pipe on a disconnected job / full disk) can't pre-empt the deliberate exit codes under `set -e`/`pipefail`.
+  - **New `EXIT_CRASH_LOOP=4`** (distinct from `EXIT_POINTER_REJECTED=3`); `ppo-train.cmd` maps BOTH 3 and 4 → `exit /b 0` so Task Scheduler `<RestartOnFailure>` never re-amplifies a deliberate halt (a no-progress crash-loop was otherwise ~Count×MAX attempts). `.cmd` also gates `exec` on `cd … || exit 1`.
+  - **`train.py` resume now HALTs on `FileNotFoundError` too** (a VALID-then-vanished `latest.json` TOCTOU) — it used to escape as a generic exit → launcher retry → next classify reads ABSENT → silent restart-from-0.
+  - **`resume_state.py`:** separate warn-once flags for the dir-fsync-unsupported vs open-failure degrades (so the benign macOS one can't mask the serious one); `_safe_unlink` → stderr + `WARNING:` prefix.
+  - **Comment-rot fixes:** `train.py`/`resume_state.py` lines still describing PR-5's "warn + fresh"/"loud fresh-start" on a rejected pointer → corrected to the PR-6 HALT.
+  - **New `ml/tests/test_ppo_train_launcher.py`** (6 lean-tier tests): source the launcher and drive `main()`'s restart-loop dispatch with stubs (halt-on-3, exit-on-0, bound-on-N-no-progress, **progress-resets-the-fail-counter**, transient-retry-then-success) + a `.cmd`↔`.sh` exit-code canary pinning the `=="3"`/`=="4"` branches.
+
+**Learned / decided:**
+
+- **The launcher's exit-code DISPATCH (not just the constant) needed a CI pin.** The PR-5 canary only matched the `EXIT_POINTER_REJECTED` _value_; nothing tested that the launcher _acts_ on it, nor that `ppo-train.cmd`'s hard-coded `=="4"` tracked `EXIT_CRASH_LOOP`. The new bash-sourcing test + the `.cmd` canary close both, and run torch-free in the lean tier.
+- **Doc promises must be code-enforced.** "preflight HALTs if the GPU isn't visible" was aspirational until this pass — exactly the silent-CPU-burn this campaign guards against.
+- Verification: `ruff check .` clean; full ml suite **204 passed / 5 skipped** (the 5 sb3-gated suites; the 6 `test_export_onnx.py` failures are still this box's Python 3.9.6 `zip(strict=True)`, untouched); `bash -n` clean.
+
+**Next:**
+
+- Unchanged from the PR-6 entry below: on shodan, the BLOCKING PR-5 validation checklist + from-scratch control run → long BEAT run gated vs `ai_lookahead@596f781`. PR-7 = deferred test-hardening (incl. now: lazy-import sb3 in `train.py` so the fake-driven HALT/reap tests run in lean CI; the optional WSL exit-code-propagation sentinel).
+
+---
+
 ## 2026-06-28 — Task C/E PR-6 (committed shodan launcher + schtasks runbook + auto-restart safety guard)
 
 **Phase:** 3 · **Who:** Ivan + Claude

--- a/docs/ml-bot/LOG.md
+++ b/docs/ml-bot/LOG.md
@@ -21,6 +21,36 @@ Entry template:
 
 ---
 
+## 2026-06-28 — Task C/E PR-6 (committed shodan launcher + schtasks runbook + auto-restart safety guard)
+
+**Phase:** 3 · **Who:** Ivan + Claude
+
+**Did:**
+
+- **Pre-flight readiness pass first** (per Ivan): repo green on `master` — `npm test` 1158/1158, lint/build exit 0, ml torch-free pytest 185 passed (the 6 `test_export_onnx.py` failures are this Mac's Python 3.9.6 hitting `zip(strict=True)`, a 3.10+ feature — not a regression, not in the PR-6 path). A 5-reader + synthesis workflow over PLAN/LOG/DECISIONS/code/tests pinned PR-6 = the committed shodan launcher + schtasks runbook, with PR-4 (#71) + PR-5 (#72) confirmed MERGED on `master`.
+- **Launcher `scripts/shodan/ppo-train.sh`**: owns the task-A BEAT production HPs (`--lr 2.5e-4 --ent-coef 0.01`), sizes `--n-envs` to cores under `SubprocVecEnv(forkserver)`, wires BOTH resume halves with matching dirs (`--state-dir`/`--checkpoint-every` + `--league-state-dir`/`--snapshot-store=disk`/`--league-dump-every`, `R=3`), pins `ENCODING_VERSION=2` + the commit for the whole campaign (HALTs on drift), TB + per-session CSV. Bounded auto-restart loop: relaunch the SAME command (HOLE-D caps the absolute budget) on a transient crash; HALT+alert on `EXIT_POINTER_REJECTED` or N consecutive **no-progress** failures (a checkpoint-step advance resets the counter).
+- **Windows→WSL bridge** `ppo-train.cmd` + importable Task Scheduler `ppo-train-task.xml` (LogonTrigger + BootTrigger, InteractiveToken for WSL GPU) — the only disconnect+reboot-surviving pattern. Operator `RUNBOOK.md` covers the BLOCKING PR-5 shodan validation checklist, the from-scratch control run (sequenced first), launch/monitor/recovery, and the [D-24] kill gate (`ppo:gate` win% Δ vs `ai_lookahead@596f781`, 95% CI lower bound > 0; turtle floor ≥ 60% decisiveRate).
+- **Auto-restart safety guard (code half, folded into PR-6).** `train.py` now HALTs with `EXIT_POINTER_REJECTED=3` on a present-but-rejected `latest.json` (was PR-5's loud-warn+fresh) — the three-way resume/fresh/HALT policy is a pure torch-free `resume_action(reason)` in `resume_state.py` (CI-tested). `load_resume_checkpoint` falls back across the retained `keep=N` SAME-build older pairs on a corrupt newest `.zip` (torch-free `resume_candidate_pairs` orders them), raising `ResumeCheckpointError` → the same HALT only when ALL retained pairs are unreadable.
+- **Verification:** ruff clean on all touched files; `test_resume_state.py` 37 green locally (6 new `resume_candidate_pairs`/`resume_action` tests); `bash -n` clean. sb3 corrupt-`.zip` fallback + all-corrupt tests added to `test_resume.py` (shodan-only). Docs updated (PLAN/DECISIONS PR-4/PR-5 "DONE locally" → MERGED #71/#72).
+
+**Learned / decided:**
+
+- **The PR-5 "loud warn + fresh" on a rejected pointer is right for an attended run but wrong unattended.** Under the schtasks auto-restart it silently re-burns the full `--timesteps` budget from step 0 — so PR-6 evolves it to **HALT + alert** (a distinct exit code the launcher treats as do-not-retry). This is a deliberate supersede of PR-5 review-decision (b), not a contradiction.
+- **The corrupt-`.zip` fallback is distinct from the keep=2 fallback PR-5 (b) refused.** PR-5 (b) refused to silently skip to keep=2 for _version/encoding-skew_ (genuinely incompatible) ckpts — PR-6 still HALTs on those. PR-6 only rolls back across SAME-build older pairs when the newest `.zip` BYTES are torn (a case (b) flagged "revisit if it bites"). Both meet at the same HALT for the incompatible case.
+- **Keep the highest-consequence decision in the torch-free tier.** `resume_action` + `resume_candidate_pairs` are pure and CI-tested, mirroring `classify_latest_pointer` — the sb3 `resume.py`/`train.py` halves stay thin (and shodan-only).
+
+**Dead ends / surprises:**
+
+- The readiness workflow's code-reader agent hit the structured-output retry cap; the synthesis agent + I read `train.py`/`resume.py` directly to fill the gap (and to verify the two unguarded failure modes that motivated folding the safety guard into PR-6).
+- This Mac has no Python ≥3.10 and no `sb3_contrib`, so the sb3-coupled resume tier (including the new corrupt-`.zip` tests) runs only on shodan; locally only the torch-free tier validates.
+
+**Next:**
+
+- On shodan: install/activate `[rl]`, run the PR-5 validation checklist + the new sb3 resume tests, then the from-scratch control run, then launch the long BEAT run at `R=3` and gate per [D-24].
+- PR-7 (deferred): env-server `main()` persistence integration test; live cross-worker `SharedDiskStore`; live forkserver two-half resume smoke.
+
+---
+
 ## 2026-06-28 — Task C/E PR-5 review-hardening (corrupt-sidecar degrade, CI-testable resume decision, GC orphan-sweep)
 
 **Phase:** 3 · **Who:** Ivan + Claude

--- a/docs/ml-bot/PLAN.md
+++ b/docs/ml-bot/PLAN.md
@@ -543,19 +543,20 @@ ppo:gate` over **3040 seat-fair games**: PPO **11.5 ± 1.3%** vs Lookahead **15.
   GC, consumer `unlinkSync` removed (PR-3). **PR-4 MERGED (PR #71, `f1224ee`):**
   new torch-free `_train_common.py` (shared env-thunk/parser/validation + `resolve_from_scratch`) reused
   by a byte-identical `train_tracer.py`; new `train.py` = `VecMonitor(SubprocVecEnv(forkserver))` +
-  TensorBoard/CSV logging + `--from-scratch`; `tensorboard` added to `[rl]`. **PR-5 landed locally**
-  (branch `ml-bot/task-ce-pr5-resume`) — idempotent checkpoint/resume core: HOLE-D budget cap
+  TensorBoard/CSV logging + `--from-scratch`; `tensorboard` added to `[rl]`. **PR-5 MERGED (PR #72,
+  `b554cd7`)** — idempotent checkpoint/resume core: HOLE-D budget cap
   (`_remaining_timesteps` + `reset_num_timesteps=False`); NEW torch+sb3-FREE `resume_state.py` (RNG
   sidecar, atomic `latest.json`-written-last + dir-fsync, GC keep-N, pointer validation) + sb3
   `resume.py` (`load_resume_checkpoint` = `MaskablePPO.load` PATH A so num_timesteps restores before
-  `SnapshotCallback` reads it = HOLE-C; `ResumeCheckpointCallback`); auto-detect resume (corrupt
-  `latest.json`⇒loud warn+fresh); per-session CSV; B6 flags (`--snapshot-store`/`--league-state-dir`/
+  `SnapshotCallback` reads it = HOLE-C; `ResumeCheckpointCallback`); auto-detect resume (a rejected
+  `latest.json` ⇒ **HALT+alert** as of PR-6 — was loud-warn+fresh); per-session CSV; B6 flags
+  (`--snapshot-store`/`--league-state-dir`/
   `--league-dump-every`) forwarded from the shared parser into `server_kwargs`; `--state-dir`/
   `--checkpoint-every`. 4-lens impl review → **2 blockers found & fixed** (GPU-resume RNG `set_rng_state`
   crash → CPU-pinned; sb3-tier RED from a 2-tuple 3-unpack). ruff clean; torch-free tier green locally;
   the sb3 tier runs on shodan. See [D-26].
 - [~] **(C)** Scale envs across cores; add the short **from-scratch control** run ([D-19] decision 1).
-  **PR-4 landed locally** (branch `ml-bot/task-ce-pr4-train`): `train.py` swaps `DummyVecEnv` →
+  **PR-4 MERGED (PR #71, `f1224ee`)**: `train.py` swaps `DummyVecEnv` →
   `VecMonitor(SubprocVecEnv(start_method=forkserver))` (env fork before `MaskablePPO`/CUDA init)
   and adds the `--from-scratch` flag (mutex with `--freeze-trunk`, relaxed LR/ent-coef, provenance
   stamped). _Still open: the actual cross-core scaling validation + the short from-scratch control
@@ -567,9 +568,10 @@ ppo:gate` over **3040 seat-fair games**: PPO **11.5 ± 1.3%** vs Lookahead **15.
       RNG + step + league pool/book (**NOT VecNormalize** — dropped per [D-26]); TensorBoard + a flat
       CSV that survives sessions; swap `DummyVecEnv` → `SubprocVecEnv` for real cross-core parallelism.
       _Slices: **PR-4 MERGED** (PR #71 `f1224ee` — `train.py` + TB/CSV + SubprocVecEnv +
-      `--from-scratch`); **PR-5 landed locally** (branch `ml-bot/task-ce-pr5-resume` — checkpoint/resume
-      core + per-session CSV + B6 flag forwarding, 2 review blockers fixed); PR-6 (committed shodan
-      launcher + schtasks runbook), PR-7 (deferred test-hardening). See [D-26]._
+      `--from-scratch`); **PR-5 MERGED** (PR #72 `b554cd7` — checkpoint/resume core + per-session CSV + B6 flag forwarding, 2 review blockers fixed); **PR-6 (this PR)** = committed shodan launcher
+      (`scripts/shodan/ppo-train.sh`) + schtasks wrapper/runbook + auto-restart safety guard
+      (rejected-pointer HALT via `EXIT_POINTER_REJECTED`, corrupt-`.zip` fallback to the retained
+      pair); PR-7 (deferred test-hardening). See [D-26]._
 
 **Acceptance criteria.**
 

--- a/ml/dicewars_ppo/_train_common.py
+++ b/ml/dicewars_ppo/_train_common.py
@@ -39,6 +39,16 @@ if TYPE_CHECKING:  # annotation-only; never imported at runtime (keeps this modu
 # (player_count - 1) opponent seats.
 DEFAULT_OPPONENTS = "ai_lookahead,ai_strategist,ai_expectimax,ai_bc,ai_defensive"
 
+# Distinct process exit code for an UNRECOVERABLE resume state ([D-26]/PR-6): a present-but-rejected
+# latest.json (corrupt-json / version|encoding skew / dangling-ref) or a corrupt .zip whose retained
+# fallbacks are also unreadable. `train.py` raises `SystemExit(EXIT_POINTER_REJECTED)` on this; the
+# shodan launcher (scripts/shodan/ppo-train.sh) treats it as HALT+alert (never retry — the bytes
+# will not heal), distinct from any OTHER non-zero exit (a transient crash it bounds-retries). Lives
+# here in the torch-free core so a lean-CI canary pins the value AND the launcher's hard-coded copy
+# has a single source of truth to track. Chosen distinct from 0 (ok) / 1 (generic raise or
+# SystemExit-string) / 2 (argparse misuse). If you change it, update ppo-train.sh's copy too.
+EXIT_POINTER_REJECTED = 3
+
 
 def _make_env_thunk(cfg: ModelConfig, args: argparse.Namespace, env_index: int):
     """A zero-arg env factory for ``DummyVecEnv``/``SubprocVecEnv`` — each launches an env-server.

--- a/ml/dicewars_ppo/resume.py
+++ b/ml/dicewars_ppo/resume.py
@@ -18,6 +18,7 @@ bit-exact.
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -32,13 +33,19 @@ from .resume_state import (
     POINTER_ENCODING_SKEW,
     POINTER_VALID,
     POINTER_VERSION_SKEW,
+    RESUME_ACTION_FRESH,
+    RESUME_ACTION_HALT,
+    RESUME_ACTION_RESUME,
     RESUME_FORMAT_VERSION,
+    ResumeCheckpointError,
     classify_latest_pointer,
     describe_pointer_rejection,
     has_resume_checkpoint,
     latest_pointer_exists,
     read_latest_pointer,
     restore_rng_sidecar,
+    resume_action,
+    resume_candidate_pairs,
     save_resume_checkpoint,
 )
 
@@ -52,8 +59,12 @@ __all__ = [
     "POINTER_ENCODING_SKEW",
     "POINTER_VALID",
     "POINTER_VERSION_SKEW",
+    "RESUME_ACTION_FRESH",
+    "RESUME_ACTION_HALT",
+    "RESUME_ACTION_RESUME",
     "RESUME_FORMAT_VERSION",
     "ResumeCheckpointCallback",
+    "ResumeCheckpointError",
     "classify_latest_pointer",
     "describe_pointer_rejection",
     "has_resume_checkpoint",
@@ -61,12 +72,14 @@ __all__ = [
     "load_resume_checkpoint",
     "read_latest_pointer",
     "restore_rng_sidecar",
+    "resume_action",
+    "resume_candidate_pairs",
     "save_resume_checkpoint",
 ]
 
 
 def load_resume_checkpoint(state_dir: str | Path, venv: Any, device: str) -> MaskablePPO:
-    """Load the learner from the latest valid checkpoint (PATH A — restores num_timesteps, [D-26]).
+    """Load the learner from the newest LOADABLE checkpoint (PATH A — restores num_timesteps).
 
     Uses ``MaskablePPO.load(env=venv)`` so policy + optimizer + ``num_timesteps`` are restored in
     ONE call BEFORE ``learn`` and BEFORE ``SnapshotCallback._on_training_start`` reads it (so the
@@ -75,20 +88,56 @@ def load_resume_checkpoint(state_dir: str | Path, venv: Any, device: str) -> Mas
     classify the entire on-disk pool as "future" and delete it — so the resume MUST go through
     ``load``. Then the RNG sidecar is restored — but a corrupt sidecar DEGRADES to a fresh stream
     (``restore_rng_sidecar``) rather than aborting: the recoverable state is already loaded.
+
+    **Corrupt-``.zip`` fallback (PR-6).** ``classify_latest_pointer`` validates the pointer JSON and
+    that the referenced files EXIST, but not that the ``.zip`` bytes are intact — a bit-rotted or
+    half-flushed newest ``.zip`` at a VALID pointer makes ``MaskablePPO.load`` raise, which under
+    the unattended schtasks auto-restart would be a PERMANENT crash-loop (every relaunch reads the
+    same bad bytes and dies). So we try the pointer's pair first, then fall back to the retained
+    ``keep=N`` OLDER pairs (newest-first, from :func:`resume_candidate_pairs`), rolling back one
+    checkpoint cadence at most. Only when EVERY retained pair fails do we raise
+    :class:`ResumeCheckpointError` — ``train.py`` turns that into the halt-and-alert exit code,
+    rather than retrying bytes that will not heal. We deliberately do NOT rewrite ``latest.json`` on
+    fallback: it is the crash hinge and the next checkpoint moves the pointer forward anyway; a
+    repeat crash before then simply re-runs this cheap fallback.
     """
-    pointer = read_latest_pointer(state_dir)
-    if pointer is None:
-        raise FileNotFoundError(f"no valid resume checkpoint in {state_dir}")
     state_dir = Path(state_dir)
-    zip_path = state_dir / pointer["ckpt"]
-    rng_path = state_dir / pointer["rng"]
-    model = MaskablePPO.load(zip_path, env=venv, device=device)
-    # The MODEL load honors `device`, but the RNG sidecar must NOT — RNG states are CPU ByteTensors
-    # and set_rng_state rejects a GPU-mapped tensor (would crash every --device cuda resume). And a
-    # torn/bit-rotted sidecar degrades to a fresh RNG stream (loud warn), not bricking the resume
-    # whose model/optimizer/num_timesteps are already restored above.
-    restore_rng_sidecar(rng_path)
-    return model
+    candidates = resume_candidate_pairs(state_dir)
+    if not candidates:
+        raise FileNotFoundError(f"no valid resume checkpoint in {state_dir}")
+    last_err: Exception | None = None
+    for i, cand in enumerate(candidates):
+        zip_path = state_dir / cand["ckpt"]
+        try:
+            model = MaskablePPO.load(zip_path, env=venv, device=device)
+        except Exception as err:  # noqa: BLE001 — a torn .zip raises BadZipFile/EOFError/RuntimeError
+            last_err = err
+            more = "trying the retained prior pair" if i + 1 < len(candidates) else "no older pair"
+            print(
+                f"WARNING: resume checkpoint {cand['ckpt']} failed to load ({err!r}); {more}.",
+                file=sys.stderr,
+            )
+            continue
+        if i > 0:
+            # Fell back past the newest pair: surface the rollback loudly — up to one
+            # --checkpoint-every window of progress (and num_timesteps) is replayed.
+            print(
+                f"WARNING: resumed from RETAINED prior checkpoint {cand['ckpt']} "
+                f"(step={cand['step']}) after {i} newer pair(s) failed to load — rolled back up to "
+                "one checkpoint cadence.",
+                file=sys.stderr,
+            )
+        # The MODEL load honors `device`, but the RNG sidecar must NOT — RNG states are CPU
+        # ByteTensors and set_rng_state rejects a GPU-mapped tensor (would crash every --device
+        # cuda resume). A torn/bit-rotted sidecar degrades to a fresh RNG stream (loud warn), not
+        # bricking the resume whose model/optimizer/num_timesteps are already restored above.
+        restore_rng_sidecar(state_dir / cand["rng"])
+        return model
+    raise ResumeCheckpointError(
+        f"all {len(candidates)} retained resume checkpoint(s) in {state_dir} failed to load; last "
+        f"error: {last_err!r}. Inspect the ckpt-*.zip pairs before deleting latest.json (it is the "
+        "breadcrumb to them)."
+    )
 
 
 class ResumeCheckpointCallback(BaseCallback):

--- a/ml/dicewars_ppo/resume.py
+++ b/ml/dicewars_ppo/resume.py
@@ -135,8 +135,11 @@ def load_resume_checkpoint(state_dir: str | Path, venv: Any, device: str) -> Mas
         return model
     raise ResumeCheckpointError(
         f"all {len(candidates)} retained resume checkpoint(s) in {state_dir} failed to load; last "
-        f"error: {last_err!r}. Inspect the ckpt-*.zip pairs before deleting latest.json (it is the "
-        "breadcrumb to them)."
+        f"error: {last_err!r}. This is usually corrupt bytes, but the SAME error across EVERY "
+        "retained pair more often means an ENVIRONMENT mismatch (a torch/sb3 version change since "
+        "the checkpoints were written, or a bad --device) than per-file corruption — verify those "
+        "FIRST. Inspect the ckpt-*.zip pairs before deleting latest.json (it is the breadcrumb to "
+        "them)."
     )
 
 

--- a/ml/dicewars_ppo/resume_state.py
+++ b/ml/dicewars_ppo/resume_state.py
@@ -36,7 +36,8 @@ import torch
 from .constants import ENCODING_VERSION
 
 # Bump if the on-disk resume layout (latest.json schema / the sidecar set) changes incompatibly, so
-# an old pointer is rejected (→ a loud fresh-start) rather than mis-loaded.
+# an old pointer is rejected (POINTER_VERSION_SKEW → resume_action HALT → a loud exit with
+# EXIT_POINTER_REJECTED, PR-6) rather than mis-loaded.
 RESUME_FORMAT_VERSION = 1
 LATEST_NAME = "latest.json"
 
@@ -77,9 +78,12 @@ class ResumeCheckpointError(RuntimeError):
     guards, just discovered at load time rather than pointer-classification time).
     """
 
-# Module-level so the macOS dir-fsync degrade (in _fsync_dir) warns once per process, not once per
-# checkpoint.
+# Module-level so each _fsync_dir degrade warns once per process, not once per checkpoint. Two
+# SEPARATE flags so the benign/expected fsync-unsupported degrade (macOS, fires on the first
+# checkpoint) can't consume a shared flag and silently suppress the UNEXPECTED open-failure warn (a
+# vanished state dir / EMFILE) — they are different-severity conditions and each warns on its own.
 _DIR_FSYNC_WARNED = False
+_DIR_OPEN_WARNED = False
 
 
 def _fsync_path(path: Path) -> None:
@@ -101,16 +105,25 @@ def _fsync_dir(path: Path) -> None:
     it degrades to a no-op rather than crashing, since this is a hardening, not a correctness
     requirement (Linux / the shodan WSL box get the guarantee). The degrade is logged ONCE (not on
     every checkpoint) so the reduced-durability mode is visible on the box it's running on rather
-    than silent — the whole point of this run is crash-safety.
+    than silent — the whole point of this run is crash-safety. The OPEN failure degrades the same
+    way (warn-once, not a silent return): the state dir was just mkdir'd, so a failure to open it is
+    unexpected (permissions / a vanished dir / EMFILE) and must not silently drop durability.
     """
+    global _DIR_FSYNC_WARNED, _DIR_OPEN_WARNED
     try:
         fd = os.open(path, os.O_RDONLY)
-    except OSError:
+    except OSError as err:
+        if not _DIR_OPEN_WARNED:
+            print(
+                f"WARNING: could not open directory {path} to fsync ({err}); checkpoint durability "
+                "is best-effort (os.replace torn-write atomicity still holds).",
+                file=sys.stderr,
+            )
+            _DIR_OPEN_WARNED = True
         return
     try:
         os.fsync(fd)
     except OSError:
-        global _DIR_FSYNC_WARNED
         if not _DIR_FSYNC_WARNED:
             print(
                 f"WARNING: directory fsync unsupported on this platform ({path}); checkpoint "
@@ -407,7 +420,13 @@ def _safe_unlink(path: Path) -> None:
     try:
         path.unlink(missing_ok=True)
     except OSError as err:
-        print(f"[resume] GC: could not unlink {path.name} ({err}); leaving on disk")
+        # stderr + WARNING prefix to match every other degradation in this module (so log scrapers
+        # see GC hiccups uniformly); the file is left on disk and a later GC pass re-sweeps it.
+        print(
+            f"WARNING: [resume] GC could not unlink {path.name} ({err}); leaving on disk "
+            "(a later GC pass re-sweeps it).",
+            file=sys.stderr,
+        )
 
 
 def _gc_old_checkpoints(state_dir: Path, *, keep: int, keep_step: int) -> None:

--- a/ml/dicewars_ppo/resume_state.py
+++ b/ml/dicewars_ppo/resume_state.py
@@ -57,6 +57,26 @@ POINTER_VERSION_SKEW = "version-skew"
 POINTER_ENCODING_SKEW = "encoding-skew"
 POINTER_DANGLING_REF = "dangling-ref"
 
+# The three-way resume decision a driver makes from a POINTER_* reason ([D-26]/PR-6). Kept here in
+# the torch-free tier (not inline in the sb3-gated train.py) so the highest-consequence
+# "resume / fresh / halt" policy is unit-testable in lean CI — the same reason
+# classify_latest_pointer itself lives here. The HALT action is the PR-6 change: a present-but-
+# rejected pointer no longer silently restarts from step 0 (unattended, it re-burns the budget).
+RESUME_ACTION_RESUME = "resume"
+RESUME_ACTION_FRESH = "fresh"
+RESUME_ACTION_HALT = "halt"
+
+
+class ResumeCheckpointError(RuntimeError):
+    """Every retained resume checkpoint failed to load — an UNRECOVERABLE resume ([D-26]/PR-6).
+
+    sb3-free (lives here so the torch-only CI tier can name it) but RAISED by ``resume.py`` after
+    its corrupt-``.zip`` fallback exhausts the keep-N retained pairs. ``train.py`` catches it, exits
+    with ``EXIT_POINTER_REJECTED`` so the PR-6 schtasks auto-restart ALERTS an operator instead of
+    crash-looping on bytes that will never heal (the same failure class the rejected-pointer halt
+    guards, just discovered at load time rather than pointer-classification time).
+    """
+
 # Module-level so the macOS dir-fsync degrade (in _fsync_dir) warns once per process, not once per
 # checkpoint.
 _DIR_FSYNC_WARNED = False
@@ -272,6 +292,23 @@ def describe_pointer_rejection(reason: str) -> str:
     }.get(reason, f"latest.json is unusable (reason: {reason}).")
 
 
+def resume_action(reason: str) -> str:
+    """Map a ``POINTER_*`` reason to the resume decision ([D-26]/PR-6) — pure, CI-testable.
+
+    ``POINTER_VALID`` → ``RESUME_ACTION_RESUME``; ``POINTER_ABSENT`` (a brand-new ``--state-dir``,
+    no prior run) → ``RESUME_ACTION_FRESH``; ANY present-but-rejected reason (corrupt JSON, version
+    or encoding skew, dangling ref) → ``RESUME_ACTION_HALT``. The driver turns HALT into a loud exit
+    with ``EXIT_POINTER_REJECTED`` so the unattended schtasks auto-restart ALERTS an operator
+    instead of silently restarting from step 0 and re-training the full ``--timesteps`` budget — and
+    so it does not overwrite the still-recoverable on-disk ``ckpt-*`` pairs the breadcrumb names.
+    """
+    if reason == POINTER_VALID:
+        return RESUME_ACTION_RESUME
+    if reason == POINTER_ABSENT:
+        return RESUME_ACTION_FRESH
+    return RESUME_ACTION_HALT
+
+
 def read_latest_pointer(state_dir: str | Path) -> dict[str, Any] | None:
     """Return the parsed+validated ``latest.json`` dict, or ``None`` if unusable.
 
@@ -296,6 +333,49 @@ def latest_pointer_exists(state_dir: str | Path) -> bool:
 def has_resume_checkpoint(state_dir: str | Path) -> bool:
     """True iff ``state_dir`` holds a valid, loadable resume checkpoint."""
     return read_latest_pointer(state_dir) is not None
+
+
+def resume_candidate_pairs(state_dir: str | Path) -> list[dict[str, Any]]:
+    """Ordered checkpoint pairs ``resume.py`` should TRY to load, newest-usable first ([D-26]/PR-6).
+
+    Torch-free (CI-tested) so the corrupt-``.zip`` FALLBACK ORDER — the highest-consequence "which
+    checkpoint do we resume from?" decision — is unit-testable without ``sb3``/a GPU, exactly like
+    :func:`classify_latest_pointer` is for the resume/fresh decision. ``resume.py`` only adds the
+    thin ``MaskablePPO.load`` try/except loop over this list.
+
+    The list is:
+
+    1. The pair ``latest.json`` validates (its explicit ``ckpt``/``rng`` names) — the newest DURABLE
+       checkpoint, tried first.
+    2. Then the retained OLDER pairs (step STRICTLY LESS THAN the pointer's, whose ``.zip`` is on
+       disk), newest-first — what GC ``keep=N`` left behind, so a bit-rotted newest ``.zip``
+       degrades to the prior good pair instead of crash-looping the unattended schtasks restart.
+
+    Returns ``[]`` when ``latest.json`` is not ``POINTER_VALID`` (the caller treats that as "no
+    resume point"; the resume/fresh/halt split is :func:`classify_latest_pointer`'s job, not this).
+
+    Pairs strictly NEWER than the pointer are deliberately EXCLUDED: a ``.zip`` newer than
+    ``latest.json`` is from a checkpoint whose write died before its ``latest.json`` rename (the
+    pointer is written LAST), so it is presumed torn and must never be preferred over the validated
+    pointer. The ``.rng.pt`` name is carried even if that sidecar is missing/corrupt —
+    ``restore_rng_sidecar`` degrades to a fresh stream, so a candidate is "usable" as long as its
+    ``.zip`` exists.
+    """
+    pointer = read_latest_pointer(state_dir)
+    if pointer is None:
+        return []
+    state_dir = Path(state_dir)
+    p_step = int(pointer["step"])
+    pairs: list[dict[str, Any]] = [
+        {"step": p_step, "ckpt": pointer["ckpt"], "rng": pointer["rng"]}
+    ]
+    for step in reversed(_checkpoint_steps(state_dir)):  # newest-first
+        if step >= p_step:
+            continue  # the pointer pair (==) is already first; newer (>) is a presumed-torn orphan
+        zip_name = f"ckpt-{step:09d}.zip"
+        if (state_dir / zip_name).is_file():  # a .zip-less orphan .rng.pt is not loadable
+            pairs.append({"step": step, "ckpt": zip_name, "rng": f"ckpt-{step:09d}.rng.pt"})
+    return pairs
 
 
 # --- save / GC ---------------------------------------------------------------------------------

--- a/ml/dicewars_ppo/train.py
+++ b/ml/dicewars_ppo/train.py
@@ -40,8 +40,10 @@ not fixed-field BC exploitation. It still loads ``--checkpoint`` for the archite
 Idempotent checkpoint/resume (PR-5, [D-26] Q3). Pass ``--state-dir`` to make a run resumable:
 ``ResumeCheckpointCallback`` checkpoints policy + optimizer + ``num_timesteps`` + process RNG every
 ``--checkpoint-every`` steps (atomic ``latest.json`` written LAST, the crash hinge — see
-``resume.py``). A relaunch of the SAME command auto-resumes from a valid ``latest.json`` (a
-corrupt/version-skewed one warns and starts fresh), going through ``MaskablePPO.load`` and
+``resume.py``). A relaunch of the SAME command auto-resumes from a valid ``latest.json``; a
+present-but-REJECTED pointer (corrupt/version/encoding skew) HALTS with ``EXIT_POINTER_REJECTED``
+(PR-6) so the auto-restart launcher alerts instead of silently restarting from step 0, and a corrupt
+newest ``.zip`` falls back to the retained prior pair. Resume goes through ``MaskablePPO.load`` and
 ``learn(reset_num_timesteps=False, total_timesteps=_remaining_timesteps(...))`` so the absolute
 ``--timesteps`` budget is honored across crashes (HOLE-D), not made additive. The Node league's own
 resume half (``--league-state-dir`` etc.) is independent ([D-26] Q3) and forwarded via
@@ -70,15 +72,22 @@ from stable_baselines3.common.vec_env import SubprocVecEnv, VecMonitor
 from . import _train_common
 from .policy import load_bc_checkpoint, repack_to_bc_checkpoint
 from .resume import (
-    POINTER_ABSENT,
-    POINTER_VALID,
+    RESUME_ACTION_HALT,
+    RESUME_ACTION_RESUME,
     ResumeCheckpointCallback,
+    ResumeCheckpointError,
     classify_latest_pointer,
     describe_pointer_rejection,
     load_resume_checkpoint,
+    resume_action,
 )
 from .snapshot_callback import SnapshotCallback
 from .train_tracer import _verify_repack_exportable, build_model
+
+# Re-export the UNRECOVERABLE-resume exit code so `tr.EXIT_POINTER_REJECTED` resolves; the single
+# source of truth (and the lean-CI canary that pins its value for the launcher) lives in the
+# torch-free _train_common.
+EXIT_POINTER_REJECTED = _train_common.EXIT_POINTER_REJECTED
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -217,21 +226,31 @@ def train(args: argparse.Namespace) -> Path:
     )
     # Resume detection ([D-26] Q3, auto-detect). classify_latest_pointer (torch-free, CI-tested)
     # says WHY the pointer is (un)usable: VALID ⇒ continue the run; ABSENT ⇒ a fresh run; any other
-    # reason ⇒ warn LOUDLY with a CAUSE-SPECIFIC message and fall back to fresh — never a silent
-    # restart-from-0 that would discard days of progress (and re-trains the absolute --timesteps
-    # budget from scratch). describe_pointer_rejection steers AWAY from deleting latest.json when
-    # on-disk ckpt pairs are still recoverable (corrupt-pointer / dangling-ref).
+    # reason ⇒ a present-but-REJECTED pointer.
+    #
+    # PR-6 safety guard. A rejected-but-present pointer used to warn and start fresh — but under the
+    # unattended schtasks auto-restart that "fresh" run silently re-trains the WHOLE --timesteps
+    # budget from step 0 (days of GPU), and worse, may overwrite the still-recoverable on-disk ckpt
+    # pairs the breadcrumb points at. So we now HALT with a cause-specific, non-destructive recovery
+    # message and EXIT_POINTER_REJECTED, which the launcher treats as alert-and-stop (NOT retry).
+    # ABSENT stays a clean fresh run (a brand-new --state-dir has no pointer); to deliberately
+    # restart a campaign, point --state-dir at a fresh/empty dir rather than leave a rejected one.
     resuming = False
     if args.state_dir:
         reason = classify_latest_pointer(args.state_dir)
-        if reason == POINTER_VALID:
+        action = resume_action(reason)
+        if action == RESUME_ACTION_RESUME:
             resuming = True
-        elif reason != POINTER_ABSENT:
+        elif action == RESUME_ACTION_HALT:
             print(
-                f"WARNING: {args.state_dir}: {describe_pointer_rejection(reason)} "
-                "Starting a FRESH run (NO resume).",
+                f"FATAL: {args.state_dir}: {describe_pointer_rejection(reason)} "
+                "Refusing to silently restart from step 0 (it would re-burn the full --timesteps "
+                "budget under auto-restart). Resolve the pointer per the message above, or point "
+                "--state-dir at a fresh directory to start over.",
                 file=sys.stderr,
             )
+            raise SystemExit(EXIT_POINTER_REJECTED)
+        # else RESUME_ACTION_FRESH: ABSENT pointer ⇒ a clean fresh run (resuming stays False)
     if resuming and args.freeze_trunk:
         # MaskablePPO.load restores weights+optimizer but NOT the build-time requires_grad freeze
         # (it lives in build_model, which resume SKIPS), so a resumed --freeze-trunk run would
@@ -274,40 +293,52 @@ def train(args: argparse.Namespace) -> Path:
     )
     venv = VecMonitor(venv)
 
-    if resuming:
-        # PATH A ([D-26] HOLE-C/D): MaskablePPO.load restores policy + optimizer + num_timesteps in
-        # one call (BEFORE learn, so SnapshotCallback rehydrates against the resumed step, not 0) +
-        # the RNG sidecar. SKIP build_model entirely — load brings back the trained weights, so
-        # a warm-start would clobber them.
-        model = load_resume_checkpoint(args.state_dir, venv, args.device)
-        print(f"resumed from {args.state_dir} at num_timesteps={model.num_timesteps}")
-    else:
-        # build_model constructs MaskablePPO on this venv (CUDA inits here, after the fork) and
-        # either warm-starts or, with --from-scratch, leaves the fresh init.
-        model, venv = build_model(cfg, ckpt, args, venv=venv)
-
-    # Assemble the callbacks: the PFSP snapshot publisher (if any) + the resume checkpointer (if
-    # --state-dir). CallbackList only when both fire; a single callback / None otherwise.
-    callbacks = []
-    if callback is not None:
-        callbacks.append(callback)
-    if args.state_dir:
-        callbacks.append(ResumeCheckpointCallback(args.state_dir, args.checkpoint_every))
-        print(f"resume checkpointer: every {args.checkpoint_every} steps → {args.state_dir}")
-    learn_callback = (
-        CallbackList(callbacks) if len(callbacks) > 1 else (callbacks[0] if callbacks else None)
-    )
-
-    # Per-session CSV keyed on the resumed step (0 for a fresh run) so a resume never truncates a
-    # prior session's progress.csv ([D-26]); TensorBoard stays one continuous run.
-    logger, sinks = _make_logger(args, resumed_step=int(model.num_timesteps))
-    if logger is not None:
-        model.set_logger(logger)  # must precede learn()
-        # Report the ACTUAL sinks (the TB-missing degradation path drops "tensorboard"), so this
-        # line can never disagree with the warning _make_logger may have just printed.
-        print(f"logging: {' + '.join(sinks)} → {args.log_dir}")
-
+    # SINGLE teardown guard from here on: once the SubprocVecEnv workers (each owning a Node
+    # env-server child) start, EVERY exit path must reap them — a resume-load failure, a build_model
+    # error, the rejected-pointer HALT, or a learn() crash — else the Node children leak. (PR-6
+    # widened this from learn()-only: a load/build raise after the workers started used to leak.)
     try:
+        if resuming:
+            # PATH A ([D-26] HOLE-C/D): MaskablePPO.load restores policy + optimizer + num_timesteps
+            # in one call (BEFORE learn, so SnapshotCallback rehydrates against the resumed step,
+            # not 0) + the RNG sidecar. SKIP build_model entirely — load brings back the trained
+            # weights, so a warm-start would clobber them. load_resume_checkpoint falls back across
+            # the retained keep=N pairs on a corrupt .zip; only when ALL are unreadable does it
+            # raise ResumeCheckpointError — an unrecoverable resume, so HALT-and-alert
+            # (EXIT_POINTER_REJECTED) rather than let the launcher retry bytes that won't heal. The
+            # SystemExit propagates through the finally below, which reaps the workers first.
+            try:
+                model = load_resume_checkpoint(args.state_dir, venv, args.device)
+            except ResumeCheckpointError as err:
+                print(f"FATAL: {err}", file=sys.stderr)
+                raise SystemExit(EXIT_POINTER_REJECTED) from err
+            print(f"resumed from {args.state_dir} at num_timesteps={model.num_timesteps}")
+        else:
+            # build_model constructs MaskablePPO on this venv (CUDA inits here, after the fork) and
+            # either warm-starts or, with --from-scratch, leaves the fresh init.
+            model, venv = build_model(cfg, ckpt, args, venv=venv)
+
+        # Assemble the callbacks: the PFSP snapshot publisher (if any) + the resume checkpointer (if
+        # --state-dir). CallbackList only when both fire; a single callback / None otherwise.
+        callbacks = []
+        if callback is not None:
+            callbacks.append(callback)
+        if args.state_dir:
+            callbacks.append(ResumeCheckpointCallback(args.state_dir, args.checkpoint_every))
+            print(f"resume checkpointer: every {args.checkpoint_every} steps → {args.state_dir}")
+        learn_callback = (
+            CallbackList(callbacks) if len(callbacks) > 1 else (callbacks[0] if callbacks else None)
+        )
+
+        # Per-session CSV keyed on the resumed step (0 for a fresh run) so a resume never truncates
+        # a prior session's progress.csv ([D-26]); TensorBoard stays one continuous run.
+        logger, sinks = _make_logger(args, resumed_step=int(model.num_timesteps))
+        if logger is not None:
+            model.set_logger(logger)  # must precede learn()
+            # Report the ACTUAL sinks (the TB-missing degradation path drops "tensorboard"), so this
+            # line can never disagree with the warning _make_logger may have just printed.
+            print(f"logging: {' + '.join(sinks)} → {args.log_dir}")
+
         if resuming:
             # [D-26] HOLE-D: cap the run at the ABSOLUTE --timesteps. Under reset_num_timesteps=
             # False SB3 adds num_timesteps back internally, so passing `remaining` makes it stop at
@@ -333,11 +364,11 @@ def train(args: argparse.Namespace) -> Path:
                 total_timesteps=args.timesteps, progress_bar=False, callback=learn_callback
             )
     finally:
-        # Always reap the env workers (each owns a Node child) even on error. Guard the close: when
-        # learn() raised because a SubprocVecEnv worker already died (the common failure here), the
-        # close()'s worker-pipe ops raise EOFError/BrokenPipeError — and a raise in `finally` would
-        # REPLACE the in-flight exception as the primary traceback, burying the real cause. Demote
-        # any teardown error to a stderr warning so learn()'s exception stays the headline.
+        # Always reap the env workers (each owns a Node child) even on error/HALT. Guard the close:
+        # when learn() raised because a SubprocVecEnv worker already died (the common failure here),
+        # the close()'s worker-pipe ops raise EOFError/BrokenPipeError — and a raise in `finally`
+        # would REPLACE the in-flight exception as the primary traceback, burying the real cause.
+        # Demote any teardown error to a stderr warning so the original exception stays headline.
         try:
             venv.close()
         except Exception as close_exc:

--- a/ml/dicewars_ppo/train.py
+++ b/ml/dicewars_ppo/train.py
@@ -126,8 +126,9 @@ def build_parser() -> argparse.ArgumentParser:
     )
     # Idempotent resume (PR-5, [D-26] Q3). --state-dir holds the SB3 zip + RNG sidecar + latest.json
     # (the crash hinge). Set it to make the run resumable: a relaunch of the SAME command resumes
-    # from a valid latest.json (a corrupt/stale one warns and starts fresh). This is the PYTHON
-    # resume half; it is INDEPENDENT of the Node league's --league-state-dir (the other half).
+    # from a valid latest.json (a present-but-rejected one HALTs with EXIT_POINTER_REJECTED per the
+    # PR-6 safety guard; an ABSENT pointer starts fresh). This is the PYTHON resume half; it is
+    # INDEPENDENT of the Node league's --league-state-dir (the other half).
     p.add_argument(
         "--state-dir",
         default=None,
@@ -309,7 +310,13 @@ def train(args: argparse.Namespace) -> Path:
             # SystemExit propagates through the finally below, which reaps the workers first.
             try:
                 model = load_resume_checkpoint(args.state_dir, venv, args.device)
-            except ResumeCheckpointError as err:
+            except (ResumeCheckpointError, FileNotFoundError) as err:
+                # ResumeCheckpointError: every retained pair was unreadable. FileNotFoundError:
+                # classify_latest_pointer said VALID but latest.json (or a referenced file) vanished
+                # before load re-read it (a single-writer TOCTOU). Either way HALT: letting a bare
+                # FileNotFoundError escape as a generic exit would have the launcher RETRY, and the
+                # next invocation's classify would then read ABSENT → RESUME_ACTION_FRESH → a silent
+                # restart from step 0 — the exact failure this guard exists to prevent.
                 print(f"FATAL: {err}", file=sys.stderr)
                 raise SystemExit(EXIT_POINTER_REJECTED) from err
             print(f"resumed from {args.state_dir} at num_timesteps={model.num_timesteps}")

--- a/ml/tests/test_ppo_train_launcher.py
+++ b/ml/tests/test_ppo_train_launcher.py
@@ -1,0 +1,174 @@
+"""Behavioral tests for the shodan PPO auto-restart launcher (``scripts/shodan/ppo-train.sh``).
+
+Lean-CI tier: this shells out to ``bash`` and imports NO ``torch``/``sb3`` — so the launcher's
+restart-loop DISPATCH is pinned in CI, not only on a live shodan BEAT run. That dispatch is the
+*consumer* side of the cross-language ``EXIT_POINTER_REJECTED`` contract (``test_train_common_args``
+only checks that the launcher *defines* the same constant; here we prove the launcher *acts* on it),
+plus the bounded crash-loop halt and the subtlest line in the file — "a checkpoint-step advance
+resets the consecutive-fail counter," i.e. the boundary between killing a genuine crash-loop and
+killing a run that has been making progress for days.
+
+The launcher's ``main "$@"`` is guarded by ``[ "${BASH_SOURCE[0]}" = "${0}" ]``, so we SOURCE the
+file (defining its functions without auto-running it), stub the heavy/external bits
+(``preflight`` / ``check_commit_pinned`` / ``run_once`` / ``latest_step`` / ``sleep``), and drive
+``main`` deterministically with no real training, git, GPU, or backoff waits.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ML_DIR = Path(__file__).resolve().parents[1]
+LAUNCHER = ML_DIR.parent / "scripts" / "shodan" / "ppo-train.sh"
+CMD = ML_DIR.parent / "scripts" / "shodan" / "ppo-train.cmd"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None or not LAUNCHER.is_file(),
+    reason="needs bash + the shodan launcher",
+)
+
+
+def _exit_code(name: str) -> int:
+    """Read an intentional-halt exit code straight from the launcher, so these tests pin the
+    DISPATCH behavior without hard-coding a value that could silently drift from the script."""
+    m = re.search(rf"^{name}=(\d+)", LAUNCHER.read_text(), re.MULTILINE)
+    assert m is not None, f"{name} must be defined in {LAUNCHER}"
+    return int(m.group(1))
+
+
+# Sets the run env + the counters the scenarios use, sources the launcher (guarded main ⇒ not run),
+# then overrides the external bits. Sentinel substitution (not str.format) keeps bash's {} braces
+# intact. Scenario snippets are appended after this, then a bare `main`.
+_PRELUDE = r"""
+export RUN_NAME="test"
+export RUN_ROOT="__RUN_ROOT__"
+export STATE_DIR="$RUN_ROOT/state"
+export MAX_CONSECUTIVE_FAILS="__MAX_FAILS__"
+export DEVICE="cpu"
+ATTEMPTS_FILE="$RUN_ROOT/attempts"
+SEQ_FILE="$RUN_ROOT/seq"
+mkdir -p "$STATE_DIR"
+: > "$ATTEMPTS_FILE"
+echo 0 > "$SEQ_FILE"
+
+source "__LAUNCHER__"
+
+# Stubs defined AFTER source ⇒ they override the script's own definitions. No real git/GPU/waits.
+preflight() { :; }
+check_commit_pinned() { :; }
+sleep() { :; }
+"""
+
+
+class _Result:
+    def __init__(self, rc: int, attempts: int, output: str) -> None:
+        self.rc = rc
+        self.attempts = attempts
+        self.output = output  # stdout + stderr merged (alerts are tee'd to both)
+
+
+def _drive_main(tmp_path: Path, scenario: str, *, max_fails: int = 5) -> _Result:
+    run_root = tmp_path / "run"
+    harness = (
+        _PRELUDE.replace("__RUN_ROOT__", str(run_root))
+        .replace("__MAX_FAILS__", str(max_fails))
+        .replace("__LAUNCHER__", str(LAUNCHER))
+        + scenario
+        + "\nmain\n"
+    )
+    script = tmp_path / "harness.sh"
+    script.write_text(harness)
+    proc = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        timeout=30,  # a runaway loop (e.g. a broken reset) fails loudly instead of hanging CI
+        cwd=str(ML_DIR.parent),
+    )
+    attempts_file = run_root / "attempts"
+    attempts = len(attempts_file.read_text().split()) if attempts_file.exists() else 0
+    return _Result(proc.returncode, attempts, proc.stdout + proc.stderr)
+
+
+def test_clean_exit_runs_once_and_returns_zero(tmp_path):
+    r = _drive_main(tmp_path, 'run_once() { echo a >> "$ATTEMPTS_FILE"; return 0; }')
+    assert r.rc == 0
+    assert r.attempts == 1  # a clean run is never relaunched
+
+
+def test_pointer_rejected_halts_immediately_without_retry(tmp_path):
+    # The heart of PR-6: exit EXIT_POINTER_REJECTED ⇒ the launcher HALTS, never bounded-retries.
+    # run_once returns the launcher's OWN constant, so the test tracks the script's value.
+    code = _exit_code("EXIT_POINTER_REJECTED")
+    r = _drive_main(
+        tmp_path,
+        'run_once() { echo a >> "$ATTEMPTS_FILE"; return "$EXIT_POINTER_REJECTED"; }',
+    )
+    assert r.rc == code  # propagated verbatim as the do-not-retry signal
+    assert r.attempts == 1  # halted on the first attempt — not retried
+    assert "not retrying" in r.output.lower()
+
+
+def test_no_progress_crash_loop_halts_at_bound(tmp_path):
+    # A persistently-failing run that never checkpoints (latest_step stays 0 — no latest.json) is
+    # bounded: exactly MAX_CONSECUTIVE_FAILS attempts, then a distinct EXIT_CRASH_LOOP halt.
+    code = _exit_code("EXIT_CRASH_LOOP")
+    r = _drive_main(
+        tmp_path,
+        'run_once() { echo a >> "$ATTEMPTS_FILE"; return 1; }',
+        max_fails=3,
+    )
+    assert r.rc == code
+    assert r.attempts == 3
+    assert "crash-loop" in r.output.lower()
+
+
+def test_checkpoint_progress_resets_the_fail_counter(tmp_path):
+    # latest_step climbs 0,0,100,100,… — the step advance observed at the top of attempt 3 resets
+    # `fails`, so with MAX=3 the bound is hit at attempt 5, NOT attempt 3. If the reset logic
+    # regressed (counter never reset), this would halt at attempt 3 and `attempts == 5` would fail.
+    code = _exit_code("EXIT_CRASH_LOOP")
+    scenario = (
+        'latest_step() { local n; n="$(cat "$SEQ_FILE")"; n=$((n + 1)); echo "$n" > "$SEQ_FILE"; '
+        'if [ "$n" -le 2 ]; then echo 0; else echo 100; fi; }\n'
+        'run_once() { echo a >> "$ATTEMPTS_FILE"; return 1; }'
+    )
+    r = _drive_main(tmp_path, scenario, max_fails=3)
+    assert r.rc == code
+    assert r.attempts == 5  # 5, not 3 — the progress at attempt 3 reset the counter
+
+
+@pytest.mark.skipif(not CMD.is_file(), reason="needs ppo-train.cmd")
+def test_cmd_maps_both_halt_codes_to_no_retry():
+    """ppo-train.cmd must map BOTH coded halts to `exit /b 0` so Task Scheduler <RestartOnFailure>
+    never re-amplifies a deliberate halt. EXIT_POINTER_REJECTED (3) is transitively pinned by the
+    test_train_common_args.py canary, but EXIT_CRASH_LOOP (4) and the .cmd's `if "%RC%"=="N"`
+    literals had NO cross-file pin: a bump of EXIT_CRASH_LOOP in ppo-train.sh would silently desync
+    the .cmd branch and re-amplify crash-loops. The launcher tests can't run cmd.exe, so pin the
+    coupling statically here (lean tier, no torch)."""
+    cmd_text = CMD.read_text()
+    for name in ("EXIT_POINTER_REJECTED", "EXIT_CRASH_LOOP"):
+        code = _exit_code(name)  # read from ppo-train.sh
+        assert re.search(rf'if\s+"%RC%"=="{code}"\s*\(', cmd_text), (
+            f'ppo-train.cmd must map RC=={code} ({name}) to no-retry: `if "%RC%"=="{code}" (`'
+        )
+    # the catch-all still propagates everything else to the backstop
+    assert "exit /b %RC%" in cmd_text
+
+
+def test_transient_failure_then_success_exits_zero(tmp_path):
+    # The bounded-RETRY path (distinct from the do-not-retry exit-3 path): a transient exit-1
+    # failure is relaunched, and a subsequent clean exit ends the loop at 0.
+    scenario = (
+        'run_once() { echo a >> "$ATTEMPTS_FILE"; '
+        'local n; n="$(cat "$SEQ_FILE")"; n=$((n + 1)); echo "$n" > "$SEQ_FILE"; '
+        '[ "$n" -ge 2 ] && return 0 || return 1; }'
+    )
+    r = _drive_main(tmp_path, scenario, max_fails=5)
+    assert r.rc == 0
+    assert r.attempts == 2  # failed once, relaunched, then succeeded

--- a/ml/tests/test_resume.py
+++ b/ml/tests/test_resume.py
@@ -149,6 +149,46 @@ def test_load_resume_survives_corrupt_rng_sidecar(tmp_path, capsys):
     assert "FRESH RNG stream" in capsys.readouterr().err
 
 
+def test_load_resume_falls_back_to_prior_pair_on_corrupt_zip(tmp_path, capsys):
+    # PR-6 corrupt-.zip fallback: a bit-rotted NEWEST .zip at a VALID pointer must not crash-loop
+    # the auto-restart — load_resume_checkpoint rolls back to the retained keep=2 prior pair (one
+    # cadence of progress lost) and loudly says so.
+    cfg = _v2_config()
+    model = _build_model(cfg)
+    model.num_timesteps = 1000
+    rz.save_resume_checkpoint(model, tmp_path, 1000, keep=2)
+    model.num_timesteps = 2000
+    rz.save_resume_checkpoint(model, tmp_path, 2000, keep=2)  # latest.json → 2000
+    ptr = rz.read_latest_pointer(tmp_path)
+    assert ptr["step"] == 2000
+    (tmp_path / ptr["ckpt"]).write_bytes(b"not a real zip")  # corrupt ONLY the newest .zip
+
+    loaded = rz.load_resume_checkpoint(tmp_path, _build_venv(cfg), "cpu")  # must NOT raise
+
+    assert loaded.num_timesteps == 1000  # rolled back to the retained prior pair
+    # latest.json is the crash hinge — NOT rewritten on fallback (the next checkpoint moves it
+    # forward; a repeat crash before then just re-runs this cheap fallback).
+    assert rz.read_latest_pointer(tmp_path)["step"] == 2000
+    err = capsys.readouterr().err
+    assert "failed to load" in err  # the newest pair's failure was surfaced
+    assert "RETAINED prior checkpoint" in err  # the rollback was surfaced
+
+
+def test_load_resume_raises_when_all_retained_pairs_corrupt(tmp_path):
+    # When EVERY retained .zip is unreadable, fallback is exhausted ⇒ ResumeCheckpointError, which
+    # train.py turns into EXIT_POINTER_REJECTED (halt-and-alert) rather than letting the launcher
+    # bounds-retry bytes that will never heal.
+    cfg = _v2_config()
+    model = _build_model(cfg)
+    for step in (1000, 2000):
+        model.num_timesteps = step
+        rz.save_resume_checkpoint(model, tmp_path, step, keep=2)
+    for zip_path in tmp_path.glob("ckpt-*.zip"):
+        zip_path.write_bytes(b"torn")  # corrupt BOTH retained pairs
+    with pytest.raises(rz.ResumeCheckpointError, match="failed to load"):
+        rz.load_resume_checkpoint(tmp_path, _build_venv(cfg), "cpu")
+
+
 def test_callback_rejects_nonpositive_cadence(tmp_path):
     with pytest.raises(ValueError, match="checkpoint_every"):
         rz.ResumeCheckpointCallback(tmp_path, checkpoint_every=0)

--- a/ml/tests/test_resume_state.py
+++ b/ml/tests/test_resume_state.py
@@ -290,3 +290,92 @@ def test_gc_handles_10_digit_steps_above_1e9(tmp_path):
     assert _steps_on_disk(tmp_path) == [1_600_000_000]  # old 10-digit pair GC'd
     assert rs.read_latest_pointer(tmp_path)["step"] == 1_600_000_000
     assert not (tmp_path / "ckpt-1500000000.rng.pt").exists()  # both halves of the old pair gone
+
+
+# --- resume_candidate_pairs (PR-6 corrupt-.zip fallback ORDER) ---------------------------------
+# The torch-free half of the corrupt-.zip fallback: resume.py only adds the thin MaskablePPO.load
+# try/except loop over this list, so the "which checkpoint do we resume from?" decision is pinned
+# here in CI rather than only on a live shodan BEAT run.
+
+
+def test_candidate_pairs_empty_when_no_pointer(tmp_path):
+    assert rs.resume_candidate_pairs(tmp_path) == []  # absent latest.json ⇒ no resume point
+
+
+def test_candidate_pairs_empty_when_pointer_rejected(tmp_path):
+    # A present-but-rejected pointer is NOT a resume candidate source — the resume/halt split is
+    # classify_latest_pointer's job; this enumerator just returns [] (train.py halts first).
+    rs.save_resume_checkpoint(FakeModel(), tmp_path, 100, keep=2)
+    (tmp_path / rs.LATEST_NAME).write_text("{ not json")  # corrupt the pointer
+    assert rs.classify_latest_pointer(tmp_path) == rs.POINTER_CORRUPT_JSON
+    assert rs.resume_candidate_pairs(tmp_path) == []
+
+
+def test_candidate_pairs_pointer_first_then_older_newest_first(tmp_path):
+    m = FakeModel()
+    for step in (1000, 2000, 3000):  # keep=2 ⇒ on-disk steps end as {2000, 3000}
+        rs.save_resume_checkpoint(m, tmp_path, step, keep=2)
+    cands = rs.resume_candidate_pairs(tmp_path)
+    assert [c["step"] for c in cands] == [3000, 2000]  # pointer (newest durable) first, then older
+    # the first entry is exactly what latest.json names (explicit ckpt/rng), not a derived guess
+    ptr = rs.read_latest_pointer(tmp_path)
+    assert cands[0] == {"step": 3000, "ckpt": ptr["ckpt"], "rng": ptr["rng"]}
+    assert cands[1] == {"step": 2000, "ckpt": "ckpt-000002000.zip", "rng": "ckpt-000002000.rng.pt"}
+
+
+def test_candidate_pairs_single_when_keep_one(tmp_path):
+    m = FakeModel()
+    rs.save_resume_checkpoint(m, tmp_path, 1000, keep=1)
+    rs.save_resume_checkpoint(m, tmp_path, 2000, keep=1)  # GC leaves only the newest
+    assert [c["step"] for c in rs.resume_candidate_pairs(tmp_path)] == [2000]
+
+
+def test_candidate_pairs_excludes_newer_orphan(tmp_path):
+    # A .zip NEWER than latest.json is from a save that died before its latest.json rename (the
+    # pointer is written LAST), so it is presumed torn and must NEVER be preferred over the pointer.
+    m = FakeModel()
+    rs.save_resume_checkpoint(m, tmp_path, 1000, keep=2)
+    (tmp_path / "ckpt-000009999.zip").write_bytes(b"torn")  # newer orphan, latest.json NOT updated
+    (tmp_path / "ckpt-000009999.rng.pt").write_bytes(b"torn")
+    assert rs.read_latest_pointer(tmp_path)["step"] == 1000  # pointer still names the durable pair
+    assert [c["step"] for c in rs.resume_candidate_pairs(tmp_path)] == [1000]  # orphan excluded
+
+
+def test_candidate_pairs_skips_zipless_older_orphan(tmp_path):
+    # An older step with only a .rng.pt (its .zip GC'd or never written) is not loadable ⇒ skipped,
+    # so resume.py never tries to MaskablePPO.load a sidecar path.
+    m = FakeModel()
+    rs.save_resume_checkpoint(m, tmp_path, 2000, keep=2)
+    rs.save_resume_checkpoint(m, tmp_path, 3000, keep=2)
+    (tmp_path / "ckpt-000002000.zip").unlink()  # leave the lone older .rng.pt behind
+    # zipless 2000 orphan skipped (no loadable .zip)
+    assert [c["step"] for c in rs.resume_candidate_pairs(tmp_path)] == [3000]
+
+
+# --- resume_action (PR-6 resume / fresh / HALT policy) -----------------------------------------
+# The highest-consequence decision (does a corrupt pointer halt or silently restart from 0?) pinned
+# in CI, not only on a live shodan run. The PR-6 change: every present-but-rejected reason HALTs.
+
+
+def test_resume_action_valid_resumes():
+    assert rs.resume_action(rs.POINTER_VALID) == rs.RESUME_ACTION_RESUME
+
+
+def test_resume_action_absent_is_fresh():
+    # ABSENT is the ONLY reason that starts fresh — a brand-new --state-dir with no prior run.
+    assert rs.resume_action(rs.POINTER_ABSENT) == rs.RESUME_ACTION_FRESH
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        rs.POINTER_CORRUPT_JSON,
+        rs.POINTER_VERSION_SKEW,
+        rs.POINTER_ENCODING_SKEW,
+        rs.POINTER_DANGLING_REF,
+    ],
+)
+def test_resume_action_present_but_rejected_halts(reason):
+    # The safety guard: a present-but-rejected pointer HALTs (driver → EXIT_POINTER_REJECTED)
+    # instead of the pre-PR-6 silent restart-from-0 that re-burned the full --timesteps budget.
+    assert rs.resume_action(reason) == rs.RESUME_ACTION_HALT

--- a/ml/tests/test_train_args.py
+++ b/ml/tests/test_train_args.py
@@ -21,7 +21,10 @@ pytest.importorskip("sb3_contrib")
 import dicewars_ppo.train as tr  # noqa: E402
 from dicewars_ppo.resume_state import (  # noqa: E402
     POINTER_CORRUPT_JSON,
+    POINTER_DANGLING_REF,
+    POINTER_ENCODING_SKEW,
     POINTER_VALID,
+    POINTER_VERSION_SKEW,
 )
 
 
@@ -477,33 +480,67 @@ def test_validate_rejects_nonpositive_checkpoint_every(tmp_path, bad):
         tr._validate(a)
 
 
-def test_corrupt_latest_warns_and_runs_fresh(tmp_path, monkeypatch, capsys):
-    """A PRESENT-but-invalid latest.json warns loudly and starts fresh — never a silent restart."""
+@pytest.mark.parametrize(
+    "reason",
+    [POINTER_CORRUPT_JSON, POINTER_VERSION_SKEW, POINTER_ENCODING_SKEW, POINTER_DANGLING_REF],
+)
+def test_rejected_pointer_halts_with_exit_pointer_rejected(tmp_path, monkeypatch, capsys, reason):
+    """A PRESENT-but-rejected latest.json HALTS with EXIT_POINTER_REJECTED (PR-6) — NOT the pre-PR-6
+    silent restart from step 0 that would re-burn the whole --timesteps budget under the unattended
+    schtasks loop. The HALT fires BEFORE SubprocVecEnv is built, so no env workers are started."""
     calls = []
     _stub_train_io(monkeypatch, calls)
 
-    class FakeModel:
-        def __init__(self):
-            self.policy = object()
-            self.num_timesteps = 0
+    def _no_build(*a, **k):
+        raise AssertionError("build_model must not run on a rejected pointer (train HALTs first)")
 
-        def learn(self, **kwargs):
-            calls.append(("learn",))
-
-    monkeypatch.setattr(tr, "build_model", lambda cfg, ckpt, args, venv=None: (FakeModel(), venv))
-    # A present-but-rejected pointer (here: corrupt JSON) ⇒ classify returns a non-ABSENT reason.
-    monkeypatch.setattr(tr, "classify_latest_pointer", lambda d: POINTER_CORRUPT_JSON)
+    monkeypatch.setattr(tr, "build_model", _no_build)
+    monkeypatch.setattr(tr, "classify_latest_pointer", lambda d: reason)
 
     a = _args(
         tmp_path, extra=["--state-dir", str(tmp_path / "state"), "--out", str(tmp_path / "o.pt")]
     )
     tr._validate(a)
-    tr.train(a)
+    with pytest.raises(SystemExit) as ei:
+        tr.train(a)
 
+    assert ei.value.code == tr.EXIT_POINTER_REJECTED  # exit 3 — the launcher's do-not-retry signal
     err = capsys.readouterr().err
-    assert "FRESH run" in err  # warned + ran fresh, never a silent restart
-    assert "BEFORE deleting latest.json" in err  # non-destructive: recoverable ckpts, don't delete
-    assert ("learn",) in calls  # ran fresh (did not abort)
+    assert "FATAL" in err
+    assert "Refusing to silently restart" in err  # never a silent restart-from-0
+    assert ("learn",) not in calls  # halted before any learn()
+    assert ("close",) not in calls  # HALT precedes SubprocVecEnv ⇒ no workers to reap
+
+
+def test_unrecoverable_resume_load_halts_and_reaps_workers(tmp_path, monkeypatch, capsys):
+    """When load_resume_checkpoint exhausts every retained pair (ResumeCheckpointError), train()
+    HALTS with EXIT_POINTER_REJECTED — but here the env workers were ALREADY started, so the single
+    teardown finally must reap them (venv.close) before the SystemExit propagates (no Node leak)."""
+    calls = []
+    _stub_train_io(monkeypatch, calls)
+
+    def _no_build(*a, **k):
+        raise AssertionError("build_model must not run on the resuming path")
+
+    monkeypatch.setattr(tr, "build_model", _no_build)
+    monkeypatch.setattr(tr, "classify_latest_pointer", lambda d: POINTER_VALID)  # ⇒ resuming=True
+
+    def _boom(state_dir, venv, device):
+        raise tr.ResumeCheckpointError("all retained pairs unreadable")
+
+    monkeypatch.setattr(tr, "load_resume_checkpoint", _boom)
+
+    a = _args(
+        tmp_path, extra=["--state-dir", str(tmp_path / "state"), "--out", str(tmp_path / "o.pt")]
+    )
+    tr._validate(a)
+    with pytest.raises(SystemExit) as ei:
+        tr.train(a)
+
+    assert ei.value.code == tr.EXIT_POINTER_REJECTED
+    assert "FATAL" in capsys.readouterr().err
+    assert ("close",) in calls  # workers reaped despite the HALT (the widened teardown guard)
+    assert ("learn",) not in calls
 
 
 def test_both_callbacks_wrapped_in_callbacklist(tmp_path, monkeypatch):

--- a/ml/tests/test_train_common_args.py
+++ b/ml/tests/test_train_common_args.py
@@ -11,6 +11,7 @@ drivers that consume this module lives in ``test_train_tracer_args.py`` (the tra
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -407,3 +408,16 @@ def test_remaining_timesteps_caps_absolute_budget():
     assert tc._remaining_timesteps(1000, 400) == 600  # mid-run resume
     assert tc._remaining_timesteps(1000, 1000) == 0  # budget exactly met ⇒ no-op
     assert tc._remaining_timesteps(1000, 1500) == 0  # overshoot clamps to 0, never negative
+
+
+def test_exit_pointer_rejected_matches_launcher():
+    """EXIT_POINTER_REJECTED is a cross-language HALT contract ([D-26]/PR-6): train.py raises it and
+    the shodan launcher (scripts/shodan/ppo-train.sh) hard-codes the SAME value as its do-not-retry
+    signal. Pin the Python value AND assert the bash copy agrees, so a change to one side forces
+    updating the other — a silent drift would make the launcher mis-handle (retry) an unrecoverable
+    HALT."""
+    assert tc.EXIT_POINTER_REJECTED == 3  # the canonical value
+    launcher = ML_DIR.parent / "scripts" / "shodan" / "ppo-train.sh"
+    m = re.search(r"^EXIT_POINTER_REJECTED=(\d+)", launcher.read_text(), re.MULTILINE)
+    assert m is not None, "ppo-train.sh must define EXIT_POINTER_REJECTED=<n>"
+    assert int(m.group(1)) == tc.EXIT_POINTER_REJECTED

--- a/scripts/shodan/RUNBOOK.md
+++ b/scripts/shodan/RUNBOOK.md
@@ -1,0 +1,229 @@
+# shodan PPO long-run runbook (ml-bot Phase-3 task C/E, PR-6)
+
+The operator guide for the **long BEAT run** — the disconnect-surviving, auto-restarting PPO training
+job that PR-6 wraps around the PR-4 driver (`train.py`) and the PR-5 idempotent checkpoint/resume
+core. It runs on **shodan** (Windows + WSL2 Ubuntu, RTX 4070 Ti). Read this end-to-end once before
+launching: the long run burns days of GPU, so the pre-flight gates below exist to make sure that time
+is not wasted.
+
+Files in this directory:
+
+| File                 | What it is                                                                             |
+| -------------------- | -------------------------------------------------------------------------------------- |
+| `ppo-train.sh`       | the bash launcher: production HPs + both resume halves + the bounded auto-restart loop |
+| `ppo-train.cmd`      | Windows → WSL bridge (`wsl.exe -- bash … ppo-train.sh`) that Task Scheduler invokes    |
+| `ppo-train-task.xml` | importable Task Scheduler definition (survives SSH teardown + reboot)                  |
+| `RUNBOOK.md`         | this file                                                                              |
+
+---
+
+## 0. The contract you are operating under
+
+- **Resume is statistically-consistent, bounded-skew — NOT bit-exact** ([D-26] Q3). The Python half
+  (policy + optimizer + `num_timesteps` + RNG sidecar) and the Node league half
+  (`league-state-<seedBase>.json`) resume **independently** (no two-phase commit), and the Node env
+  workers cannot replay trajectories. A resumed run continuing on a slightly different random stream
+  is **expected**, not a bug.
+- **The budget is absolute** ([D-26] HOLE-D). The launcher always relaunches with the **same**
+  `--timesteps`; `_remaining_timesteps` + `learn(reset_num_timesteps=False)` cap the campaign at that
+  absolute total no matter how many times it restarts. Do **not** "top up" `TIMESTEPS` on a restart
+  expecting more training — raise it deliberately and understand it changes the absolute target.
+- **Two states are never silently retried** (PR-6 safety guard). `train.py` exits
+  **`EXIT_POINTER_REJECTED` (3)** on an unrecoverable resume state, and the launcher treats that as
+  **halt + alert**, never relaunch. See §6.
+- **Pin the commit + encoding for the whole campaign.** The launcher records `git rev-parse HEAD` in
+  `RUN_COMMIT` on first launch and **halts** if HEAD later drifts; it also refuses to launch unless
+  `ENCODING_VERSION == 2`. A mid-run `git pull` that bumps the encoding makes pooled snapshots
+  unloadable (`POINTER_ENCODING_SKEW`). Finish the campaign on one commit.
+
+---
+
+## 1. Prerequisites (one-time, on shodan)
+
+```bash
+# in WSL, at the repo root
+cd ~/dicewarsjs            # or wherever you cloned it
+cd ml && python -m venv .venv && source .venv/bin/activate
+pip install -e .[rl]       # gymnasium + stable-baselines3 + sb3-contrib + pettingzoo + tensorboard
+python -c "import torch; print(torch.__version__, torch.cuda.is_available())"   # expect True
+```
+
+- `pip install -e .[rl]` **re-resolves torch from PyPI** and may replace your CUDA build — see
+  `ml/README.md` for the `constraints.txt` pin if `torch.cuda.is_available()` flips to `False`.
+- `node` must be on PATH inside WSL (the trainer spawns one Node `ppo-env-server.mjs` per env via
+  `EnvServerProcess`, `cwd = repo root`, `shutil.which("node")`).
+- The BC warm-start checkpoint (`ml/checkpoints/v2-base/bc_model.pt`, the deployed `ai_bc`) must be
+  present. It is a trained artifact, not committed — copy it to shodan if missing.
+
+---
+
+## 2. Gate BEFORE the long run — the PR-5 shodan validation checklist (BLOCKING)
+
+The sb3-coupled resume **execution** path is shodan-only (the lean CI tier has no sb3). It must pass
+on this box **before** you trust the auto-restart with a multi-day job. Run the rl tiers + the
+[D-26] checklist:
+
+```bash
+cd ml && source .venv/bin/activate
+python -m pytest tests/test_resume.py tests/test_train_args.py tests/test_train_common_args.py \
+                 tests/test_snapshot_callback.py tests/test_train_tracer_args.py -q
+```
+
+Confirm (these are the [D-26] holes the long run depends on; the tests above pin each):
+
+- [ ] `MaskablePPO.load` round-trips with **no `custom_objects`** and restores `num_timesteps`
+      (PATH A / HOLE-C) — `test_load_resume_restores_num_timesteps_and_policy`.
+- [ ] `--device cuda` resume restores the RNG sidecar **to CPU without crashing**
+      (`test_load_resume_on_cuda_restores_rng_without_crash`, runs only with a GPU).
+- [ ] `_setup_learn` caps at the **absolute** `--timesteps` under `reset_num_timesteps=False`
+      (HOLE-D) — `test_resume_setup_learn_caps_at_absolute_budget`.
+- [ ] **Corrupt-`.zip` fallback** rolls back to the retained prior pair, and **all-corrupt** raises
+      `ResumeCheckpointError` (→ the halt path) — the two new PR-6 tests in `test_resume.py`.
+- [ ] A **live forkserver two-half resume**: start a short run with `--state-dir` + `--league-state-dir`,
+      kill it mid-flight, relaunch the SAME command, and confirm it resumes (see §4 smoke).
+
+> If any of these fail on shodan, **stop** and fix before launching — this path has never run off the
+> GPU box. (Locally, only the torch-free `test_resume_state.py` tier runs; it covers the candidate
+> ordering + the resume/fresh/halt policy, not the live `MaskablePPO.load`.)
+
+Also confirm the **turtle floor** before committing: the field must stay decisive. A quick
+multi-seed check that global `decisiveRate >= 0.60` (no degenerate stall equilibrium) — see
+`npm run ppo:league-probe` / `arena:sweep` decisiveRate output.
+
+---
+
+## 3. The from-scratch control run (sequenced BEFORE the long run) — [D-19] / [D-26] Q6
+
+The task-A +33.4 BEAT was partly **fixed-field exploitation** (4 of 7 gate opponents, including all 3
+strong, were training opponents — [D-23]). The control run proves a gate win is **real PPO learning**,
+not that artifact: train from a fresh init (no BC warm start) for a short budget and confirm it learns
+_something_ above chance.
+
+```bash
+FROM_SCRATCH=1 RUN_NAME=ppo-control TIMESTEPS=1000000 DEVICE=cuda \
+    bash scripts/shodan/ppo-train.sh
+```
+
+`--from-scratch` is mutually exclusive with `--freeze-trunk` and relaxes `--lr`/`--ent-coef` only when
+those are omitted; the launcher passes explicit production HPs, so set `LR`/`ENT_COEF` for the control
+explicitly if you want the from-scratch exploration defaults instead. Gate it (see §5) and sanity-check
+the curve in TensorBoard before spending days on the long run.
+
+---
+
+## 4. Launch the long run
+
+### 4a. Interactive (good for the first launch + the live-resume smoke)
+
+```bash
+cd ~/dicewarsjs
+source ml/.venv/bin/activate
+bash scripts/shodan/ppo-train.sh            # RUN_NAME=ppo-long, TIMESTEPS=20000000 by default
+```
+
+**Live two-half resume smoke** (do this once): let it write at least one checkpoint
+(`ml/runs/ppo-long/state/latest.json` appears and its `step` advances), `Ctrl-C`, then re-run the exact
+same command. It should log `resumed from … at num_timesteps=<N>` and continue — not restart at 0.
+
+Common overrides (env vars; defaults in `ppo-train.sh` header):
+
+| Var                                   | Default            | Meaning                                         |
+| ------------------------------------- | ------------------ | ----------------------------------------------- |
+| `TIMESTEPS`                           | `20000000`         | absolute env-step budget for the whole campaign |
+| `N_ENVS`                              | `min(nproc-2, 12)` | parallel `SubprocVecEnv(forkserver)` workers    |
+| `LR` / `ENT_COEF`                     | `2.5e-4` / `0.01`  | task-A BEAT production HPs                      |
+| `CHECKPOINT_EVERY` / `SNAPSHOT_EVERY` | `100000`           | resume cadence / PFSP snapshot cadence (steps)  |
+| `RESERVE_BASELINES`                   | `3`                | R, **locked** at 3 ([D-24]/B5)                  |
+| `DEVICE`                              | `cuda`             | use `cpu` only for a smoke                      |
+| `MAX_CONSECUTIVE_FAILS`               | `5`                | no-progress crash-loop bound                    |
+
+### 4b. Unattended via Task Scheduler (survives SSH teardown + reboot)
+
+1. Edit `ppo-train-task.xml`: set `<UserId>` (twice) to your account and the `<Command>` /
+   `<WorkingDirectory>` to the Windows path of this `scripts\shodan` dir. Edit `ppo-train.cmd`'s
+   `REPO_WSL_PATH` / `VENV_ACTIVATE` (or set them as env vars).
+2. Import + start:
+   ```bat
+   schtasks /create /tn "dicewars-ppo-train" /xml scripts\shodan\ppo-train-task.xml
+   schtasks /run    /tn "dicewars-ppo-train"
+   ```
+3. **GPU caveat:** WSL2 CUDA generally needs the user session. The template uses an
+   `InteractiveToken` principal + a logon trigger — pair with auto-login to survive reboot. If you
+   switch to "run whether logged on or not", verify `torch.cuda.is_available()` is `True` under that
+   context first (the launcher preflight halts loudly otherwise).
+
+---
+
+## 5. Gate the result — the [D-24] / [D-7] kill gate
+
+After a budget unit (or at the end), export the repacked actor and gate it on **win%** (never ELO)
+vs `ai_lookahead@596f781`:
+
+```bash
+# export the long-run actor (the npm ppo:export script points at the TRACER ckpt; override --ckpt)
+cd ml && source .venv/bin/activate
+python -m dicewars_bc.export_weights \
+    --ckpt runs/ppo-long/ppo.pt \
+    --out ../src/ai/ppoPolicyWeights.js \
+    --fixture ../tests/fixtures/bc/ppoForwardCases.json
+cd .. && npm run ppo:gate            # 20 runs x 150 games, PPO vs Lookahead@596f781, paired Δ + 95% CI
+```
+
+- **PASS = `BEAT`**: a statistically significant win% edge — the paired per-run win% **Δ 95% CI lower
+  bound is > 0**. `TIE`/`BEHIND` do not pass.
+- **Kill gate ([D-24]):** if, after a budget unit, the 95% CI lower bound is **not** > 0 → declare
+  **plateau** and fall back to the best of Track A / Phase 2 (`ai_bc`). A small true edge needs more
+  `--runs` to clear the CI: `npm run ppo:gate -- --runs 40 --games 200`.
+- Sanity baseline: `npm run ppo:gate -- --weights src/ai/bcPolicyWeights.js --fixture tests/fixtures/bc/forwardCases.json --name BCanchor`
+  validates the harness against the known BC anchor (≈ TIE/BEHIND).
+
+Record the result (PPO win% / Lookahead win% / Δ / CI / the run commit + Lookahead pin) in
+`docs/ml-bot/RESULTS.md`.
+
+---
+
+## 6. Monitoring & recovery
+
+**Monitor:**
+
+- `ml/runs/<name>/launcher.log` — every attempt, exit code, restart, and ALERT (also on stdout).
+- `ml/runs/<name>/tb/` — TensorBoard event files (one continuous run, merged by `num_timesteps`) +
+  per-session `progress-<resumed_step>.csv` (a resume never truncates an earlier session's CSV).
+- `ml/runs/<name>/state/latest.json` — the crash hinge; its `step` is the resume point.
+- `nvidia-smi` in WSL — the learner should keep the GPU busy (it is the binding rate, [D-24]).
+
+**When the launcher HALTS (`EXIT_POINTER_REJECTED` / exit 3 — "UNRECOVERABLE resume state"):**
+
+`train.py` prints a cause-specific, **non-destructive** message via `describe_pointer_rejection`.
+The recovery action depends on the cause:
+
+- `corrupt-json` / `dangling-ref`: the **pointer** broke but the `ckpt-*.zip`/`.rng.pt` pairs on disk
+  are likely still loadable. **Inspect them BEFORE deleting `latest.json`** (it is the breadcrumb to
+  them). The corrupt-`.zip` fallback means a torn _newest_ zip auto-rolls back to the retained prior
+  pair; a halt here means the pointer itself (or every retained pair) is unusable.
+- `version-skew` / `encoding-skew`: the on-disk checkpoints are from an **incompatible build** — a
+  fresh start is correct. This should not happen mid-campaign because the commit + encoding are
+  pinned; if it does, something changed under the run (check `RUN_COMMIT`).
+
+To **deliberately** restart a campaign, point `--state-dir`/`RUN_NAME` at a **fresh** directory rather
+than leaving a rejected pointer in place — the launcher's halt is exactly there to stop a silent
+restart-from-0 from re-burning days of GPU.
+
+**When the launcher HALTS on a crash-loop** (`N` consecutive failures with no checkpoint progress):
+the run is dying before it can checkpoint. Read the last attempt's traceback (launcher.log / stdout) —
+common causes: a wedged Node env-server (`ppo-env-server.mjs`), an OOM, or a GPU/driver fault. Fix the
+cause, then re-run; a failure _after_ the step advances resets the counter, so this only trips on a
+genuine no-progress loop.
+
+**Stop the unattended run:** `schtasks /end /tn "dicewars-ppo-train"` (and disable the task if you do
+not want it to relaunch at next logon/boot).
+
+---
+
+## 7. After the run
+
+1. Gate (§5); if `BEAT`, the exported `src/ai/ppoPolicyWeights.js` is the candidate to merge (it is a
+   distinct file from `bcPolicyWeights.js`).
+2. Update `docs/ml-bot/RESULTS.md` (win% table + the Lookahead pin) and `LOG.md`.
+3. Deferred test-hardening (env-server `main()` persistence integration test, live cross-worker
+   `SharedDiskStore`, live forkserver two-half resume smoke) is **PR-7**, not part of this run.

--- a/scripts/shodan/RUNBOOK.md
+++ b/scripts/shodan/RUNBOOK.md
@@ -209,11 +209,14 @@ To **deliberately** restart a campaign, point `--state-dir`/`RUN_NAME` at a **fr
 than leaving a rejected pointer in place — the launcher's halt is exactly there to stop a silent
 restart-from-0 from re-burning days of GPU.
 
-**When the launcher HALTS on a crash-loop** (`N` consecutive failures with no checkpoint progress):
-the run is dying before it can checkpoint. Read the last attempt's traceback (launcher.log / stdout) —
-common causes: a wedged Node env-server (`ppo-env-server.mjs`), an OOM, or a GPU/driver fault. Fix the
-cause, then re-run; a failure _after_ the step advances resets the counter, so this only trips on a
-genuine no-progress loop.
+**When the launcher HALTS on a crash-loop** (`N` consecutive failures with no checkpoint progress,
+launcher exit `EXIT_CRASH_LOOP` / `4`): the run is dying before it can checkpoint. Read the last
+attempt's traceback (launcher.log / stdout) — common causes: a wedged Node env-server
+(`ppo-env-server.mjs`), an OOM, or a GPU/driver fault. Fix the cause, then re-run; a failure _after_
+the step advances resets the counter, so this only trips on a genuine no-progress loop. Under Task
+Scheduler this is **not** auto-relaunched: `ppo-train.cmd` maps both intentional halt codes (`3` and
+`4`) to `0`, so `<RestartOnFailure>` does not re-amplify the crash-loop — the task stops and waits for
+you (re-run it with `schtasks /run` after fixing the cause).
 
 **Stop the unattended run:** `schtasks /end /tn "dicewars-ppo-train"` (and disable the task if you do
 not want it to relaunch at next logon/boot).

--- a/scripts/shodan/ppo-train-task.xml
+++ b/scripts/shodan/ppo-train-task.xml
@@ -18,7 +18,11 @@
   (pair with auto-login to survive reboot). If you instead need "run whether logged on or not", switch
   LogonType to Password and confirm `torch.cuda.is_available()` is True under that context FIRST — the
   launcher's preflight will HALT loudly if the GPU/venv is not visible. The internal bash loop already
-  auto-restarts on transient crashes; <RestartOnFailure> here is only a backstop if the .cmd dies.
+  auto-restarts on transient crashes, and ppo-train.cmd maps the two CODED halts
+  (EXIT_POINTER_REJECTED=3, EXIT_CRASH_LOOP=4) to 0 so <RestartOnFailure> below never re-amplifies
+  those. Other non-zero exits still hit the backstop and are retried up to Count times: a genuine
+  .cmd/wsl death, AND the launcher's preflight `exit 1` halts (encoding/commit/checkpoint) — the
+  latter is intended, since some preflight failures (CUDA/drive not ready) are transient at boot.
 
   If `schtasks` rejects this file, re-save it as UTF-16 LE (the format Task Scheduler exports natively).
 -->

--- a/scripts/shodan/ppo-train-task.xml
+++ b/scripts/shodan/ppo-train-task.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Task Scheduler template for the disconnect-surviving PPO launcher (ml-bot Phase-3 PR-6, [D-26]).
+
+  Import on shodan (PowerShell/cmd, as the run user):
+      schtasks /create /tn "dicewars-ppo-train" /xml scripts\shodan\ppo-train-task.xml
+  Start / stop / inspect:
+      schtasks /run    /tn "dicewars-ppo-train"
+      schtasks /end    /tn "dicewars-ppo-train"
+      schtasks /query  /tn "dicewars-ppo-train" /v /fo LIST
+
+  EDIT BEFORE IMPORT (placeholders):
+    * <UserId>SHODAN\you</UserId>          -> your account (`whoami`); appears TWICE (trigger + principal)
+    * <Command> / <WorkingDirectory>       -> the Windows path to scripts\shodan on this box
+
+  GPU CAVEAT (read RUNBOOK.md "Scheduling"): WSL2 CUDA generally needs the user's session. This
+  template uses an InteractiveToken principal + a LogonTrigger, so it runs when the user is logged on
+  (pair with auto-login to survive reboot). If you instead need "run whether logged on or not", switch
+  LogonType to Password and confirm `torch.cuda.is_available()` is True under that context FIRST — the
+  launcher's preflight will HALT loudly if the GPU/venv is not visible. The internal bash loop already
+  auto-restarts on transient crashes; <RestartOnFailure> here is only a backstop if the .cmd dies.
+
+  If `schtasks` rejects this file, re-save it as UTF-16 LE (the format Task Scheduler exports natively).
+-->
+<Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Description>DiceWarsJS ml-bot PPO long BEAT run — disconnect-surviving launcher (PR-6).</Description>
+    <URI>\dicewars-ppo-train</URI>
+  </RegistrationInfo>
+  <Triggers>
+    <LogonTrigger>
+      <Enabled>true</Enabled>
+      <UserId>SHODAN\you</UserId>
+    </LogonTrigger>
+    <BootTrigger>
+      <Enabled>true</Enabled>
+      <Delay>PT1M</Delay>
+    </BootTrigger>
+  </Triggers>
+  <Principals>
+    <Principal id="Author">
+      <UserId>SHODAN\you</UserId>
+      <LogonType>InteractiveToken</LogonType>
+      <RunLevel>HighestAvailable</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <AllowHardTerminate>true</AllowHardTerminate>
+    <StartWhenAvailable>true</StartWhenAvailable>
+    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
+    <IdleSettings>
+      <StopOnIdleEnd>false</StopOnIdleEnd>
+      <RestartOnIdle>false</RestartOnIdle>
+    </IdleSettings>
+    <AllowStartOnDemand>true</AllowStartOnDemand>
+    <Enabled>true</Enabled>
+    <Hidden>false</Hidden>
+    <RunOnlyIfIdle>false</RunOnlyIfIdle>
+    <WakeToRun>false</WakeToRun>
+    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>
+    <Priority>7</Priority>
+    <RestartOnFailure>
+      <Interval>PT5M</Interval>
+      <Count>3</Count>
+    </RestartOnFailure>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>C:\Users\you\dicewarsjs\scripts\shodan\ppo-train.cmd</Command>
+      <WorkingDirectory>C:\Users\you\dicewarsjs\scripts\shodan</WorkingDirectory>
+    </Exec>
+  </Actions>
+</Task>

--- a/scripts/shodan/ppo-train.cmd
+++ b/scripts/shodan/ppo-train.cmd
@@ -1,0 +1,28 @@
+@echo off
+REM ==================================================================================================
+REM  Windows -> WSL bridge for the disconnect-surviving PPO launcher (ml-bot Phase-3 PR-6, [D-26]).
+REM
+REM  Task Scheduler runs THIS .cmd (see ppo-train-task.xml); it invokes wsl.exe to run the real bash
+REM  launcher (scripts/shodan/ppo-train.sh) inside the [rl] venv. Going through Task Scheduler +
+REM  wsl.exe is the only pattern that survives an SSH teardown AND a box reboot ([D-26] task-E):
+REM  a run started over a bare `ssh` session dies when the session ends.
+REM
+REM  CONFIGURE (edit these, or set them as machine/user environment variables):
+REM    WSL_DISTRO       the WSL distro name (`wsl -l -v` to list).            default: Ubuntu
+REM    REPO_WSL_PATH    repo root AS WSL SEES IT (e.g. /home/you/dicewarsjs   default: /home/%USERNAME%/dicewarsjs
+REM                     or /mnt/c/Users/you/dicewarsjs).
+REM    VENV_ACTIVATE    venv activate script, relative to the repo root.      default: ml/.venv/bin/activate
+REM
+REM  To override a training knob for this scheduled run (e.g. a bigger budget), prepend it to the
+REM  bash command below, e.g.  ... && TIMESTEPS=40000000 bash scripts/shodan/ppo-train.sh
+REM  Run the FROM-SCRATCH control run from a shell first (RUNBOOK.md) before scheduling the long run.
+REM ==================================================================================================
+setlocal
+if "%WSL_DISTRO%"==""    set "WSL_DISTRO=Ubuntu"
+if "%REPO_WSL_PATH%"=="" set "REPO_WSL_PATH=/home/%USERNAME%/dicewarsjs"
+if "%VENV_ACTIVATE%"=="" set "VENV_ACTIVATE=ml/.venv/bin/activate"
+
+REM -l = login shell so a conda/venv init in the user's profile is honored; then activate the [rl]
+REM venv explicitly (the launcher's preflight HALTS loudly if torch/sb3 are still missing).
+wsl.exe -d %WSL_DISTRO% -- bash -lc "cd '%REPO_WSL_PATH%' && source '%VENV_ACTIVATE%' 2>/dev/null; exec bash scripts/shodan/ppo-train.sh"
+exit /b %ERRORLEVEL%

--- a/scripts/shodan/ppo-train.cmd
+++ b/scripts/shodan/ppo-train.cmd
@@ -24,5 +24,31 @@ if "%VENV_ACTIVATE%"=="" set "VENV_ACTIVATE=ml/.venv/bin/activate"
 
 REM -l = login shell so a conda/venv init in the user's profile is honored; then activate the [rl]
 REM venv explicitly (the launcher's preflight HALTS loudly if torch/sb3 are still missing).
-wsl.exe -d %WSL_DISTRO% -- bash -lc "cd '%REPO_WSL_PATH%' && source '%VENV_ACTIVATE%' 2>/dev/null; exec bash scripts/shodan/ppo-train.sh"
-exit /b %ERRORLEVEL%
+REM `cd ... || exit 1` so a misconfigured REPO_WSL_PATH fails with a clear error instead of running
+REM ppo-train.sh from $HOME and dying with an opaque "No such file or directory"; `source` stays
+REM non-fatal (2>/dev/null) because the launcher preflight re-checks the venv.
+wsl.exe -d %WSL_DISTRO% -- bash -lc "cd '%REPO_WSL_PATH%' || exit 1; source '%VENV_ACTIVATE%' 2>/dev/null; exec bash scripts/shodan/ppo-train.sh"
+REM Capture wsl's exit code immediately (no intervening command clobbers ERRORLEVEL). The 3/4
+REM do-not-retry mapping below relies on wsl.exe propagating the launcher's exit code to ERRORLEVEL;
+REM modern WSL2 (shodan) does. On an ancient WSL that didn't, a coded halt would just be retried by
+REM the backstop (harmless: exit 3 re-halts within seconds; exit 4 re-amplifies, bounded by Count).
+set "RC=%ERRORLEVEL%"
+
+REM The two CODED halts (3, 4) must not be re-amplified by the task's <RestartOnFailure> backstop (it
+REM fires on ANY non-zero exit and can't tell a deliberate halt from a dead .cmd): a relaunch only
+REM re-halts+re-alerts (3) or re-runs a no-progress crash-loop (4) for ~Count x MAX_CONSECUTIVE_FAILS
+REM attempts. So map 3 and 4 to 0. Everything else propagates to the backstop and IS retried up to
+REM <RestartOnFailure Count> times -- intended for transient boot-time failures (CUDA/drive not ready
+REM yet), but note this INCLUDES the launcher's own preflight `exit 1` halts (encoding/commit/
+REM checkpoint), which therefore re-alert at most Count times rather than once.
+REM   3 = EXIT_POINTER_REJECTED  (unrecoverable resume state -- bytes won't heal)
+REM   4 = EXIT_CRASH_LOOP        (bounded no-progress crash-loop -- needs an operator, not a relaunch)
+if "%RC%"=="3" (
+  echo ppo-train.cmd: launcher halted EXIT_POINTER_REJECTED ^(3^) -- intentional, not retrying. See RUNBOOK "Recovery".
+  exit /b 0
+)
+if "%RC%"=="4" (
+  echo ppo-train.cmd: launcher halted on a crash-loop ^(4^) -- intentional, not retrying. See RUNBOOK "crash-loop".
+  exit /b 0
+)
+exit /b %RC%

--- a/scripts/shodan/ppo-train.sh
+++ b/scripts/shodan/ppo-train.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+#
+# Disconnect-surviving PPO launcher for the long BEAT run (ml-bot Phase-3 task C/E, PR-6, [D-26]).
+#
+# WHAT THIS IS. A thin, idempotent wrapper around `python -m dicewars_ppo.train` that owns the
+# PRODUCTION hyperparameters (the task-A BEAT config, deliberately NOT a train.py default — see
+# _train_common.resolve_from_scratch / LOG) and turns the PR-5 idempotent checkpoint/resume core
+# into an AUTO-RESTARTING multi-day job: on a transient crash it relaunches the SAME command with the
+# SAME --timesteps, so HOLE-D's _remaining_timesteps caps the run at the ABSOLUTE budget rather than
+# re-burning it per relaunch. It is meant to be driven on shodan (Windows + WSL2 Ubuntu, RTX 4070 Ti)
+# under Task Scheduler so it survives SSH teardown AND a box reboot — the only disconnect-surviving
+# pattern ([D-26] task-E). See scripts/shodan/ppo-train.cmd + ppo-train-task.xml for the schtasks
+# wrapper, and scripts/shodan/RUNBOOK.md for launch / monitor / recovery / the kill gate.
+#
+# WHY A BOUNDED-RESTART LOOP (not a bare `while true`). The binding throughput constraint is the SB3
+# learner loop, not env-sim ([D-24]/B5), so the job is long-lived and WILL hit transient deaths
+# (a wedged Node env-server, an OOM blip, a driver hiccup). We relaunch those. But two failure modes
+# must NEVER be retried blindly, and train.py signals the first with a distinct exit code:
+#   * EXIT_POINTER_REJECTED (3): a present-but-rejected latest.json (corrupt/version/encoding skew,
+#     dangling ref) OR a corrupt .zip whose retained fallbacks are also unreadable. Retrying re-reads
+#     the same bad bytes forever, and a silent fresh start would re-burn days of GPU. => HALT + ALERT.
+#   * A crash-loop with NO forward progress (the run dies before the first checkpoint, every time).
+#     We bound CONSECUTIVE no-progress failures; a failure AFTER the checkpoint step advanced resets
+#     the counter, so a run that crashes once after days of progress is not killed by a stale count.
+#
+# USAGE (all knobs are env vars with production defaults; see RUNBOOK.md for the control-run recipe):
+#   bash scripts/shodan/ppo-train.sh                       # the long BEAT run (warm-started)
+#   FROM_SCRATCH=1 RUN_NAME=ppo-control TIMESTEPS=1000000 \
+#       bash scripts/shodan/ppo-train.sh                   # the [D-19] from-scratch control run
+#
+set -euo pipefail
+
+# --- locate the repo (this file is scripts/shodan/ppo-train.sh => repo root is two levels up) ------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ML_DIR="$REPO_ROOT/ml"
+ENCODE_JS="$REPO_ROOT/src/arena/encodeObservation.js"
+
+# --- run identity + paths -------------------------------------------------------------------------
+RUN_NAME="${RUN_NAME:-ppo-long}"
+RUN_ROOT="${RUN_ROOT:-$ML_DIR/runs/$RUN_NAME}"
+STATE_DIR="${STATE_DIR:-$RUN_ROOT/state}"          # Python resume half (zip + RNG sidecar + latest.json)
+SNAPSHOT_DIR="${SNAPSHOT_DIR:-$RUN_ROOT/league}"    # PFSP snapshot pool (weights + manifest.json)
+LEAGUE_STATE_DIR="${LEAGUE_STATE_DIR:-$RUN_ROOT/league-state}"  # Node resume half + disk win-rate store
+LOG_DIR="${LOG_DIR:-$RUN_ROOT/tb}"                  # TensorBoard event files + per-session progress CSV
+OUT="${OUT:-$RUN_ROOT/ppo.pt}"                      # repacked BC-format actor (what ppo:export consumes)
+LAUNCH_LOG="$RUN_ROOT/launcher.log"
+
+# --- model + budget + production HPs --------------------------------------------------------------
+CHECKPOINT="${CHECKPOINT:-checkpoints/v2-base/bc_model.pt}"  # BC warm start (resolved from $ML_DIR)
+TIMESTEPS="${TIMESTEPS:-20000000}"                  # ABSOLUTE env-step budget for the WHOLE campaign
+DEVICE="${DEVICE:-cuda}"                             # shodan GPU; "cpu" only for a smoke
+LR="${LR:-2.5e-4}"                                  # task-A BEAT config (production HP — NOT a default)
+ENT_COEF="${ENT_COEF:-0.01}"                        # task-A BEAT config (production HP)
+GAMMA="${GAMMA:-0.999}"
+
+# --- parallelism ([D-26] Q4: SubprocVecEnv(forkserver), CUDA inits AFTER the fork) ----------------
+# Size to cores but leave headroom for the learner + the per-worker Node env-servers. n_steps*n_envs
+# stays divisible by the default batch_size (512 is a multiple of 128) for any n_envs, so the
+# train.py divisibility guard never trips on this default.
+if [ -z "${N_ENVS:-}" ]; then
+  CORES="$(nproc 2>/dev/null || echo 8)"
+  if [ "$CORES" -gt 14 ]; then N_ENVS=12; elif [ "$CORES" -gt 3 ]; then N_ENVS=$((CORES - 2)); else N_ENVS=1; fi
+fi
+
+# --- PFSP league (B3/B4) + persistence (B6) -------------------------------------------------------
+RESERVE_BASELINES="${RESERVE_BASELINES:-3}"         # R=3 LOCKED ([D-24]/B5): turtle-equilibrium floor
+SNAPSHOT_EVERY="${SNAPSHOT_EVERY:-100000}"
+CHECKPOINT_EVERY="${CHECKPOINT_EVERY:-100000}"      # resume cadence (independent of --snapshot-every)
+LEAGUE_DUMP_EVERY="${LEAGUE_DUMP_EVERY:-50}"        # Node league dump cadence in BOOKED episodes
+
+# --- auto-restart policy --------------------------------------------------------------------------
+EXIT_POINTER_REJECTED=3                              # MUST match dicewars_ppo._train_common.EXIT_POINTER_REJECTED
+                                                     # (a CI canary in test_train_common_args.py pins the pair)
+MAX_CONSECUTIVE_FAILS="${MAX_CONSECUTIVE_FAILS:-5}"  # bound a no-progress crash-loop
+BACKOFF_BASE_S="${BACKOFF_BASE_S:-15}"               # backoff = min(BACKOFF_BASE_S * fails, BACKOFF_MAX_S)
+BACKOFF_MAX_S="${BACKOFF_MAX_S:-120}"
+EXPECTED_ENCODING_VERSION="${EXPECTED_ENCODING_VERSION:-2}"
+
+mkdir -p "$RUN_ROOT"
+
+log() { printf '%s [ppo-train] %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$*" | tee -a "$LAUNCH_LOG"; }
+alert() { log "ALERT: $*"; }  # a hook point: redirect/extend to email/push if desired (RUNBOOK.md)
+
+# Read the integer "step" out of latest.json without a jq dependency (WSL Ubuntu may not ship it).
+latest_step() {
+  local f="$STATE_DIR/latest.json"
+  [ -f "$f" ] || { echo 0; return; }
+  grep -oE '"step"[[:space:]]*:[[:space:]]*[0-9]+' "$f" 2>/dev/null | grep -oE '[0-9]+' | tail -n1 || echo 0
+}
+
+# --- preflight: fail FAST and LOUD before committing a multi-day job ------------------------------
+preflight() {
+  command -v node >/dev/null 2>&1 || { alert "node not on PATH (the env-servers need it)"; exit 1; }
+  [ -f "$ENCODE_JS" ] || { alert "missing $ENCODE_JS"; exit 1; }
+  local enc
+  enc="$(grep -oE 'ENCODING_VERSION[[:space:]]*=[[:space:]]*[0-9]+' "$ENCODE_JS" | grep -oE '[0-9]+' | tail -n1 || echo '?')"
+  if [ "$enc" != "$EXPECTED_ENCODING_VERSION" ]; then
+    alert "ENCODING_VERSION=$enc but expected $EXPECTED_ENCODING_VERSION — a mid-campaign bump makes"
+    alert "pooled snapshots unloadable (POINTER_ENCODING_SKEW). Refusing to launch."
+    exit 1
+  fi
+  [ -f "$ML_DIR/$CHECKPOINT" ] || { alert "BC checkpoint not found: $ML_DIR/$CHECKPOINT"; exit 1; }
+  python -c "import torch, sb3_contrib, gymnasium" 2>/dev/null \
+    || { alert "the [rl] venv is not active (need torch + sb3_contrib + gymnasium)"; exit 1; }
+}
+
+# Pin the commit for the WHOLE run: a `git pull` mid-campaign could change the encoding/env under a
+# resuming learner. Record it on first launch; HALT if HEAD drifts on a later (re)start.
+check_commit_pinned() {
+  local head pin_file="$RUN_ROOT/RUN_COMMIT"
+  head="$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo 'no-git')"
+  if [ ! -f "$pin_file" ]; then
+    echo "$head" >"$pin_file"
+    log "pinned run to commit $head"
+  elif [ "$(cat "$pin_file")" != "$head" ]; then
+    alert "HEAD ($head) != the pinned run commit ($(cat "$pin_file")) — the code/env changed under a"
+    alert "resuming run. Refusing to continue. Check out the pinned commit, or start a fresh RUN_NAME."
+    exit 1
+  fi
+}
+
+run_once() {
+  local extra=()
+  [ "${FROM_SCRATCH:-0}" = "1" ] && extra+=(--from-scratch)
+  ( cd "$ML_DIR" && python -m dicewars_ppo.train \
+      --checkpoint "$CHECKPOINT" \
+      --out "$OUT" \
+      --timesteps "$TIMESTEPS" \
+      --n-envs "$N_ENVS" \
+      --start-method forkserver \
+      --lr "$LR" --ent-coef "$ENT_COEF" --gamma "$GAMMA" \
+      --device "$DEVICE" \
+      --snapshot-dir "$SNAPSHOT_DIR" --snapshot-every "$SNAPSHOT_EVERY" \
+      --snapshot-store disk \
+      --reserve-baselines "$RESERVE_BASELINES" \
+      --league-state-dir "$LEAGUE_STATE_DIR" --league-dump-every "$LEAGUE_DUMP_EVERY" \
+      --state-dir "$STATE_DIR" --checkpoint-every "$CHECKPOINT_EVERY" \
+      --log-dir "$LOG_DIR" \
+      "${extra[@]}" )
+}
+
+main() {
+  preflight
+  log "run=$RUN_NAME root=$RUN_ROOT timesteps=$TIMESTEPS n_envs=$N_ENVS device=$DEVICE lr=$LR \
+ent_coef=$ENT_COEF R=$RESERVE_BASELINES from_scratch=${FROM_SCRATCH:-0}"
+
+  local fails=0 prev_step=-1 attempt=0
+  while true; do
+    check_commit_pinned
+    local step
+    step="$(latest_step)"
+    if [ "$step" -gt "$prev_step" ]; then
+      [ "$fails" -gt 0 ] && log "progress since last attempt (step $prev_step -> $step); resetting fail counter"
+      fails=0
+    fi
+    prev_step="$step"
+
+    attempt=$((attempt + 1))
+    log "attempt #$attempt (resume step=$step, consecutive_fails=$fails)"
+
+    local rc=0
+    run_once && rc=0 || rc=$?
+
+    if [ "$rc" -eq 0 ]; then
+      log "training completed cleanly (exit 0). Repacked actor → $OUT"
+      log "NEXT: export + gate — see scripts/shodan/RUNBOOK.md ('Gate the result')."
+      exit 0
+    fi
+
+    if [ "$rc" -eq "$EXIT_POINTER_REJECTED" ]; then
+      alert "train.py exited $EXIT_POINTER_REJECTED (UNRECOVERABLE resume state). NOT retrying — the"
+      alert "bytes will not heal. Inspect $STATE_DIR per the FATAL message above and RUNBOOK.md"
+      alert "('Recovery'). Halting."
+      exit "$EXIT_POINTER_REJECTED"
+    fi
+
+    fails=$((fails + 1))
+    if [ "$fails" -ge "$MAX_CONSECUTIVE_FAILS" ]; then
+      alert "$fails consecutive failures with no checkpoint progress (last exit $rc) — this is a"
+      alert "crash-loop, not a transient death. Halting so an operator can investigate (RUNBOOK.md)."
+      exit 1
+    fi
+
+    local backoff=$((BACKOFF_BASE_S * fails))
+    [ "$backoff" -gt "$BACKOFF_MAX_S" ] && backoff="$BACKOFF_MAX_S"
+    log "transient exit $rc; relaunching SAME command in ${backoff}s (HOLE-D caps the absolute budget)"
+    sleep "$backoff"
+  done
+}
+
+main "$@"

--- a/scripts/shodan/ppo-train.sh
+++ b/scripts/shodan/ppo-train.sh
@@ -72,6 +72,10 @@ LEAGUE_DUMP_EVERY="${LEAGUE_DUMP_EVERY:-50}"        # Node league dump cadence i
 # --- auto-restart policy --------------------------------------------------------------------------
 EXIT_POINTER_REJECTED=3                              # MUST match dicewars_ppo._train_common.EXIT_POINTER_REJECTED
                                                      # (a CI canary in test_train_common_args.py pins the pair)
+EXIT_CRASH_LOOP=4                                    # this launcher's OWN intentional-halt code for a
+                                                     # bounded no-progress crash-loop (distinct from a
+                                                     # transient exit so ppo-train.cmd can map it to 0 and
+                                                     # stop schtasks <RestartOnFailure> from re-amplifying it)
 MAX_CONSECUTIVE_FAILS="${MAX_CONSECUTIVE_FAILS:-5}"  # bound a no-progress crash-loop
 BACKOFF_BASE_S="${BACKOFF_BASE_S:-15}"               # backoff = min(BACKOFF_BASE_S * fails, BACKOFF_MAX_S)
 BACKOFF_MAX_S="${BACKOFF_MAX_S:-120}"
@@ -79,7 +83,10 @@ EXPECTED_ENCODING_VERSION="${EXPECTED_ENCODING_VERSION:-2}"
 
 mkdir -p "$RUN_ROOT"
 
-log() { printf '%s [ppo-train] %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$*" | tee -a "$LAUNCH_LOG"; }
+# `|| true`: the deliberate exit codes (EXIT_POINTER_REJECTED / EXIT_CRASH_LOOP) drive the do-not-
+# retry contract and must NEVER be pre-empted by a tee failure (a broken stdout pipe on a job whose
+# terminal went away, or a full disk) aborting the script early under `set -e` + `pipefail`.
+log() { printf '%s [ppo-train] %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$*" | tee -a "$LAUNCH_LOG" || true; }
 alert() { log "ALERT: $*"; }  # a hook point: redirect/extend to email/push if desired (RUNBOOK.md)
 
 # Read the integer "step" out of latest.json without a jq dependency (WSL Ubuntu may not ship it).
@@ -101,8 +108,26 @@ preflight() {
     exit 1
   fi
   [ -f "$ML_DIR/$CHECKPOINT" ] || { alert "BC checkpoint not found: $ML_DIR/$CHECKPOINT"; exit 1; }
-  python -c "import torch, sb3_contrib, gymnasium" 2>/dev/null \
-    || { alert "the [rl] venv is not active (need torch + sb3_contrib + gymnasium)"; exit 1; }
+  local import_err
+  if ! import_err="$(python -c "import torch, sb3_contrib, gymnasium" 2>&1)"; then
+    # Surface the actual ImportError, not a generic "venv not active" — a partially-broken install
+    # (e.g. torch built against the wrong CUDA libs) needs the real message to diagnose, not a
+    # reinstall of a venv that is already present.
+    alert "the [rl] venv is not usable (need torch + sb3_contrib + gymnasium): $import_err"
+    exit 1
+  fi
+  # DEVICE defaults to cuda, and SB3's get_device('cuda') SILENTLY falls back to CPU when CUDA is not
+  # visible (no exception) — so a cuda run could burn the WHOLE --timesteps budget on CPU (days), the
+  # exact waste this launcher exists to prevent, while train.py still logs the REQUESTED device=cuda.
+  # Assert availability here and HALT — the docs (RUNBOOK §1/§4b, ppo-train-task.xml) promise this guard.
+  if [ "${DEVICE%%:*}" = "cuda" ]; then
+    if ! python -c "import torch, sys; sys.exit(0 if torch.cuda.is_available() else 1)" 2>/dev/null; then
+      alert "DEVICE=cuda but torch.cuda.is_available() is False — refusing to launch: it would train"
+      alert "on CPU for days (the budget burn this run guards). Fix CUDA/the [rl] venv (RUNBOOK §1),"
+      alert "or set DEVICE=cpu deliberately for a smoke."
+      exit 1
+    fi
+  fi
 }
 
 # Pin the commit for the WHOLE run: a `git pull` mid-campaign could change the encoding/env under a
@@ -178,8 +203,9 @@ ent_coef=$ENT_COEF R=$RESERVE_BASELINES from_scratch=${FROM_SCRATCH:-0}"
     fails=$((fails + 1))
     if [ "$fails" -ge "$MAX_CONSECUTIVE_FAILS" ]; then
       alert "$fails consecutive failures with no checkpoint progress (last exit $rc) — this is a"
-      alert "crash-loop, not a transient death. Halting so an operator can investigate (RUNBOOK.md)."
-      exit 1
+      alert "crash-loop, not a transient death. Halting (exit $EXIT_CRASH_LOOP) so an operator can"
+      alert "investigate (RUNBOOK.md '§6 crash-loop')."
+      exit "$EXIT_CRASH_LOOP"
     fi
 
     local backoff=$((BACKOFF_BASE_S * fails))
@@ -189,4 +215,11 @@ ent_coef=$ENT_COEF R=$RESERVE_BASELINES from_scratch=${FROM_SCRATCH:-0}"
   done
 }
 
-main "$@"
+# Run main() only when this file is EXECUTED, not when it is SOURCED. The real entrypoints
+# (direct `bash scripts/shodan/ppo-train.sh`, and ppo-train.cmd's `exec bash … ppo-train.sh`) are
+# executed, so the guard is true and main runs exactly as before. The launcher tests
+# (ml/tests/test_ppo_train_launcher.py) SOURCE this file to stub preflight/run_once/latest_step/sleep
+# and drive main()'s restart loop deterministically — without the guard, sourcing would auto-run it.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main "$@"
+fi


### PR DESCRIPTION
## Phase-3 task C/E PR-6 — committed shodan launcher + schtasks runbook + auto-restart safety guard

The last task C/E ops slice before the long BEAT run. Wraps the PR-4 driver (`train.py`, #71) + the PR-5 idempotent checkpoint/resume core (#72) in a **disconnect-surviving, auto-restarting** launcher, and folds in the auto-restart **safety guard** (since the restart is now unattended).

Scope was confirmed up front (all recommended): schtasks-wrapped WSL launch, fold the full safety guard into PR-6, author locally first.

### Ops
- **`scripts/shodan/ppo-train.sh`** — owns the production HPs (`--lr 2.5e-4 --ent-coef 0.01`, deliberately *not* a `train.py` default), wires both resume halves (`--state-dir`/`--checkpoint-every` + `--league-state-dir`/`--snapshot-store=disk`/`--league-dump-every`, `R=3`), sizes `--n-envs` under `SubprocVecEnv(forkserver)`, pins `ENCODING_VERSION`+the commit for the whole campaign, and runs a **bounded auto-restart loop**: relaunch the SAME command (HOLE-D caps the absolute `--timesteps`) on a transient crash, but **HALT+alert** on `EXIT_POINTER_REJECTED` or N consecutive *no-progress* failures (a checkpoint-step advance resets the counter).
- **`ppo-train.cmd` + `ppo-train-task.xml`** — Windows→WSL Task Scheduler bridge: survives SSH teardown **and** reboot (the only disconnect-surviving pattern, [D-26] task-E).
- **`RUNBOOK.md`** — the BLOCKING PR-5 shodan validation checklist, the from-scratch control run (sequenced first), launch/monitor/recovery, and the [D-24] kill gate (`ppo:gate` win% Δ vs `ai_lookahead@596f781`, 95% CI lower bound > 0).

### Safety guard (code)
- `train.py` now **HALTs** with `EXIT_POINTER_REJECTED=3` on a present-but-rejected `latest.json` — superseding PR-5's loud-warn+fresh, which under the unattended loop silently re-burns the whole budget from step 0.
- `load_resume_checkpoint` falls back across the retained `keep=N` **same-build** older pairs on a corrupt newest `.zip`, raising `ResumeCheckpointError` → the same HALT only when **all** retained pairs are unreadable. Still HALTs (never silently skips) on version/encoding-skew — reconciling with PR-5 review-decision (b).
- The resume/fresh/HALT policy (`resume_action`) and the fallback order (`resume_candidate_pairs`) are **pure, torch-free, CI-tested** in `resume_state.py`, mirroring `classify_latest_pointer`.
- `train()`'s teardown widened to a single `try/finally` so the env workers (each owning a Node child) are reaped on **every** exit path — also fixes a pre-existing `build_model` leak.
- `EXIT_POINTER_REJECTED` single-sourced in torch-free `_train_common`; a lean-CI canary asserts the launcher's hard-coded copy matches.

### Docs
- `PLAN.md` / `DECISIONS.md`: corrected the stale "PR-4/PR-5 landed locally" → **MERGED** (#71 / #72); added the D-26 PR-6 entry; `LOG.md` PR-6 entry.

### Validation
- ruff + `bash -n` + `npm run build` clean; **198 torch-free ml tests pass** (new `resume_candidate_pairs` / `resume_action` / exit-code canary). No JS source touched.
- The sb3-coupled tests (corrupt-`.zip` fallback, the `train.py` HALT, `ResumeCheckpointError`) are **shodan-only** here (this box is py3.9 + no sb3) and are part of the blocking shodan checklist before the long run.
- Authored + a 5-lens adversarial review workflow → **1 blocker** (a stale test still asserting the reversed contract) + minors, **all fixed** (parametrized HALT test over all 4 rejected reasons; `ResumeCheckpointError` driver test; pointer-not-rewritten assertion; the cross-language canary).

> ⚠️ Merging PR-6 ≠ launching the run. The long BEAT run is gated on the shodan-only PR-5 validation checklist + the from-scratch control run (see `RUNBOOK.md`) — neither can run off the GPU box. PR-7 = deferred test-hardening (env-server `main()` persistence integration test; live cross-worker `SharedDiskStore`; live forkserver two-half resume smoke).
