### PR TITLE
feat(ml): wire ai_ppo bot into arena + in-game AI registry

### DIFF
--- a/src/ai/aiConfig.js
+++ b/src/ai/aiConfig.js
@@ -14,6 +14,20 @@ export const load_ai_adaptive = async () => (await import('./ai_adaptive.js')).a
 export const load_ai_strategist = async () => (await import('./ai_strategist.js')).ai_strategist;
 export const load_ai_lookahead = async () => (await import('./ai_lookahead.js')).ai_lookahead;
 export const load_ai_expectimax = async () => (await import('./ai_expectimax.js')).ai_expectimax;
+/*
+ * PPO is a modern `(BotState) => move` neural bot, not a legacy mutable-game-view
+ * AI, so its loader returns it pre-wrapped by `adaptModernBot` — the same reverse
+ * adapter community bots use. That tags it `__modernBot` so the in-game `runAI`
+ * loop drives it with a sanitized BotState instead of a legacy game view (which it
+ * cannot read — an unwrapped modern bot would throw every turn). The arena and
+ * tournament screens use the RAW bot from `builtInBots.js`, whose consumers already
+ * call `fn(botState)` directly, so no wrapper is needed there.
+ */
+export const load_ai_ppo = async () => {
+  const { ai_ppo } = await import('./ai_ppo.js');
+  const { adaptModernBot } = await import('../arena/modernBotAdapter.js');
+  return adaptModernBot(ai_ppo, 'ai_ppo');
+};
 
 /**
  * AI Strategy Registry
@@ -94,6 +108,17 @@ export const AI_STRATEGIES = {
     description: 'Chance-node expectimax over win/loss outcomes weighted by exact dice odds',
     difficulty: 5,
     loader: load_ai_expectimax,
+    implementation: null,
+  },
+
+  // PPO self-play RL net (Phase 3). No search: a single reactive forward pass, so
+  // it plays on learned instinct, not lookahead.
+  ai_ppo: {
+    id: 'ai_ppo',
+    name: 'PPO AI',
+    description: 'Neural net trained by PPO self-play against a league of bots',
+    difficulty: 5,
+    loader: load_ai_ppo,
     implementation: null,
   },
 };

--- a/src/ai/ai_ppo.js
+++ b/src/ai/ai_ppo.js
@@ -1,0 +1,32 @@
+/**
+ * PPO — the self-play reinforcement-learning bot (ml-bot Phase 3).
+ *
+ * Same in-browser machinery as the behavioral-cloning bot (`ai_bc`): it shares the
+ * identical EdgePolicyNet architecture, the synchronous pure-JS forward pass
+ * (`bcForward.js`), and the v2 observation encoder, so it runs as just another
+ * modern bot — `(BotState) => { from, to } | null`. The ONLY difference is the
+ * weights: instead of imitating `ai_lookahead` (what BC does), these were trained
+ * by reinforcement learning — PPO self-play against a field of opponent bots. For
+ * the training regime, provenance, and current status see `docs/ml-bot/`; the
+ * per-export specifics live in the auto-generated header of `ppoPolicyWeights.js`.
+ *
+ * The exported symbol in `ppoPolicyWeights.js` is named `BC_POLICY` because both
+ * the BC and PPO weights are emitted by the same exporter (`export_weights.py`);
+ * we alias it to `PPO_POLICY` here so the source reads honestly. `makeBC`'s
+ * encoder-version guard validates these weights at import time and throws if they
+ * skew from the live encoder (mis-columned tensors → silently corrupt moves).
+ *
+ * @module ai/ai_ppo
+ */
+
+import { makeBC } from './ai_bc.js';
+import { BC_POLICY as PPO_POLICY } from './ppoPolicyWeights.js';
+
+/**
+ * The PPO bot move function — the PPO policy run through the shared forward pass.
+ * @param {import('../arena/types.js').BotState} botState
+ * @returns {{ from: number, to: number } | null} An attack, or null to end the turn.
+ */
+export const ai_ppo = makeBC({ policy: PPO_POLICY });
+
+export default ai_ppo;

--- a/src/arena/builtInBots.js
+++ b/src/arena/builtInBots.js
@@ -16,6 +16,7 @@ import { ai_strategist } from '../ai/ai_strategist.js';
 import { ai_lookahead } from '../ai/ai_lookahead.js';
 import { ai_expectimax } from '../ai/ai_expectimax.js';
 import { ai_bc } from '../ai/ai_bc.js';
+import { ai_ppo } from '../ai/ai_ppo.js';
 
 export const BUILT_IN_BOTS = [
   { id: 'ai_example', name: 'Example', fn: adaptLegacyBot(ai_example, 'Example') },
@@ -34,4 +35,11 @@ export const BUILT_IN_BOTS = [
    * its wrapper dereferences `state.turnOrder`, a field a BotState lacks.)
    */
   { id: 'ai_bc', name: 'BC', fn: ai_bc },
+  /*
+   * PPO — the self-play RL net (Phase 3). Like BC, already a modern
+   * `(BotState) => move` bot, so it registers RAW (every BUILT_IN_BOTS consumer
+   * runs bots through runMatch/runBotDirect, which calls `fn(botState)`). Wrapping
+   * it with adaptModernBot here would make it throw every turn — see the BC note above.
+   */
+  { id: 'ai_ppo', name: 'PPO', fn: ai_ppo },
 ];

--- a/tests/ai/ai_ppo.test.js
+++ b/tests/ai/ai_ppo.test.js
@@ -1,0 +1,134 @@
+/**
+ * PPO bot — the in-browser self-play RL net (ml-bot Phase 3).
+ *
+ * PPO reuses ai_bc's machinery (forward pass + encoder), so the numeric parity is
+ * already covered by tests/ai/ppoForward.test.js. This file covers the wiring that
+ * makes PPO *playable*: that it returns legal moves on a real BotState, that the
+ * in-game aiConfig path reverse-adapts it so runAI drives it without throwing (the
+ * "modern bot on the legacy path throws every turn" trap), and that its raw arena
+ * registration actually runs its policy.
+ */
+import { createGame } from '../../src/engine/GameRunner.js';
+import { applyAction, getValidMoves } from '../../src/engine/StateManager.js';
+import { runAI } from '../../src/engine/AIAdapter.js';
+import { ai_ppo } from '../../src/ai/ai_ppo.js';
+import { ai_bc } from '../../src/ai/ai_bc.js';
+import { getAIImplementation } from '../../src/ai/aiConfig.js';
+import { createBotState } from '../../src/arena/botState.js';
+import { BUILT_IN_BOTS } from '../../src/arena/builtInBots.js';
+import { runMatch } from '../../src/arena/matchRunner.js';
+
+const moveKey = m => `${m.from}->${m.to}`;
+
+/** A real engine state whose current player has at least one legal attack. */
+function firstStateWithMoves() {
+  for (let seed = 1; seed <= 300; seed++) {
+    const state = createGame({ seed, playerCount: 7 });
+    if (getValidMoves(state).length > 0) return state;
+  }
+  throw new Error('no initial state with moves found in 300 seeds');
+}
+
+describe('ai_ppo bot', () => {
+  it('returns a legal move or null, deterministically', () => {
+    const state = firstStateWithMoves();
+    const me = state.turnOrder[state.currentPlayerIndex];
+    const botState = createBotState(state, me);
+
+    const move = ai_ppo(botState);
+    expect(ai_ppo(botState)).toEqual(move); // deterministic (argmax)
+
+    if (move !== null) {
+      const legal = new Set(getValidMoves(state).map(moveKey));
+      expect(legal.has(moveKey(move))).toBe(true);
+    }
+  });
+
+  it('plays its own PPO weights, not the BC clone', () => {
+    /*
+     * ai_ppo is a 2-line alias: makeBC({ policy: PPO_POLICY }). If that import were
+     * fat-fingered to bcPolicyWeights, every OTHER test here would still pass — same
+     * legal moves, same determinism, same arena wiring — silently shipping BC under
+     * the "PPO" name. The PPO and BC nets were trained differently (RL self-play vs
+     * imitating ai_lookahead), so their argmax edges diverge on many boards. Assert
+     * they differ on at least one initial state — the seed-independent signal that
+     * ai_ppo is backed by its OWN weights. (Empirically ~2/3 of initial states
+     * diverge, so scanning a handful of seeds is not flaky.)
+     */
+    const choiceKey = m => (m === null ? 'STOP' : moveKey(m));
+    let diverged = false;
+    for (let seed = 1; seed <= 60 && !diverged; seed++) {
+      const state = createGame({ seed, playerCount: 7 });
+      if (getValidMoves(state).length === 0) continue;
+      const me = state.turnOrder[state.currentPlayerIndex];
+      const botState = createBotState(state, me);
+      if (choiceKey(ai_ppo(botState)) !== choiceKey(ai_bc(botState))) diverged = true;
+    }
+    expect(diverged).toBe(true);
+  });
+
+  it('drives a full game as a seat without throwing', () => {
+    let state = createGame({ seed: 7, playerCount: 7, recordHistory: false });
+    for (let step = 0; step < 4000; step++) {
+      if (state.gameOver) break;
+      const player = state.turnOrder[state.currentPlayerIndex];
+      let move = null;
+      if (player === 0) {
+        move = ai_ppo(createBotState(state, player));
+      }
+      if (move) {
+        state = applyAction(state, { type: 'ATTACK', from: move.from, to: move.to });
+      } else {
+        state = applyAction(state, { type: 'END_TURN' });
+      }
+    }
+    expect(state).toBeDefined();
+  }, 30_000);
+});
+
+describe('PPO in the in-game AI loop (aiConfig)', () => {
+  it('loads pre-adapted and drives runAI without hitting the legacy path', async () => {
+    /*
+     * Regression: a raw modern `(BotState) => move` bot dropped into aiConfig would
+     * hit runAI's LEGACY branch — handed a mutable game view, not a BotState — and
+     * throw every turn (the legacy-path trap). The loader must return an
+     * `adaptModernBot`-tagged function so runAI takes the modern path (sanitize
+     * engine state → BotState → call the bot).
+     */
+    const fn = await getAIImplementation('ai_ppo');
+    expect(fn.__modernBot).toBe(true);
+
+    const state = firstStateWithMoves();
+    const move = runAI(state, fn); // must NOT throw; returns { from, to } | null
+
+    if (move !== null) {
+      const legal = new Set(getValidMoves(state).map(moveKey));
+      expect(legal.has(moveKey(move))).toBe(true);
+    }
+  });
+});
+
+describe('PPO built-in arena registration', () => {
+  it('actually plays in the arena (called with a BotState), no adapter errors', () => {
+    const ppoEntry = BUILT_IN_BOTS.find(b => b.name === 'PPO');
+    expect(ppoEntry).toBeDefined();
+
+    /*
+     * Cross-seed sum, mirroring the BC arena test: per-seat board trajectory is not
+     * fully seeded (some opponents use unseeded Math.random), so on a single seed PPO
+     * can legitimately make 0 attacks. ppoErrors === 0 is the seed-independent signal —
+     * any error here means the modern bot is being mis-called (the adapter-mismatch bug).
+     */
+    const field = BUILT_IN_BOTS.map(b => ({ name: b.name, fn: b.fn }));
+    let ppoErrors = 0;
+    let ppoAttacks = 0;
+    for (let seed = 1; seed <= 6; seed++) {
+      const res = runMatch({ bots: field, seed });
+      const ppo = res.botStats.find(s => s.name === 'PPO');
+      ppoErrors += ppo.errors;
+      ppoAttacks += ppo.attacksMade;
+    }
+    expect(ppoErrors).toBe(0);
+    expect(ppoAttacks).toBeGreaterThan(0);
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

Adds **`ai_ppo`**, the in-browser PPO self-play RL bot (ml-bot Phase 3), and wires it into both the arena and the in-game AI registry.

It reuses the BC machinery — `makeBC({ policy: PPO_POLICY })`, i.e. the shared `EdgePolicyNet`, the synchronous pure-JS forward pass (`bcForward.js`), and the v2 observation encoder — over the already-committed PPO weights (`ppoPolicyWeights.js`, merged in #63). The **only** difference from `ai_bc` is the weights.

## Registration (the RAW-vs-wrapped asymmetry)

| Surface | How it's registered | Why |
| --- | --- | --- |
| `builtInBots.js` (arena/tournament) | **RAW** `ai_ppo` | Consumers run bots through `runMatch`/`runBotDirect`, which call `fn(botState)` directly — exactly the modern-bot signature. Mirrors `ai_bc`. |
| `aiConfig.js` (in-game loop) | `adaptModernBot(ai_ppo)` | The in-game `runAI` would otherwise hit its legacy branch (mutable game view, not a `BotState`) and throw every turn. The wrapper tags `__modernBot` so `runAI` takes the modern path. |

This makes PPO the **first ml-bot selectable as an in-game opponent** — it appears in the TitleScreen AI picker at difficulty 5, alongside strategist/lookahead/expectimax.

## Tests (`tests/ai/ai_ppo.test.js`)

- Legal-move/null + determinism (argmax) on a real `BotState`
- Drives a full game as a seat without throwing
- **Plays its own PPO weights, not the BC clone** — asserts `ai_ppo` diverges from `ai_bc` on ≥1 board, so a fat-fingered `bcPolicyWeights` import can't silently ship BC under the "PPO" name
- In-game `aiConfig` path: loader returns a `__modernBot`-tagged fn and `runAI` doesn't throw
- Arena registration: cross-seed `errors === 0` (seed-independent adapter-mismatch signal) + `attacksMade > 0`

JS↔Python numeric parity is covered separately by `tests/ai/ppoForward.test.js` against the committed fixture (runs, not skipped).

## Review notes

Reviewed across four lenses (correctness, comments, tests, silent-failure). Fixes folded in before this PR:
- Added the **weights-binding** divergence test (above).
- Corrected the `ai_ppo.js` provenance comment: the shipped weights are the **fixed-field** task-A run (#63), not the PFSP league; dropped the rot-prone "strongest policy" superlatives and PR-number reference, pointing to `docs/ml-bot/` instead.

**Deferred (out of scope — pre-existing shared infra):** `createAIFunctionMapping`'s broad `catch` swallows a loader throw into a silent `ai_default` substitution. `ai_ppo` is the first loader that can throw by design (the encoder-version guard), but a weights/encoder skew is a build-time event caught loudly by CI (the import-time guard fires wherever `builtInBots`/`ai_ppo` is imported, plus the parity test) — it can't silently reach a deployed user. Worth a focused follow-up, not a rider here.

## Verification

- Full suite: **1163 passing** · targeted: 11/11 · lint clean · `npm run build` ✓