### PR TITLE
feat(ml): reward-persona roster plan + Phase-1 behavioral-eval harness

### DIFF
--- a/docs/ml-bot/EVAL_HARNESS.md
+++ b/docs/ml-bot/EVAL_HARNESS.md
@@ -1,0 +1,486 @@
+# Behavioral-Eval Harness — spec (parked)
+
+> **Status:** Parked design spec — drafted 2026-06-28 alongside [PERSONAS.md](./PERSONAS.md) while
+> `ppo-long` trains. This is the measurement half of the persona-roster plan: the win%-vs-Lookahead
+> gate (`ppo:gate`) answers _"is it stronger?"_ — it is **blind to play-style**. This harness answers
+> _"is it DIFFERENT, and how?"_ by profiling any bot across a seed sweep on a set of behavioral axes
+> and doing a **paired comparison against a control**.
+>
+> **Grounded:** every file:line below was verified by a parallel code-map + two adversarial reviews
+> (feasibility skeptic + completeness critic) this session. Their corrections are folded in — this is
+> the post-review spec, not the first draft.
+>
+> **Scope honesty (the load-bearing caveat):** the five persona bots
+> (Conqueror/Blitz/Expansionist/Predator/Survivor) **do not exist in the repo yet** — `BUILT_IN_BOTS`
+> has exactly one generic `PPO` bot (`src/arena/builtInBots.js:44`). So this splits into two phases:
+>
+> - **Phase 1 — ✅ BUILT (2026-06-28):** the harness + its tests, validated on _existing built-ins_.
+>   Shipped: the §6 engine signal (`onTurn(…, actingPlayerId)` in `matchRunner.js`),
+>   `scripts/lib/behavior-core.mjs` (pure logic, 17 unit tests), `scripts/behavior-profile.mjs`
+>   (`npm run behavior:profile`), `tests/behaviorCore.test.js`. Acceptance check passes: `Strategist` vs
+>   `Defensive` separate on aggression (Δ≈0.85, CI excludes 0) at a 3×6 pilot budget. Adversarially
+>   reviewed (kill-attribution timing, seat mapping, null-alignment) — clean.
+> - **Phase 2 (after the personas are trained):** point it at the persona weight files and produce the
+>   signature table. The persona rows in §8 are **aspirational** until those bots exist; the
+>   `PERSONA_SIGNATURES` / `DEFAULT_MDE` stubs in `behavior-core.mjs` already encode the pre-registered
+>   hypotheses so the multiplicity story is fixed in advance.
+
+---
+
+## 1. Key finding
+
+**No engine or `matchRunner` changes are required** — but the draft's "no instrumentation required" was
+an overclaim and is corrected here. The harness must wire up two **opt-in, zero-cost-when-omitted**
+callbacks and accumulate the signals itself:
+
+- `onTurn(turnNumber, state)` — defined `src/arena/matchRunner.js:213`, fired after every player-turn
+  at `:325`. Source of the territory/dice/board-shape curves.
+- `onStep(step)` — defined `:214`, fired per attack at `:145-159` and at turn-end (STOP) at `:175-190`.
+  Source of per-turn attack/pass counts.
+
+Both are genuinely free when unset: the per-step hot path only builds steps when a handler exists
+(`stepHandler` is `undefined` unless `recorder || onStep`, `:261-267`; the attack-path `buildStep` is
+gated `if (onStep)` at `:145` and reuses the already-computed observation), and `onTurn` is guarded at
+`:325`. `runArena` does **not** forward `onTurn` (`src/arena/arenaRunner.js:102-109`), so the harness
+drives `runMatch` directly.
+
+**One recommended optional engine change** (§6): extend `onTurn` to
+`onTurn(turnNumber, state, actingPlayerId)`, passing the `currentPlayerId` already computed at
+`matchRunner.js:276`. It is backward-compatible (absent/old callers ignore the extra arg) and resolves
+**three** problems at once — the aggression bias (§2a), kill-attribution without a second replay pass
+(§2c), and clean active-turn counting. Both reviews recommend taking it; this spec adopts it.
+
+---
+
+## 2. Metrics
+
+Each metric is computed **per profiled bot, per game**, reduced to **one scalar per run** (a seed
+block), then aggregated to **mean ± 95% CI across runs** via `meanCi` (`scripts/lib/stats.mjs:60-66`).
+`pi` = the profiled bot's seat index. Feasibility tags use the reviewed taxonomy: _yes-from-existing_
+(a stored signal), _harness-capture_ (wire an existing callback + accumulate — no engine change),
+_derive-from-replay_ (re-simulate).
+
+### 2.1 Core axes
+
+| #   | Axis                  | Definition (per game)                                                     | Source            | Key file:line                                                              |
+| --- | --------------------- | ------------------------------------------------------------------------- | ----------------- | -------------------------------------------------------------------------- |
+| a   | **Aggression**        | attacks per _active turn_ = `attacksMade / activeTurns(pi)`               | harness-capture   | `attacksMade` `matchRunner.js:342`; `activeTurns` from `onTurn` actor (§6) |
+| b   | **Territory curve**   | `state.players[pi].territoryCount` sampled each `onTurn`, indexed by turn | harness-capture   | `onTurn` `:325`; `recalcPlayerStats` `StateManager.js:108-116`             |
+| c   | **Kills / game**      | opponents whose _last_ territory `pi` captured                            | harness-capture\* | elim flip `StateManager.js:122-128`; actor via `onTurn` (§6)               |
+| d   | **Turns-to-win**      | `turnCount` over games `pi` won (unit = **player-turns**, not rounds)     | yes-from-existing | `winner` `:350`, `turnCount` `:352`                                        |
+| e   | **Placement dist.**   | histogram of 1-based `placement`; + `avgPlacement`, `top1/top3`           | yes-from-existing | `placement` `:341`, `calculatePlacements` `:370-390`                       |
+| f   | **Win% vs reference** | FFA win-rate with the reference bot (default `Lookahead`) in the field    | yes-from-existing | `winner` `:350`; CI via `meanCi`; paired via `pairedDelta`                 |
+
+\* `c` becomes a pure `onTurn` computation with the §6 actor arg; without it, it is _derive-from-replay_
+(a full second simulation per game via `trajectoryFromReplay` `trajectoryExport.js:246`).
+
+**Corrections folded in (do not re-introduce):**
+
+- **(a) aggression bias — the subtle one.** `runBotTurn` emits the turn-end STOP step only when
+  `phase !== GAME_OVER`; a _winning_ turn returns early at `matchRunner.js:99` and emits **no STOP**.
+  So counting active turns as "# STOP steps" undercounts by exactly 1 on every game the bot wins, while
+  the winning attacks _are_ counted — inflating aggression **in proportion to win rate**, which differs
+  across personas and would contaminate the comparison. **Fix:** count active turns from `onTurn`
+  firings attributed to `pi` (§6), which include the victory turn; or, if not adopting §6,
+  `activeTurns = stopCount + (result.winner === pi ? 1 : 0)`. Documented in the metric, not silent.
+- **(b) k=0 gap.** `onTurn` first fires _after_ turn 1, so there is no initial-board sample. Seed index
+  0 from the `createGame` initial state (`GameRunner.js:37-68`) before the loop, or document the curve
+  starts at k=1. The JSON example's `t0` is the seeded initial state, not an `onTurn` sample.
+- **(d) unit.** `turnCount` increments once per _player-turn_ (`matchRunner.js:324`), **not** per full
+  round (`state.turnNumber`). A valid, consistent cross-bot axis — but label the unit so "turns" is not
+  misread as rounds.
+
+### 2.2 Style / "turtle" axes — added by review (the personality discriminators)
+
+The original six axes **cannot reveal a bot that wins by sitting on a dice pile** — exactly the turtle
+behavior observed in playtesting. These are all cheap from existing signals and are first-class, not
+diagnostics:
+
+| #   | Axis                        | Why it discriminates                                                 | Source            | Key file:line                                                   |
+| --- | --------------------------- | -------------------------------------------------------------------- | ----------------- | --------------------------------------------------------------- |
+| g   | **Avg dice reserve**        | the turtle's signature — sits on a big pile                          | harness-capture   | `diceCount` `StateManager.js:112-117`; `finalDice` `:340`       |
+| h   | **Dice per territory**      | turtle (dense, high) vs expansionist (thin, low)                     | harness-capture   | same as (g) ÷ (b)                                               |
+| i   | **Capture efficiency**      | `attacksWon/attacksMade` — cautious (high) vs reckless (low)         | yes-from-existing | `attacksWon` `:343`                                             |
+| j   | **Zero-attack-turn frac.**  | clearest pass-turn / turtle signal                                   | harness-capture   | `onStep` STOP with 0 attacks since last STOP (`:175-190`)       |
+| k   | **Border exposure**         | turtle clusters to shrink frontier vs aggressor                      | harness-capture   | `isBorder` `botState.js:50`, or recompute from `onTurn` state   |
+| l   | **Largest connected group** | "connectivity economics" the Expansionist reward targets             | yes-from-existing | `connectedTerritories` `botState.js:74` / player `largestGroup` |
+| m   | **Survival time / length**  | Survivor survives long _even when losing_ (all games, not just wins) | harness-capture   | `eliminated` flip in `onTurn` (`StateManager.js:122-128`)       |
+| n   | **Territory AUC**           | **scalar** reduction of (b) so it flows through `pairedDelta`        | harness-capture   | integrate the (b) curve (mean or normalized AUC)                |
+
+**(n) is not optional — it fixes an internal contradiction:** the persona table assigns Expansionist
+the signature "territory HIGHER," but a curve cannot go through `pairedDelta`/`classifyGate`. Reducing
+the captured curve to a scalar AUC (or net-territory mean) makes Expansionist's (and Survivor's
+territory aspect) `signaturePass` actually computable.
+
+**Dropped as redundant:** `attacksPerGame` as a separate paired axis — it is ≈ aggression × mean active
+turns and adds nothing over the turn-normalized axis. Derive on demand if ever needed.
+
+---
+
+## 3. Statistical design — the part that makes "distinct" mean something
+
+This section is new (the draft had none) and is where both reviews put their highest-severity findings.
+
+### 3.1 Aggregation & the unit of replication
+
+Per axis: collect one scalar per **run** (a seed block of `games` matches), then `meanCi(perRun[])`.
+**Critically, `meanCi`'s `n` is the RUN count, not the game count** — CI half-width is driven by
+_between-run_ variance / √runs. More games per run shrinks within-run noise; only more _runs_ tightens
+the CI. Budget both deliberately.
+
+### 3.2 Minimum detectable effect (MDE) — no "trivially significant" passes
+
+`signaturePass = "the expected-direction CI excludes 0"` will fire on a behaviorally meaningless
+difference (e.g. aggression Δ 0.1 with CI [0.05, 0.15]) once games are plentiful — defeating the whole
+point. **Require both:**
+
+```
+signaturePass(axis) := |delta| >= MDE(axis)  AND  CI excludes 0  (in the expected direction)
+```
+
+Pre-register a practical MDE per axis (e.g. aggression ≥ ~1 extra attack/turn; kills ≥ ~0.5/game;
+turns-to-win ≥ ~15%). These are placeholders to **calibrate from a pilot**: run a few runs on the
+trained personas, estimate between-run SD per axis, then solve `runs` (and `games`/run) for a CI
+half-width comfortably under the MDE. State the resulting budget in the run log; do not hard-code
+20×150 without that check.
+
+### 3.3 Multiplicity — one hypothesis per persona
+
+5 personas × ~12 axes ≈ 60 CIs at per-axis 95% inflates family-wise error badly. **Pre-register exactly
+one confirmatory signature hypothesis per persona** (a named axis, or an explicit AND-conjunction like
+Blitz's "aggression HIGHER **and** turns-to-win LOWER") _before_ running. That bounds the confirmatory
+family to ~5 tests; apply **Holm** across those 5. **All other axes are descriptive** (reported, not
+pass/fail). `PERSONA_SIGNATURES` encodes the one hypothesis + AND/OR rule per persona.
+
+### 3.4 Null-run policy (winners-only axes)
+
+Turns-to-win is `null` for any run where the bot never won — and `pairedDelta`
+(`ppo-gate-core.mjs:31-41`) throws on length mismatch and silently mis-pairs if one side drops a run.
+**Policy:** when _either_ persona or control yields `null` at run `i`, drop index `i` from **both**
+arrays before pairing (preserves alignment); emit the reduced `n`. Or require a minimum win count per
+block. Applies to any winners-only axis.
+
+### 3.5 Pairing — honest about its strength
+
+The draft claimed "the same paired logic `ppo:gate` uses." **It is weaker than that** and the spec must
+not overclaim: `ppo:gate` pairs candidate and bar _within one game_; profiling each persona in its
+**own** field shares only the map **seed** with the control, not the same opponents/interactions.
+
+**Recommended design — fixed standard opponent field, honest seed-level pairing.** Profile each persona
+(and the control) in an **identical** opponent field (same opponents, same reference, same seeds, full
+seat rotation). Every persona then faces the _same_ opponents → clean, comparable signatures; pairing is
+**seed/map-level** (documented as such), and §3.2's power sizing accounts for the extra variance. This
+is preferred over co-seating because co-seating changes _what opponents each persona faces_ (a Predator
+seated among 4 aggressive personas has a different kill rate than vs standard opponents) — contaminating
+the very signatures we measure.
+
+**Secondary "melee" mode for persona×persona separation.** To answer "are the five distinct from _each
+other_" (not just from Conqueror), add an optional mode that co-seats all personas + control in one
+shared field and emits a persona×persona `pairedDelta` matrix (judged by paired-diff CI excluding 0 with
+MDE — _not_ marginal-CI overlap, which is the weaker test). This mode accepts interaction by design and,
+as a bonus, is ~N× cheaper than N separate sweeps — but it is for the separation matrix, not the clean
+signatures.
+
+### 3.6 Determinism
+
+Pairing, reproducibility, and the byte-identical-JSON test all assume bot decisions are a pure function
+of state. The engine RNG is seeded, but a PPO policy in **sampling** mode (or any bot using
+`Math.random` for tie-breaks) breaks this. **Require profiled bots to run in greedy/argmax inference**
+and assert no internal RNG — enforce in the persona loader, not just the smoke test.
+
+### 3.7 Quarantine — don't bias the metric you're measuring
+
+Dropping games where the profiled bot hit `maxMovesHit` removes its _most aggressive_ turns (100 attacks
+in one turn) → biases aggression **down**; and an opponent's forced-end distorts the game but isn't
+caught if you only check the profiled seat. **Policy:** quarantine on **any** seat's forced-end counters
+(`errors|invalidMoves|maxMovesHit > 0`, D-14, `matchRunner.js:344-346`), **report the quarantine rate
+per persona**, and emit profiles **both with and without** quarantine so a systematic shift is visible,
+not silent.
+
+### 3.8 Training-field match (fixed-field-exploitation guard)
+
+Per the task-A caveat, a persona trained at a given `playerCount`/`maxAreas`/`dicePerArea` can look
+artificially strong or distinct if profiled at a _different_ field size. **Record those three with each
+persona's weights and have the harness ASSERT the profiling field equals the training field — hard error
+on mismatch**, not an open question. (Also fix the draft's 7-vs-8 inconsistency: the example field is 5
+opponents + 1 reference + 1 profiled = 7 seats = `DEFAULT_PLAYER_COUNT`; the "N=8" note was wrong.)
+
+---
+
+## 4. Architecture
+
+Two files, mirroring the `ppo-gate.mjs` (CLI) / `ppo-gate-core.mjs` (pure, unit-testable) split:
+
+- **`scripts/behavior-profile.mjs`** — CLI: arg parse, bot enumeration, the seed×rotation sweep driving
+  `runMatch`, output (JSON/CSV/table).
+- **`scripts/lib/behavior-core.mjs`** — pure logic (no arena, no I/O): per-game extraction, per-run
+  aggregation, MDE/multiplicity decision, persona-vs-control + persona×persona comparison. Unit-testable
+  like `ppo-gate-core.mjs`.
+
+Lives under `scripts/` (offline analysis CLI like `arena-sweep.mjs`), not `src/`.
+
+### Public API (`behavior-core.mjs`)
+
+```
+// Per-game extraction. `capture` carries the onTurn/onStep-accumulated arrays for THIS game.
+profileGameFromCapture(matchResult, playerIndex, capture) -> GameProfile
+//   GameProfile: { aggression, territoryCurve[], territoryAuc, kills, won, turnsToWin|null,
+//                  placement, avgDiceReserve, dicePerTerritory, captureEfficiency,
+//                  zeroAttackTurnFrac, borderExposure, largestGroup, survivalTurn }
+
+aggregateRuns(perRunValues[]) -> { mean, ci }          // thin wrapper over meanCi
+aggregateCurves(perRunCurves[][]) -> { turns[], mean[], ci[] }   // aligned, padded (§2 b)
+
+compareToControl(personaRuns, controlRuns, signature) -> {
+  perAxis: { <axis>: { delta, ci, lo, hi, verdict } },  // verdict = classifyGate (HIGHER/SAME/LOWER)
+  signaturePass: boolean                                // §3.2 MDE AND CI-excludes-0, §3.3 Holm-adjusted
+}
+separationMatrix(allPersonaRuns) -> { /* persona×persona pairedDelta, §3.5 melee mode */ }
+
+PERSONA_SIGNATURES  // persona -> { axis | axes[], direction, rule:'AND'|'single', mde }
+```
+
+`profileGameFromCapture` derives (d/e/i) from `matchResult` directly and (a/b/c/g–n) from `capture`. The
+terminal-stat math (`wins`, `avgPlacement`, `attackWinRate`) should be a **shared helper extracted from
+`arenaRunner.js:130-168`**, not re-implemented (the one duplication the review flagged).
+
+### CLI
+
+```
+node scripts/behavior-profile.mjs \
+  --bots PPO,Blitz,Expansionist,Predator,Survivor \   # profiled seats (Phase 2)
+  --reference Lookahead \                              # win%-vs-ref; present in every field
+  --opponents Default,Defensive,Strategist,Adaptive,Expectimax \  # fixed FFA filler (identical for all)
+  --control Conqueror \                               # auto-injected into the profiled set if absent
+  --runs 20 --games 150 \                             # CALIBRATE via §3.2 pilot, don't hard-code
+  --melee \                                           # optional §3.5 persona×persona mode
+  --no-quarantine \                                   # emit unfiltered too (§3.7)
+  --json                                              # JSON->stdout, human table->stderr
+```
+
+The **control is always profiled** with identical run/game/rotation config (auto-injected if not in
+`--bots`); assert `controlRuns.length === personaRuns.length` before `pairedDelta`.
+
+### Sweep execution (per profiled bot, fixed field)
+
+1. Field = `rotatedField([...opponents, reference, bot], r)` (`ppo-gate-core.mjs:127-132`); reuse
+   `buildGateField`'s present/collision guardrails (`:103-112`) for the reference-in-field +
+   name-collision checks rather than re-deriving them.
+2. `STRIDE = Math.max(1_000_000, games*1000)` (`arena-sweep.mjs:45`); run `r` uses seeds
+   `r*STRIDE+1 … +games`, each replayed through all N seat rotations (the `ppo-gate.mjs` seat-fair
+   architecture).
+3. `runMatch({ bots, seed, recordTrajectory:false, onTurn, onStep })` with a fresh per-game `capture`:
+   ```
+   const cap = { terr: [], dice: [], attacks: 0, stops: 0, zeroTurns: 0, sinceStop: 0, killTurns: [], elimAt: {} };
+   onTurn: (t, s, actor) => {                    // actor via §6
+     cap.terr.push(s.players[pi].territoryCount);
+     cap.dice.push(s.players[pi].diceCount);      // copy scalars NOW — never retain s (it mutates)
+     if (actor === pi) cap.activeTurns = (cap.activeTurns ?? 0) + 1;
+     /* diff eliminated set vs last turn; if actor===pi credit a kill */
+   };
+   onStep: (step) => { if (step.playerId !== pi) return;
+     if (isStopMove(step.chosenMove)) { if (cap.sinceStop === 0) cap.zeroTurns++; cap.sinceStop = 0; }
+     else cap.sinceStop++; };
+   ```
+4. `profileGameFromCapture(result, pi, cap)`; quarantine per §3.7.
+5. Reduce the block to per-run scalars; push to `perRun[bot][axis]`.
+
+---
+
+## 5. Reused utilities (exact)
+
+| Function                                 | File:line                                             | Use                                        |
+| ---------------------------------------- | ----------------------------------------------------- | ------------------------------------------ |
+| `runMatch` + `onTurn`/`onStep`           | `matchRunner.js:224-361` (cb `:213/:214`)             | run each game, stream board + step signals |
+| `botStats`                               | `matchRunner.js:336-347`                              | (a num),(d),(e),(g),(i), quarantine        |
+| `MatchResult` winner/turnCount           | `matchRunner.js:350/:352`                             | (d),(f)                                    |
+| `calculatePlacements`                    | `matchRunner.js:370-390`                              | placement ranks (already applied)          |
+| `recalcPlayerStats`                      | `StateManager.js:108-117`                             | territoryCount (b), diceCount (g)          |
+| `applyAction`                            | `StateManager.js:161-173`                             | replay re-sim (kills fallback)             |
+| `trajectoryFromReplay` / `replayToState` | `trajectoryExport.js:246` / `replayFormat.js:198-208` | kill-attribution fallback (no §6)          |
+| `isStopMove` / `buildStep`               | `trajectoryExport.js:61` / `:129-140`                 | ATTACK vs STOP in `onStep`                 |
+| `botState` isBorder/connected            | `botState.js:50` / `:74`                              | (k) border, (l) largest group              |
+| `meanCi` / `tCrit` / `mean`              | `stats.mjs:60-66 / :50 / :53`                         | mean ± 95% CI — **CI math reused**         |
+| `pairedDelta` / `classifyGate`           | `ppo-gate-core.mjs:31-41 / :53-57`                    | paired Δ + HIGHER/SAME/LOWER               |
+| `rotatedField` / `buildGateField`        | `ppo-gate-core.mjs:127-132 / :103-112`                | seat fairness, field guardrails            |
+| arenaRunner accumulators                 | `arenaRunner.js:130-168`                              | **extract** shared terminal-stat helper    |
+| `BUILT_IN_BOTS`                          | `builtInBots.js:21`                                   | built-in enumeration (`ai_ppo` `:44`)      |
+| `resolveBot`/`loadBot`/`getArg`          | `cli-utils.mjs:49/:37`, `cli-args.mjs:25`             | file/weight bots + arg parsing             |
+| JSON-stdout / table-stderr               | `_tune.mjs:130-142`                                   | dual output                                |
+
+---
+
+## 6. The one recommended engine change (backward-compatible)
+
+Extend `onTurn`'s firing at `matchRunner.js:325` to pass the acting player:
+
+```
+onTurn?.(turnCount, state, currentPlayerId);   // currentPlayerId already computed at :276
+```
+
+Old/absent callers ignore the third arg; `runArena` passes no `onTurn`, so nothing else changes. This:
+
+1. **Fixes the aggression bias (§2a)** — active turns counted from `onTurn` firings where
+   `actor === pi`, which include the victory turn.
+2. **Removes the second replay pass for kills (§2c)** — diff the eliminated set across consecutive
+   `onTurn` firings and credit the acting player; O(1) live instead of a full re-simulation at
+   runs×games×N×rotations scale.
+3. Makes both O(1) and live.
+
+Both reviews recommend taking it; keep replay-based kills as a cross-check in a test.
+
+---
+
+## 7. Output format
+
+`--json` → stdout (machine), human table → stderr (`_tune.mjs:130-142`). Shape (abbreviated):
+
+```jsonc
+{
+  "config": {
+    "runs": 20,
+    "games": 150,
+    "stride": 1000000,
+    "reference": "Lookahead",
+    "control": "Conqueror",
+    "opponents": ["Default", "..."],
+    "fieldSize": 7,
+    "trainingFieldAsserted": true,
+    "quarantine": { "on": true, "ratePerBot": { "Blitz": 0.004 } },
+    "mde": { "aggression": 1.0, "kills": 0.5, "turnsToWin": 0.15 },
+  },
+  "bots": [
+    {
+      "name": "Blitz",
+      "metrics": {
+        "aggression": { "mean": 4.8, "ci": 0.3 },
+        "turnsToWin": { "mean": 22.4, "ci": 1.9, "n": 142 }, // null mean if n==0
+        "kills": { "mean": 1.7, "ci": 0.2 },
+        "avgDiceReserve": { "mean": 9.1, "ci": 0.6 },
+        "dicePerTerritory": { "mean": 1.3, "ci": 0.1 },
+        "captureEfficiency": { "mean": 0.71, "ci": 0.03 },
+        "zeroAttackTurnFrac": { "mean": 0.06, "ci": 0.02 },
+        "borderExposure": { "mean": 0.55, "ci": 0.03 },
+        "largestGroup": { "mean": 11.0, "ci": 0.7 },
+        "survivalTurn": { "mean": 38.0, "ci": 2.4 },
+        "winPctVsRef": { "mean": 41.0, "ci": 3.2 },
+        "avgPlacement": { "mean": 2.6, "ci": 0.1 },
+        "placementHist": { "1": 0.41, "2": 0.18 },
+        "territoryCurve": { "turns": [0, 1, 2], "mean": [7.0, 8.1, 9.4], "ci": [0.0, 0.4, 0.6] },
+        "territoryAuc": { "mean": 412.0, "ci": 18.0 },
+      },
+      "vsControl": {
+        // paired Δ (persona − Conqueror), §3.4 aligned
+        "aggression": { "delta": 2.1, "ci": 0.4, "lo": 1.7, "hi": 2.5, "verdict": "HIGHER" },
+        "turnsToWin": {
+          "delta": -9.8,
+          "ci": 2.0,
+          "lo": -11.8,
+          "hi": -7.8,
+          "verdict": "LOWER",
+          "n": 138,
+        },
+        "signature": {
+          "axes": ["aggression", "turnsToWin"],
+          "rule": "AND",
+          "mdeMet": true,
+          "holmAdjusted": true,
+          "signaturePass": true,
+        },
+      },
+    },
+  ],
+  "separationMatrix": {
+    /* §3.5 melee mode, optional */
+  },
+}
+```
+
+CSV (optional `--csv <dir>`): `summary.csv`, `territory.csv` (tidy long form for plotting),
+`vs_control.csv`, `separation.csv`. Console table prints the headline axes + the per-persona signature
+verdict.
+
+---
+
+## 8. Persona signatures (aspirational — Phase 2)
+
+One **pre-registered** confirmatory hypothesis per persona (§3.3); everything else is descriptive.
+
+| Persona      | Reward              | Pre-registered signature vs Conqueror                           | Rule   |
+| ------------ | ------------------- | --------------------------------------------------------------- | ------ |
+| Conqueror    | win (control)       | — baseline                                                      | —      |
+| Blitz/Tempo  | low γ / fast        | aggression **HIGHER** AND turns-to-win **LOWER**                | AND    |
+| Expansionist | dense net-territory | territory AUC (n) **HIGHER**                                    | single |
+| Predator     | elimination bounty  | kills/game **HIGHER**                                           | single |
+| Survivor     | placement reward    | avg placement **LOWER/better** (survivalTurn HIGHER as support) | single |
+
+Turtle-detection axes (g–l) are the descriptive backbone: they're how we'd _show_ that Blitz stopped
+hoarding (avgDiceReserve LOWER, zeroAttackTurnFrac LOWER) relative to the Conqueror turtle observed in
+play — even though aggression+tempo is Blitz's confirmatory signature.
+
+---
+
+## 9. Integration
+
+- **npm:** `"behavior:profile": "node scripts/behavior-profile.mjs"`. Optional preset
+  `"behavior:personas"` wiring the 5 personas + Conqueror control + Lookahead reference.
+- **vs `arena:sweep`:** shares STRIDE/seed-block/`meanCi`; adds behavioral axes + paired control.
+- **vs `ppo:gate`:** complementary — `ppo:gate` = _"stronger?"_ (paired Δwin% vs Lookahead),
+  `behavior:profile` = _"different?"_ (paired Δ on behavioral axes vs Conqueror), reusing the very same
+  `pairedDelta`/`classifyGate`. Pipeline: train personas → (optional) `ppo:gate` for strength →
+  `behavior:profile` for distinct style. A persona "ships as a persona" when `signaturePass === true`
+  (MDE + Holm) — strength is _not_ required of a personality bot (PERSONAS §9 open question).
+
+---
+
+## 10. Test plan
+
+Scoped runs only (`npx vitest run tests/behaviorCore.test.js`), never the full suite from a subagent
+(CLAUDE.md). Node env — no DOM.
+
+**Unit (`behavior-core.mjs`, deterministic, no arena):**
+
+1. `profileGameFromCapture` on a hand-built `MatchResult` + capture: correct
+   `aggression = attacks/activeTurns` **including the victory-turn correction**; `turnsToWin` only on
+   wins (`null` otherwise); placement from `botStats`; dice/efficiency/zero-turn/border/largest-group.
+2. **Kill attribution:** synthetic 3-player game where X delivers Y's last-territory capture →
+   `kills(X)===1`, others 0; a capture that does _not_ zero the defender → no kill. Test **both** the §6
+   `onTurn`-actor path and the replay path agree.
+3. `aggregateRuns` ≡ `meanCi`; `aggregateCurves` aligns/pads variable-length curves; `territoryAuc`
+   reduction correct.
+4. `compareToControl`: crafted per-run arrays → exact `pairedDelta` + verdicts; **`signaturePass` true
+   only when |Δ| ≥ MDE AND CI excludes 0 in the expected direction** (assert it is FALSE for a
+   significant-but-sub-MDE Δ); Holm adjustment across the 5.
+5. **Null-run policy:** a `null` turns-to-win run on either side drops index `i` from both, preserving
+   alignment; `pairedDelta` never sees mismatched lengths.
+6. Edge cases: never-wins (`turnsToWin {n:0, mean:null}`), 0 kills, quarantined game excluded,
+   single-win block.
+
+**Integration smoke (`behavior-profile.mjs`):**
+
+7. Two built-ins, `--runs 2 --games 5`, fixed seeds → JSON parses, all axes present, paired arrays
+   length === runs, no `NaN`/unexpected `null`.
+8. **Determinism:** identical args twice → byte-identical JSON (requires argmax inference, §3.6).
+9. **Zero-cost guard:** `runMatch` with no `onStep`/`onTurn` builds zero steps (spy on `buildStep` /
+   assert `stepHandler` undefined) — protects the "callbacks off ⇒ free" invariant for arena/gate.
+10. **Discrimination sanity (Phase 1 acceptance):** profiling two deliberately different built-ins
+    (`Defensive` vs `Strategist`) yields ≥1 axis with non-overlapping paired-Δ CI _exceeding MDE_ —
+    proves the harness can actually detect a style difference before any persona exists.
+
+---
+
+## 11. Open decisions for Ivan
+
+Most review findings are settled above. These are the genuine judgment calls:
+
+1. **Pairing mode (§3.5):** ship the fixed-standard-field design (clean signatures, honest seed-level
+   pairing) as primary — agreed? And is the co-seated "melee" persona×persona matrix worth building in
+   v1, or defer it?
+2. **MDE values (§3.2):** the per-axis "behaviorally meaningful" thresholds are a product call, not a
+   code one. Placeholders are in §3.2; we calibrate against a pilot once a persona exists — but the
+   _direction_ (e.g. "1 extra attack/turn is meaningful, 0.1 isn't") is yours.
+3. **§6 engine one-liner:** adopt it (recommended — fixes the bias + kills in one backward-compatible
+   line), or keep the engine untouched and pay the replay pass + the explicit `+1` aggression
+   correction?
+4. **Budget:** runs vs games split is driven by the pilot's between-run SD (§3.1). No fixed number until
+   then — flagging so 20×150 isn't mistaken for a decision.

--- a/docs/ml-bot/EVAL_HARNESS.md
+++ b/docs/ml-bot/EVAL_HARNESS.md
@@ -6,9 +6,11 @@
 > _"is it DIFFERENT, and how?"_ by profiling any bot across a seed sweep on a set of behavioral axes
 > and doing a **paired comparison against a control**.
 >
-> **Grounded:** every file:line below was verified by a parallel code-map + two adversarial reviews
-> (feasibility skeptic + completeness critic) this session. Their corrections are folded in — this is
-> the post-review spec, not the first draft.
+> **Grounded:** the file:line citations below were verified against the source by a parallel
+> code-map + two adversarial reviews (feasibility skeptic + completeness critic). Line numbers are a
+> point-in-time anchor and **drift as files change** — the **symbol name** in each citation is the
+> durable reference; if a line looks off, grep the symbol. (The `matchRunner.js` numbers here were
+> re-synced after this PR's own `onTurn` JSDoc expansion shifted them.)
 >
 > **Scope honesty (the load-bearing caveat):** the five persona bots
 > (Conqueror/Blitz/Expansionist/Predator/Survivor) **do not exist in the repo yet** — `BUILT_IN_BOTS`
@@ -17,9 +19,10 @@
 > - **Phase 1 — ✅ BUILT (2026-06-28):** the harness + its tests, validated on _existing built-ins_.
 >   Shipped: the §6 engine signal (`onTurn(…, actingPlayerId)` in `matchRunner.js`),
 >   `scripts/lib/behavior-core.mjs` (pure logic, 17 unit tests), `scripts/behavior-profile.mjs`
->   (`npm run behavior:profile`), `tests/behaviorCore.test.js`. Acceptance check passes: `Strategist` vs
->   `Defensive` separate on aggression (Δ≈0.85, CI excludes 0) at a 3×6 pilot budget. Adversarially
->   reviewed (kill-attribution timing, seat mapping, null-alignment) — clean.
+>   (`npm run behavior:profile`), `tests/behaviorCore.test.js`. Acceptance check (a **manual pilot**,
+>   not an automated assertion — the exact Δ depends on field & budget): `Strategist` vs `Defensive`
+>   separate on aggression / zero-attack-turn fraction with a CI excluding 0 at a small pilot budget.
+>   Adversarially reviewed (kill-attribution timing, seat mapping, null-alignment) — clean.
 > - **Phase 2 (after the personas are trained):** point it at the persona weight files and produce the
 >   signature table. The persona rows in §8 are **aspirational** until those bots exist; the
 >   `PERSONA_SIGNATURES` / `DEFAULT_MDE` stubs in `behavior-core.mjs` already encode the pre-registered
@@ -29,26 +32,27 @@
 
 ## 1. Key finding
 
-**No engine or `matchRunner` changes are required** — but the draft's "no instrumentation required" was
-an overclaim and is corrected here. The harness must wire up two **opt-in, zero-cost-when-omitted**
-callbacks and accumulate the signals itself:
+The harness needs **one small, backward-compatible `matchRunner` signal** — the §6 `onTurn` actor arg,
+**shipped in this PR** — and beyond that only wires up two **opt-in, zero-cost-when-omitted** callbacks
+that it accumulates itself. (The draft's "no instrumentation required" was an overclaim; corrected here.)
 
-- `onTurn(turnNumber, state)` — defined `src/arena/matchRunner.js:213`, fired after every player-turn
-  at `:325`. Source of the territory/dice/board-shape curves.
-- `onStep(step)` — defined `:214`, fired per attack at `:145-159` and at turn-end (STOP) at `:175-190`.
+- `onTurn(turnNumber, state, actingPlayerId)` — defined `src/arena/matchRunner.js:213`, fired after
+  every player-turn at `:330`. Source of the territory/dice/board-shape curves; the third arg
+  (`actingPlayerId`, §6) attributes the turn.
+- `onStep(step)` — defined `:219`, fired per attack at `:145-159` and at turn-end (STOP) at `:175-190`.
   Source of per-turn attack/pass counts.
 
-Both are genuinely free when unset: the per-step hot path only builds steps when a handler exists
-(`stepHandler` is `undefined` unless `recorder || onStep`, `:261-267`; the attack-path `buildStep` is
-gated `if (onStep)` at `:145` and reuses the already-computed observation), and `onTurn` is guarded at
-`:325`. `runArena` does **not** forward `onTurn` (`src/arena/arenaRunner.js:102-109`), so the harness
-drives `runMatch` directly.
+Both callbacks are genuinely free when unset: the per-step hot path only builds steps when a handler
+exists (`stepHandler` is `undefined` unless `recorder || onStep`, `:266-272`; the attack-path
+`buildStep` is gated `if (onStep)` at `:145` and reuses the already-computed observation), and `onTurn`
+is guarded at `:330`. `runArena` does **not** forward `onTurn` (`src/arena/arenaRunner.js:102-109`), so
+the harness drives `runMatch` directly.
 
-**One recommended optional engine change** (§6): extend `onTurn` to
-`onTurn(turnNumber, state, actingPlayerId)`, passing the `currentPlayerId` already computed at
-`matchRunner.js:276`. It is backward-compatible (absent/old callers ignore the extra arg) and resolves
-**three** problems at once — the aggression bias (§2a), kill-attribution without a second replay pass
-(§2c), and clean active-turn counting. Both reviews recommend taking it; this spec adopts it.
+**The §6 engine change (shipped):** `onTurn` now passes `actingPlayerId` — the `currentPlayerId`
+already computed at `matchRunner.js:281`. It is backward-compatible (absent/old 2-arg callers ignore
+the extra arg) and resolves **three** problems at once — the aggression bias (§2a), kill-attribution
+without a second replay pass (§2c), and clean active-turn counting. Both reviews recommended it; it is
+now in the engine (see §6).
 
 ---
 
@@ -64,12 +68,12 @@ _derive-from-replay_ (re-simulate).
 
 | #   | Axis                  | Definition (per game)                                                     | Source            | Key file:line                                                              |
 | --- | --------------------- | ------------------------------------------------------------------------- | ----------------- | -------------------------------------------------------------------------- |
-| a   | **Aggression**        | attacks per _active turn_ = `attacksMade / activeTurns(pi)`               | harness-capture   | `attacksMade` `matchRunner.js:342`; `activeTurns` from `onTurn` actor (§6) |
-| b   | **Territory curve**   | `state.players[pi].territoryCount` sampled each `onTurn`, indexed by turn | harness-capture   | `onTurn` `:325`; `recalcPlayerStats` `StateManager.js:108-116`             |
+| a   | **Aggression**        | attacks per _active turn_ = `attacksMade / activeTurns(pi)`               | harness-capture   | `attacksMade` `matchRunner.js:347`; `activeTurns` from `onTurn` actor (§6) |
+| b   | **Territory curve**   | `state.players[pi].territoryCount` sampled each `onTurn`, indexed by turn | harness-capture   | `onTurn` `:330`; `recalcPlayerStats` `StateManager.js:108-116`             |
 | c   | **Kills / game**      | opponents whose _last_ territory `pi` captured                            | harness-capture\* | elim flip `StateManager.js:122-128`; actor via `onTurn` (§6)               |
-| d   | **Turns-to-win**      | `turnCount` over games `pi` won (unit = **player-turns**, not rounds)     | yes-from-existing | `winner` `:350`, `turnCount` `:352`                                        |
-| e   | **Placement dist.**   | histogram of 1-based `placement`; + `avgPlacement`, `top1/top3`           | yes-from-existing | `placement` `:341`, `calculatePlacements` `:370-390`                       |
-| f   | **Win% vs reference** | FFA win-rate with the reference bot (default `Lookahead`) in the field    | yes-from-existing | `winner` `:350`; CI via `meanCi`; paired via `pairedDelta`                 |
+| d   | **Turns-to-win**      | `turnCount` over games `pi` won (unit = **player-turns**, not rounds)     | yes-from-existing | `winner` `:355`, `turnCount` `:357`                                        |
+| e   | **Placement dist.**   | histogram of 1-based `placement`; + `avgPlacement`, `top1/top3`           | yes-from-existing | `placement` `:346`, `calculatePlacements` `:375-395`                       |
+| f   | **Win% vs reference** | FFA win-rate with the reference bot (default `Lookahead`) in the field    | yes-from-existing | `winner` `:355`; CI via `meanCi`; paired via `pairedDelta`                 |
 
 \* `c` becomes a pure `onTurn` computation with the §6 actor arg; without it, it is _derive-from-replay_
 (a full second simulation per game via `trajectoryFromReplay` `trajectoryExport.js:246`).
@@ -80,13 +84,14 @@ _derive-from-replay_ (re-simulate).
   `phase !== GAME_OVER`; a _winning_ turn returns early at `matchRunner.js:99` and emits **no STOP**.
   So counting active turns as "# STOP steps" undercounts by exactly 1 on every game the bot wins, while
   the winning attacks _are_ counted — inflating aggression **in proportion to win rate**, which differs
-  across personas and would contaminate the comparison. **Fix:** count active turns from `onTurn`
-  firings attributed to `pi` (§6), which include the victory turn; or, if not adopting §6,
-  `activeTurns = stopCount + (result.winner === pi ? 1 : 0)`. Documented in the metric, not silent.
+  across personas and would contaminate the comparison. **Fix (shipped):** count active turns from
+  `onTurn` firings attributed to `pi` (§6 actor arg), which include the victory turn. (The pre-§6
+  alternative, had the engine been left untouched, was `activeTurns = stopCount + (result.winner === pi ? 1 : 0)`
+  — no longer needed.) Documented in the metric, not silent.
 - **(b) k=0 gap.** `onTurn` first fires _after_ turn 1, so there is no initial-board sample. Seed index
   0 from the `createGame` initial state (`GameRunner.js:37-68`) before the loop, or document the curve
   starts at k=1. The JSON example's `t0` is the seeded initial state, not an `onTurn` sample.
-- **(d) unit.** `turnCount` increments once per _player-turn_ (`matchRunner.js:324`), **not** per full
+- **(d) unit.** `turnCount` increments once per _player-turn_ (`matchRunner.js:329`), **not** per full
   round (`state.turnNumber`). A valid, consistent cross-bot axis — but label the unit so "turns" is not
   misread as rounds.
 
@@ -98,9 +103,9 @@ diagnostics:
 
 | #   | Axis                        | Why it discriminates                                                 | Source            | Key file:line                                                   |
 | --- | --------------------------- | -------------------------------------------------------------------- | ----------------- | --------------------------------------------------------------- |
-| g   | **Avg dice reserve**        | the turtle's signature — sits on a big pile                          | harness-capture   | `diceCount` `StateManager.js:112-117`; `finalDice` `:340`       |
+| g   | **Avg dice reserve**        | the turtle's signature — sits on a big pile                          | harness-capture   | `diceCount` `StateManager.js:112-117`; `finalDice` `:345`       |
 | h   | **Dice per territory**      | turtle (dense, high) vs expansionist (thin, low)                     | harness-capture   | same as (g) ÷ (b)                                               |
-| i   | **Capture efficiency**      | `attacksWon/attacksMade` — cautious (high) vs reckless (low)         | yes-from-existing | `attacksWon` `:343`                                             |
+| i   | **Capture efficiency**      | `attacksWon/attacksMade` — cautious (high) vs reckless (low)         | yes-from-existing | `attacksWon` `:348`                                             |
 | j   | **Zero-attack-turn frac.**  | clearest pass-turn / turtle signal                                   | harness-capture   | `onStep` STOP with 0 attacks since last STOP (`:175-190`)       |
 | k   | **Border exposure**         | turtle clusters to shrink frontier vs aggressor                      | harness-capture   | `isBorder` `botState.js:50`, or recompute from `onTurn` state   |
 | l   | **Largest connected group** | "connectivity economics" the Expansionist reward targets             | yes-from-existing | `connectedTerritories` `botState.js:74` / player `largestGroup` |
@@ -114,6 +119,13 @@ territory aspect) `signaturePass` actually computable.
 
 **Dropped as redundant:** `attacksPerGame` as a separate paired axis — it is ≈ aggression × mean active
 turns and adds nothing over the turn-normalized axis. Derive on demand if ever needed.
+
+> **Shipped in Phase 1 (vs this design list):** `behavior-core.mjs`'s `AXES` implements g
+> (`avgDiceReserve`), h (`dicePerTerritory`), i (`captureEfficiency`), j (`zeroAttackTurnFrac`), l
+> (`largestGroup`), m (`survivalTurn`), plus the core a/d/e/f and `avgTerritory` (the scalar reduction
+> of (b) that stands in for the territory AUC (n)). **Not yet implemented:** the full territory _curve_,
+> a separate `territoryAuc`, and **(k) border exposure** — these are Phase-2 / future axes, not part of
+> the shipped profiler.
 
 ---
 
@@ -193,17 +205,21 @@ and assert no internal RNG — enforce in the persona loader, not just the smoke
 Dropping games where the profiled bot hit `maxMovesHit` removes its _most aggressive_ turns (100 attacks
 in one turn) → biases aggression **down**; and an opponent's forced-end distorts the game but isn't
 caught if you only check the profiled seat. **Policy:** quarantine on **any** seat's forced-end counters
-(`errors|invalidMoves|maxMovesHit > 0`, D-14, `matchRunner.js:344-346`), **report the quarantine rate
-per persona**, and emit profiles **both with and without** quarantine so a systematic shift is visible,
-not silent.
+(`errors|invalidMoves|maxMovesHit > 0`, D-14, `matchRunner.js:349-351`), **report the quarantine rate
+per persona** (shipped: `config.quarantine.ratePerBot` + a per-bot terminal warning when a bot's sample
+is reduced or fully gutted). **Phase 2 / TODO:** emit profiles **both with and without** quarantine in
+one run so a systematic shift is visible; today use the `--no-quarantine` flag for the unfiltered pass.
 
 ### 3.8 Training-field match (fixed-field-exploitation guard)
 
 Per the task-A caveat, a persona trained at a given `playerCount`/`maxAreas`/`dicePerArea` can look
 artificially strong or distinct if profiled at a _different_ field size. **Record those three with each
 persona's weights and have the harness ASSERT the profiling field equals the training field — hard error
-on mismatch**, not an open question. (Also fix the draft's 7-vs-8 inconsistency: the example field is 5
-opponents + 1 reference + 1 profiled = 7 seats = `DEFAULT_PLAYER_COUNT`; the "N=8" note was wrong.)
+on mismatch**, not an open question. (Field-size model, as shipped: the **reference is one of the
+`--opponents`**, not a separate seat — `fieldSize = opponents.length + 1` (the +1 is the profiled seat).
+So a 7-seat field = `DEFAULT_PLAYER_COUNT` means **6 opponents (the reference among them) + 1 profiled**.
+The shipped _default_ `--opponents` list has 5 entries → a 6-seat field; pass 6 opponents to profile at
+the full 7.)
 
 ---
 
@@ -219,70 +235,79 @@ Two files, mirroring the `ppo-gate.mjs` (CLI) / `ppo-gate-core.mjs` (pure, unit-
 
 Lives under `scripts/` (offline analysis CLI like `arena-sweep.mjs`), not `src/`.
 
-### Public API (`behavior-core.mjs`)
+### Public API (`behavior-core.mjs`) — as shipped
 
 ```
+// Build the per-game accumulator + the onTurn/onStep handlers to wire into runMatch.
+makeCapture(playerIndex) -> { capture, onTurn, onStep }
+
 // Per-game extraction. `capture` carries the onTurn/onStep-accumulated arrays for THIS game.
-profileGameFromCapture(matchResult, playerIndex, capture) -> GameProfile
-//   GameProfile: { aggression, territoryCurve[], territoryAuc, kills, won, turnsToWin|null,
-//                  placement, avgDiceReserve, dicePerTerritory, captureEfficiency,
-//                  zeroAttackTurnFrac, borderExposure, largestGroup, survivalTurn }
+profileGameFromCapture(result, playerIndex, capture) -> GameProfile   // throws on a misaligned capture
+//   GameProfile: { won, placement, turnsToWin|null, attacksMade, aggression|null,
+//                  captureEfficiency|null, avgDiceReserve|null, avgTerritory|null,
+//                  dicePerTerritory|null, largestGroup|null, kills, survivalTurn,
+//                  zeroAttackTurnFrac|null }   // null = no qualifying turn/attack this game (≠ 0)
 
-aggregateRuns(perRunValues[]) -> { mean, ci }          // thin wrapper over meanCi
-aggregateCurves(perRunCurves[][]) -> { turns[], mean[], ci[] }   // aligned, padded (§2 b)
+reduceRun(profiles[]) -> Record<axis, number|null>      // one scalar per AXES key per run
+summarizeAxis(perRunValues[]) -> { mean, ci, n } | null // mean ± 95% CI; n = RUN count (§3.1)
+alignDropNull(a[], b[]) -> { a[], b[], n }              // drop indices null on either side (§3.4)
+compareAxis(personaRuns[], controlRuns[]) -> { delta, ci, lo, hi, verdict, n } | null  // paired Δ
+compareToControl(personaRuns[], controlRuns[]) -> Record<axis, compareAxis-result | null>
+signaturePass(signature, vsControl, mde) -> boolean     // §3.2 MDE AND CI-excludes-0; THROWS w/o MDE
 
-compareToControl(personaRuns, controlRuns, signature) -> {
-  perAxis: { <axis>: { delta, ci, lo, hi, verdict } },  // verdict = classifyGate (HIGHER/SAME/LOWER)
-  signaturePass: boolean                                // §3.2 MDE AND CI-excludes-0, §3.3 Holm-adjusted
-}
-separationMatrix(allPersonaRuns) -> { /* persona×persona pairedDelta, §3.5 melee mode */ }
-
-PERSONA_SIGNATURES  // persona -> { axis | axes[], direction, rule:'AND'|'single', mde }
+AXES                // the canonical axis-key list (single source of truth)
+PERSONA_SIGNATURES  // persona -> { axes: [{ axis, direction }], rule: 'AND'|'single' }   (Phase-2 stub)
+DEFAULT_MDE         // partial Record<axis, number>; a signature axis MUST have an entry (else throws)
 ```
 
-`profileGameFromCapture` derives (d/e/i) from `matchResult` directly and (a/b/c/g–n) from `capture`. The
-terminal-stat math (`wins`, `avgPlacement`, `attackWinRate`) should be a **shared helper extracted from
-`arenaRunner.js:130-168`**, not re-implemented (the one duplication the review flagged).
+> **Not yet built (Phase 2 / future):** `aggregateCurves` (territory _curve_ alignment/padding),
+> `separationMatrix` (§3.5 persona×persona melee), Holm adjustment across the 5 confirmatory tests, and
+> the `--melee`/`--csv` CLI modes. The shipped `summarizeAxis` is the `aggregateRuns` thin-`meanCi`
+> wrapper the draft named. The terminal-stat math (`avgPlacement`, win%, capture-efficiency) is computed
+> in `behavior-core.mjs` directly; extracting a shared helper from `arenaRunner.js:130-168` remains a
+> **TODO** (the one duplication the review flagged).
 
 ### CLI
 
 ```
 node scripts/behavior-profile.mjs \
   --bots PPO,Blitz,Expansionist,Predator,Survivor \   # profiled seats (Phase 2)
-  --reference Lookahead \                              # win%-vs-ref; present in every field
-  --opponents Default,Defensive,Strategist,Adaptive,Expectimax \  # fixed FFA filler (identical for all)
+  --opponents Default,Defensive,Strategist,Adaptive,Expectimax,Lookahead \  # fixed FFA filler; MUST include the reference
+  --reference Lookahead \                              # win%-vs-ref; one of --opponents (fills a seat in every field)
   --control Conqueror \                               # auto-injected into the profiled set if absent
   --runs 20 --games 150 \                             # CALIBRATE via §3.2 pilot, don't hard-code
-  --melee \                                           # optional §3.5 persona×persona mode
-  --no-quarantine \                                   # emit unfiltered too (§3.7)
+  --no-quarantine \                                   # run a second, unfiltered pass (§3.7)
   --json                                              # JSON->stdout, human table->stderr
+  # --melee (§3.5 persona×persona) is NOT yet implemented — Phase 2.
 ```
+
+Above is a 7-seat field (6 opponents incl. the reference + 1 profiled seat). The reference **must** be
+one of `--opponents` or the CLI exits with an error.
 
 The **control is always profiled** with identical run/game/rotation config (auto-injected if not in
 `--bots`); assert `controlRuns.length === personaRuns.length` before `pairedDelta`.
 
 ### Sweep execution (per profiled bot, fixed field)
 
-1. Field = `rotatedField([...opponents, reference, bot], r)` (`ppo-gate-core.mjs:127-132`); reuse
-   `buildGateField`'s present/collision guardrails (`:103-112`) for the reference-in-field +
-   name-collision checks rather than re-deriving them.
+1. Field = `rotatedField([bot, ...opponents], r)` (`ppo-gate-core.mjs:127-132`) — the profiled bot is
+   field[0] and rotation `r` seats it at `r`; the reference is one of `--opponents`. The CLI's own
+   validation enforces the reference-in-field + name-collision invariants up front (the `buildGateField`
+   guardrails at `:103-112` are the equivalent for `ppo:gate`).
 2. `STRIDE = Math.max(1_000_000, games*1000)` (`arena-sweep.mjs:45`); run `r` uses seeds
    `r*STRIDE+1 … +games`, each replayed through all N seat rotations (the `ppo-gate.mjs` seat-fair
    architecture).
-3. `runMatch({ bots, seed, recordTrajectory:false, onTurn, onStep })` with a fresh per-game `capture`:
+3. `runMatch({ bots, seed, onTurn, onStep })` with a fresh per-game capture from `makeCapture(pi)`:
    ```
-   const cap = { terr: [], dice: [], attacks: 0, stops: 0, zeroTurns: 0, sinceStop: 0, killTurns: [], elimAt: {} };
-   onTurn: (t, s, actor) => {                    // actor via §6
-     cap.terr.push(s.players[pi].territoryCount);
-     cap.dice.push(s.players[pi].diceCount);      // copy scalars NOW — never retain s (it mutates)
-     if (actor === pi) cap.activeTurns = (cap.activeTurns ?? 0) + 1;
-     /* diff eliminated set vs last turn; if actor===pi credit a kill */
-   };
-   onStep: (step) => { if (step.playerId !== pi) return;
-     if (isStopMove(step.chosenMove)) { if (cap.sinceStop === 0) cap.zeroTurns++; cap.sinceStop = 0; }
-     else cap.sinceStop++; };
+   const { capture, onTurn, onStep } = makeCapture(pi);  // see behavior-core.mjs for the real impl
+   // onTurn(t, s, actor): on the profiled bot's own turns push s.players[pi]'s scalars
+   //   (territoryCount/diceCount/largestGroup) and bump activeTurns; diff the eliminated set and, if
+   //   actor === pi, credit a kill. Copy scalars per turn — don't retain `s` across turns (each turn
+   //   is a fresh cloned state, so retaining N of them just pins memory; the engine never mutates a
+   //   prior turn's state in place).
+   // onStep(step): for the profiled seat, count a zero-attack (pass) turn when a STOP arrives with no
+   //   intervening attack.
    ```
-4. `profileGameFromCapture(result, pi, cap)`; quarantine per §3.7.
+4. `profileGameFromCapture(result, pi, capture)`; quarantine per §3.7.
 5. Reduce the block to per-run scalars; push to `perRun[bot][axis]`.
 
 ---
@@ -291,10 +316,10 @@ The **control is always profiled** with identical run/game/rotation config (auto
 
 | Function                                 | File:line                                             | Use                                        |
 | ---------------------------------------- | ----------------------------------------------------- | ------------------------------------------ |
-| `runMatch` + `onTurn`/`onStep`           | `matchRunner.js:224-361` (cb `:213/:214`)             | run each game, stream board + step signals |
-| `botStats`                               | `matchRunner.js:336-347`                              | (a num),(d),(e),(g),(i), quarantine        |
-| `MatchResult` winner/turnCount           | `matchRunner.js:350/:352`                             | (d),(f)                                    |
-| `calculatePlacements`                    | `matchRunner.js:370-390`                              | placement ranks (already applied)          |
+| `runMatch` + `onTurn`/`onStep`           | `matchRunner.js:229-366` (cb `:213/:219`)             | run each game, stream board + step signals |
+| `botStats`                               | `matchRunner.js:341-352`                              | (a num),(d),(e),(g),(i), quarantine        |
+| `MatchResult` winner/turnCount           | `matchRunner.js:355/:357`                             | (d),(f)                                    |
+| `calculatePlacements`                    | `matchRunner.js:375-395`                              | placement ranks (already applied)          |
 | `recalcPlayerStats`                      | `StateManager.js:108-117`                             | territoryCount (b), diceCount (g)          |
 | `applyAction`                            | `StateManager.js:161-173`                             | replay re-sim (kills fallback)             |
 | `trajectoryFromReplay` / `replayToState` | `trajectoryExport.js:246` / `replayFormat.js:198-208` | kill-attribution fallback (no §6)          |
@@ -310,15 +335,16 @@ The **control is always profiled** with identical run/game/rotation config (auto
 
 ---
 
-## 6. The one recommended engine change (backward-compatible)
+## 6. The engine change (backward-compatible) — SHIPPED in this PR
 
-Extend `onTurn`'s firing at `matchRunner.js:325` to pass the acting player:
+`onTurn`'s firing at `matchRunner.js:330` now passes the acting player:
 
 ```
-onTurn?.(turnCount, state, currentPlayerId);   // currentPlayerId already computed at :276
+if (onTurn) onTurn(turnCount, state, currentPlayerId);   // currentPlayerId already computed at :281
 ```
 
-Old/absent callers ignore the third arg; `runArena` passes no `onTurn`, so nothing else changes. This:
+Old/absent 2-arg callers ignore the third arg; `runArena` passes no `onTurn`, and the only other
+`runMatch` `onTurn` consumer (`scripts/lib/ppo-env.mjs`) is 2-arg — so nothing else changes. This:
 
 1. **Fixes the aggression bias (§2a)** — active turns counted from `onTurn` firings where
    `actor === pi`, which include the victory turn.
@@ -327,13 +353,18 @@ Old/absent callers ignore the third arg; `runArena` passes no `onTurn`, so nothi
    runs×games×N×rotations scale.
 3. Makes both O(1) and live.
 
-Both reviews recommend taking it; keep replay-based kills as a cross-check in a test.
+Both reviews recommended it; it is now in the engine. (A replay-based kill cross-check remains a
+worthwhile future test.)
 
 ---
 
 ## 7. Output format
 
-`--json` → stdout (machine), human table → stderr (`_tune.mjs:130-142`). Shape (abbreviated):
+`--json` → stdout (machine), human table → stderr. Shape below is the **full Phase-2 target**
+(abbreviated); the **shipped Phase-1 JSON** carries only the `AXES` metrics + per-axis `vsControl`
+(each `{ delta, ci, lo, hi, verdict, n }`), `config.quarantine.ratePerBot`, and a per-bot `liveRuns`
+count — it does **not** yet emit `territoryCurve`, `territoryAuc`, `borderExposure`, `placementHist`, or
+the `separationMatrix`/`signature` blocks. (`winPctVsRef` ships as the `winPct` axis.)
 
 ```jsonc
 {
@@ -479,8 +510,7 @@ Most review findings are settled above. These are the genuine judgment calls:
 2. **MDE values (§3.2):** the per-axis "behaviorally meaningful" thresholds are a product call, not a
    code one. Placeholders are in §3.2; we calibrate against a pilot once a persona exists — but the
    _direction_ (e.g. "1 extra attack/turn is meaningful, 0.1 isn't") is yours.
-3. **§6 engine one-liner:** adopt it (recommended — fixes the bias + kills in one backward-compatible
-   line), or keep the engine untouched and pay the replay pass + the explicit `+1` aggression
-   correction?
+3. **~~§6 engine one-liner~~ — RESOLVED:** adopted and shipped in this PR (`onTurn` now passes
+   `actingPlayerId`); the bias + kill attribution are handled live, no replay pass needed.
 4. **Budget:** runs vs games split is driven by the pilot's between-run SD (§3.1). No fixed number until
    then — flagging so 20×150 isn't mistaken for a decision.

--- a/docs/ml-bot/EVAL_HARNESS.md
+++ b/docs/ml-bot/EVAL_HARNESS.md
@@ -122,7 +122,7 @@ turns and adds nothing over the turn-normalized axis. Derive on demand if ever n
 
 > **Shipped in Phase 1 (vs this design list):** `behavior-core.mjs`'s `AXES` implements g
 > (`avgDiceReserve`), h (`dicePerTerritory`), i (`captureEfficiency`), j (`zeroAttackTurnFrac`), l
-> (`largestGroup`), m (`survivalTurn`), plus the core a/d/e/f and `avgTerritory` (the scalar reduction
+> (`largestGroup`), m (`survivalTurn`), plus the core a/c/d/e/f (incl. c `kills`) and `avgTerritory` (the scalar reduction
 > of (b) that stands in for the territory AUC (n)). **Not yet implemented:** the full territory _curve_,
 > a separate `territoryAuc`, and **(k) border exposure** — these are Phase-2 / future axes, not part of
 > the shipped profiler.
@@ -314,24 +314,24 @@ The **control is always profiled** with identical run/game/rotation config (auto
 
 ## 5. Reused utilities (exact)
 
-| Function                                 | File:line                                             | Use                                        |
-| ---------------------------------------- | ----------------------------------------------------- | ------------------------------------------ |
-| `runMatch` + `onTurn`/`onStep`           | `matchRunner.js:229-366` (cb `:213/:219`)             | run each game, stream board + step signals |
-| `botStats`                               | `matchRunner.js:341-352`                              | (a num),(d),(e),(g),(i), quarantine        |
-| `MatchResult` winner/turnCount           | `matchRunner.js:355/:357`                             | (d),(f)                                    |
-| `calculatePlacements`                    | `matchRunner.js:375-395`                              | placement ranks (already applied)          |
-| `recalcPlayerStats`                      | `StateManager.js:108-117`                             | territoryCount (b), diceCount (g)          |
-| `applyAction`                            | `StateManager.js:161-173`                             | replay re-sim (kills fallback)             |
-| `trajectoryFromReplay` / `replayToState` | `trajectoryExport.js:246` / `replayFormat.js:198-208` | kill-attribution fallback (no §6)          |
-| `isStopMove` / `buildStep`               | `trajectoryExport.js:61` / `:129-140`                 | ATTACK vs STOP in `onStep`                 |
-| `botState` isBorder/connected            | `botState.js:50` / `:74`                              | (k) border, (l) largest group              |
-| `meanCi` / `tCrit` / `mean`              | `stats.mjs:60-66 / :50 / :53`                         | mean ± 95% CI — **CI math reused**         |
-| `pairedDelta` / `classifyGate`           | `ppo-gate-core.mjs:31-41 / :53-57`                    | paired Δ + HIGHER/SAME/LOWER               |
-| `rotatedField` / `buildGateField`        | `ppo-gate-core.mjs:127-132 / :103-112`                | seat fairness, field guardrails            |
-| arenaRunner accumulators                 | `arenaRunner.js:130-168`                              | **extract** shared terminal-stat helper    |
-| `BUILT_IN_BOTS`                          | `builtInBots.js:21`                                   | built-in enumeration (`ai_ppo` `:44`)      |
-| `resolveBot`/`loadBot`/`getArg`          | `cli-utils.mjs:49/:37`, `cli-args.mjs:25`             | file/weight bots + arg parsing             |
-| JSON-stdout / table-stderr               | `_tune.mjs:130-142`                                   | dual output                                |
+| Function                                 | File:line                                             | Use                                                                                     |
+| ---------------------------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `runMatch` + `onTurn`/`onStep`           | `matchRunner.js:229-366` (cb `:213/:219`)             | run each game, stream board + step signals                                              |
+| `botStats`                               | `matchRunner.js:341-352`                              | (a num),(d),(e),(g),(i), quarantine                                                     |
+| `MatchResult` winner/turnCount           | `matchRunner.js:355/:357`                             | (d),(f)                                                                                 |
+| `calculatePlacements`                    | `matchRunner.js:375-395`                              | placement ranks (already applied)                                                       |
+| `recalcPlayerStats`                      | `StateManager.js:108-117`                             | territoryCount (b), diceCount (g)                                                       |
+| `applyAction`                            | `StateManager.js:161-173`                             | replay re-sim (kills fallback)                                                          |
+| `trajectoryFromReplay` / `replayToState` | `trajectoryExport.js:246` / `replayFormat.js:198-208` | kill-attribution fallback (no §6)                                                       |
+| `isStopMove` / `buildStep`               | `trajectoryExport.js:61` / `:129-140`                 | ATTACK vs STOP in `onStep`                                                              |
+| `botState` isBorder/connected            | `botState.js:50` / `:74`                              | (k) border, (l) largest group                                                           |
+| `meanCi` / `tCrit` / `mean`              | `stats.mjs:60-66 / :50 / :53`                         | mean ± 95% CI — **CI math reused**                                                      |
+| `pairedDelta` / `classifyGate`           | `ppo-gate-core.mjs:31-41 / :53-57`                    | paired Δ + HIGHER/SAME/LOWER                                                            |
+| `rotatedField` / `buildGateField`        | `ppo-gate-core.mjs:127-132 / :103-112`                | seat fairness, field guardrails                                                         |
+| arenaRunner accumulators                 | `arenaRunner.js:130-168`                              | **extract** shared terminal-stat helper                                                 |
+| `BUILT_IN_BOTS`                          | `builtInBots.js:21`                                   | built-in enumeration (`ai_ppo` `:44`)                                                   |
+| `resolveBot`/`loadBot`/`getArg`          | `cli-utils.mjs:49/:37`, `cli-args.mjs:25`             | arg parsing (`getArg`/`hasFlag`) now; `resolveBot`/`loadBot` = Phase-2 weight-file bots |
+| JSON-stdout / table-stderr               | `_tune.mjs:130-142`                                   | dual output                                                                             |
 
 ---
 

--- a/docs/ml-bot/PERSONAS.md
+++ b/docs/ml-bot/PERSONAS.md
@@ -168,9 +168,11 @@ There are two ways to say "win fast":
 So Ivan's multiplicative framing is exactly the _safe_ formulation. **Recommended Blitz config:**
 lower `gamma` first (0.99, maybe 0.97); if that isn't punchy enough, add a small **bounded**
 terminal speed-bonus `reward = won × (1 + b·clip(1 − turns/T_ref, 0, 1))` with `b` modest (e.g.
-0.5) so it never dominates the win/loss ordering. **Secondary knob:** `ent_coef` (default 0.01) —
-more entropy = more exploration = less likely to settle into the safe turtle; bump it for Blitz,
-but it's a training-dynamics knob, not a reward, so tune it second.
+0.5) so it never dominates the win/loss ordering. **Secondary knob:** `ent_coef` — the applicable
+default for the **warm-started** personas is **0.0** (`_train_common.py:153`; `0.01` is only the
+_from-scratch_ fallback at `:340`). More entropy = more exploration = less likely to settle into the
+safe turtle; bump it (e.g. toward `0.01`) for Blitz, but it's a training-dynamics knob, not a reward,
+so tune it second.
 
 **The tradeoff to measure, not assume.** The turtle is (as Ivan said) probably win%-optimal. Tempo
 pressure **trades win% for speed/aggression** — a Blitz might win 38% fast vs Conqueror 45% slow.
@@ -219,8 +221,9 @@ artifact that makes the roster credible. **The full grounded spec is now
 zero-attack-turn fraction, border exposure), the statistical rigor (MDE/power so "distinct" can't fire
 on a trivial difference; one pre-registered signature per persona with Holm), and the build plan
 (Phase 1 = harness + tests on existing built-ins; Phase 2 = profile the personas once trained). It
-reuses the existing `meanCi`/`pairedDelta`/`rotatedField` machinery and needs **no engine changes**
-(one optional backward-compatible `onTurn` arg recommended).
+reuses the existing `meanCi`/`pairedDelta`/`rotatedField` machinery and needs only **one small,
+backward-compatible engine signal** — the `onTurn` actor arg — which **shipped with the Phase-1
+harness** (see EVAL_HARNESS §6).
 
 **On "plays better / more fun against humans" — be honest about what's trainable.** Self-play
 optimizes against _bots_; humans blunder differently, and we have **no human game logs at scale**

--- a/docs/ml-bot/PERSONAS.md
+++ b/docs/ml-bot/PERSONAS.md
@@ -1,0 +1,255 @@
+# Reward-Shaped Personality Roster — design note (parked)
+
+> **Status:** Parked design note — **not yet executable.** Drafted 2026-06-28 while the
+> first true long run (`ppo-long`, 20M, BC-warm-start) is training on shodan. **Nothing here
+> touches that job.** This is the queued payload for the concurrent-run scaffolding Ivan wants
+> to build _after_ `ppo-long` finishes, exports, and gates.
+>
+> **Relationship to existing decisions:** [D-19](./DECISIONS.md#d-19) chose **sparse terminal-win
+> reward first**, with _"shaping only if too slow; placement = the ELO trap."_ This note is the
+> deferred shaping work — but reframed: not to make the gate bot stronger, to make a **roster of
+> equally-trained bots with deliberately different play styles**, some of which are _supposed_ to
+> sacrifice win% for character. New decisions this implies are flagged `D-27?` etc. (next free
+> number after D-26) and should be promoted to `DECISIONS.md` if/when accepted.
+
+---
+
+## 1. Thesis
+
+Reward shaping produces behaviorally distinct policies — that is its entire purpose in RL. The
+goal here is a **roster of bots that are all well-trained but play with different tendencies**:
+an expansionist that grabs land, a predator that hunts eliminations, a blitzer that wins fast, a
+survivor that plays for placement. Value to the project:
+
+- **Playability / fun.** Ivan's playtesting observation: today's PPO bot **turtles early —
+  builds a dice reserve, then attacks.** Probably win%-optimal; not exciting to play against. A
+  personality roster gives humans varied, characterful opponents.
+- **Exploration insurance.** A shaped reward is also a different _exploration prior_. One persona
+  might escape a local optimum the sparse reward gets stuck in, then transfer — i.e. a personality
+  could, surprisingly, **out-win** the pure-wins bot. Don't bet on it, but watch for it.
+- **Cheap.** Established earlier this session: runs are **serial-PPO-latency-bound** with idle
+  CPU/GPU/RAM on shodan. 3–5 personas run **concurrently for ≈ the cost of one** — the natural
+  first use of the concurrent-run harness.
+
+### The one non-obvious constraint
+
+**In DiceWars, the win condition _is_ owning all territory.** So "maximize territory" and "win"
+are nearly the same objective — a naive territory reward will converge to almost the same policy
+as pure-wins and yield **no personality.** Personalities only emerge **where the reward diverges
+from winning.** Every persona below is designed around a deliberate divergence; the lever is
+almost always one of:
+
+- **dense vs. terminal** — reward _during_ the game (each turn) vs. only at the end. Dense rewards
+  buy myopia (act now), which is most of what "aggressive" means.
+- **net vs. gross** — reward net change, never gross gains (gross invites ping-pong reward-hacking).
+- **multiplicative-time vs. additive-penalty** — both create "win fast"; only one is safe (§6).
+
+---
+
+## 2. Where the reward lives (implementation surface)
+
+The reward is **one line**:
+
+```python
+# ml/dicewars_ppo/env.py:205
+reward = float(frame.won)   # +1 if learner won, else 0  (sparse terminal-win, D-19)
+```
+
+The wire protocol (`ml/dicewars_ppo/wire.py`, `src/arena/trajectoryExport.js`) **already carries
+more terminal signal than the reward uses**:
+
+| Signal                                      | On the wire today?                   | Cost to use as reward                                                         |
+| ------------------------------------------- | ------------------------------------ | ----------------------------------------------------------------------------- |
+| `won` (1/0)                                 | ✅ (used)                            | —                                                                             |
+| `winner` (seat/-1)                          | ✅                                   | free                                                                          |
+| `placement` (1=1st…0=last, range-validated) | ✅ (unused)                          | **free** — Survivor persona                                                   |
+| `truncated` (stalemate cap)                 | ✅                                   | free                                                                          |
+| game `turnCount`                            | ✅ (`finalize()`, JS side)           | cheap — Blitz terminal speed-bonus                                            |
+| Δterritory / turn                           | ❌                                   | small: env-server emits a per-frame scalar → wire/header field + version bump |
+| elimination event                           | ❌ (derivable from placement deltas) | small, same as above                                                          |
+
+So **placement-, tempo-, and turn-count-based personas are essentially free** (signal already
+plumbed + a `--gamma` flag). Dense-territory and elimination-bounty personas need the **JS
+env-server to emit a per-frame scalar** — a wire/header addition carrying the same discipline as
+the encoding contract (bump a version constant; JS emitter and Python consumer change in one commit).
+
+---
+
+## 3. Two independent design axes — do not co-vary
+
+1. **Reward objective** (this note's focus): what the +signal rewards.
+2. **Opponent field**: who the learner trains against.
+
+Keep them orthogonal. **Phase-3 is _already_ self-play** — a PFSP league of past snapshots +
+heterogeneous baselines (B0–B6, [D-19]+ task B). "Pure self-play" (only past selves, no
+hand-coded baselines) is a _separate_ experiment on axis 2: it tends to produce
+internally-consistent-but-exploitable strategies and can collapse without diversity — the league
+exists precisely to prevent that. **Change reward XOR opponent field per run, never both**, or you
+can't attribute the behavioral difference. This note holds axis 2 fixed at the current league.
+
+---
+
+## 4. The roster
+
+| Persona           | Reward change                               | Expected tendency                  | Diverges from win via                   | Impl cost          | Gate expectation          |
+| ----------------- | ------------------------------------------- | ---------------------------------- | --------------------------------------- | ------------------ | ------------------------- |
+| **Conqueror**     | `frame.won` (today)                         | Balanced; turtle→strike            | — (control)                             | none               | the bar (pure-wins)       |
+| **Blitz / Tempo** | lower `gamma` (+ opt. terminal speed-bonus) | Fast, aggressive, early pressure   | multiplicative-time                     | **free** (flag)    | likely **below** bar; fun |
+| **Expansionist**  | dense Δ(net territory)/turn                 | Grabs land now; overextends        | dense + net                             | small (wire field) | below bar                 |
+| **Predator**      | bounty per player eliminated                | Hunts kills; takes risky finishers | dense + net                             | small (wire field) | below/near bar            |
+| **Survivor**      | `placement` instead of binary win           | Conservative; plays for 2nd/3rd    | rank ≠ win (the "ELO trap", repurposed) | **free** (on wire) | high ELO, lower win%      |
+
+### Conqueror (control)
+
+Today's reward, re-run from the same warm-start as the others. **Required** as the baseline the
+behavioral metrics (§7) are measured _against_ — "the predator eliminates 1.8× more players than
+the conqueror" only means something with a matched control.
+
+### Blitz / Tempo — Ivan's idea, and the most promising "fun" bot
+
+The intuition: scale the win reward _down_ by game length so a 1-turn win is worth far more than a
+1000-turn win, coaxing aggression. **This is principled** — see §6 for the full treatment. Short
+version: the current `gamma=0.999` is _why_ the bot turtles (a slow win is worth ~82% of a fast one
+— almost no tempo pressure), so the cleanest first cut is **just lower gamma** (e.g. 0.99 → a
+200-turn win worth ~13% of an instant win). Optional escalation: an explicit bounded terminal
+speed-bonus keyed on `turnCount`. Foregrounded because it directly targets the turtle Ivan saw and
+costs zero new code.
+
+### Expansionist
+
+Dense reward of **net** territory gained each turn (never gross — §5). Buys myopia: grab land
+_now_, even when consolidating is the higher-win% play. The terminal-only version of this collapses
+back into Conqueror (territory-at-end ≈ winning), so the **dense** framing is load-bearing.
+
+### Predator
+
+A bounty each time the learner removes a player from the board. Pushes the bot to **take the kill**
+even when it's risk-suboptimal for winning — the "aggressive, eliminates more players" bot Ivan
+described. Derivable from placement deltas without a new territory field.
+
+### Survivor — the "ELO trap" as a feature
+
+[D-19] explicitly avoided placement reward for the gate bot, calling it **"the ELO trap"**:
+optimizing rank rather than the win produces a bot that plays for 2nd/3rd instead of going for 1st
+— great ELO, mediocre win%. For a _personality_ bot that conservative, survive-don't-conquer style
+**is the deliverable.** Costs nothing — `placement` is already on the wire.
+
+---
+
+## 5. The tempo lever in depth (Blitz)
+
+Ivan's framing: _"win in 1 turn → 1000 points; win in 1000 turns → 1 point."_ That's a
+**multiplicative terminal time-bonus**, and it's the sharper cousin of the discount factor `gamma`,
+which the trainer already exposes as `--gamma` (default **0.999**, `_train_common.py:149`).
+
+**Why gamma is the principled lever.** With sparse `+1` terminal-win and discount `γ`, the value of
+a state that wins in `T` steps is `γ^T · P(win)`. So `γ` _is_ a smooth "win fast" multiplier:
+
+| γ     | value of a 200-turn win (vs instant) | tempo pressure                        |
+| ----- | ------------------------------------ | ------------------------------------- |
+| 0.999 | 0.999²⁰⁰ ≈ **0.82**                  | almost none — **why the bot turtles** |
+| 0.99  | 0.99²⁰⁰ ≈ **0.13**                   | strong                                |
+| 0.97  | 0.97²⁰⁰ ≈ **0.002**                  | extreme (likely reckless)             |
+
+Lowering `γ` is the textbook way to induce "reach the goal quickly," is **lower-variance** than a
+big explicit multiplier (the discount is baked into every bootstrap step, not dumped on one terminal
+frame), and is a **zero-code-change** starting point.
+
+**The safety insight — multiplicative beats additive, and Ivan's intuition is the safe one.**
+There are two ways to say "win fast":
+
+- **Multiplicative** (gamma, or Ivan's decay-multiplier): a win is `positive × decay > 0`; a loss
+  is `0`. **A win can never be worth less than a loss.** Induces "win FAST" but **never "lose
+  fast."** ✅
+- **Additive per-step penalty** (`−c` each turn): a long win is `1 − c·T`, which for large `c·T`
+  drops **below** an immediate loss's `0`. A mistuned penalty makes the bot **throw games to end
+  them** — suicidal. ⚠️
+
+So Ivan's multiplicative framing is exactly the _safe_ formulation. **Recommended Blitz config:**
+lower `gamma` first (0.99, maybe 0.97); if that isn't punchy enough, add a small **bounded**
+terminal speed-bonus `reward = won × (1 + b·clip(1 − turns/T_ref, 0, 1))` with `b` modest (e.g.
+0.5) so it never dominates the win/loss ordering. **Secondary knob:** `ent_coef` (default 0.01) —
+more entropy = more exploration = less likely to settle into the safe turtle; bump it for Blitz,
+but it's a training-dynamics knob, not a reward, so tune it second.
+
+**The tradeoff to measure, not assume.** The turtle is (as Ivan said) probably win%-optimal. Tempo
+pressure **trades win% for speed/aggression** — a Blitz might win 38% fast vs Conqueror 45% slow.
+That's _fine for a personality bot_, but §7's `avg turns-to-win` and aggression index must
+**quantify** the shift so we know we bought aggression and how much win% it cost.
+
+---
+
+## 6. Reward-hacking & failure modes (design against these up front)
+
+- **Gross-territory ping-pong.** Rewarding _gross_ territory gained lets the agent farm the signal
+  by capturing-then-losing a border tile repeatedly. **Mitigation:** reward **net** territory only.
+  (Potential-based shaping à la Ng et al. 1999 removes hacking but _provably preserves the original
+  optimum_ — i.e. it gives you Conqueror faster, not a new personality. We deliberately do **not**
+  use it for the persona reward; we accept a moved optimum and guard the hack manually.)
+- **Additive-penalty suicide.** See §5 — keep tempo pressure **multiplicative**, never a large
+  additive step cost.
+- **Predator over-commitment.** An elimination bounty too large makes the bot take losing fights for
+  a kill. **Mitigation:** bounty small relative to the terminal win; cap per-turn.
+- **Survivor passivity / kingmaking.** Placement reward can produce a do-nothing bot that coasts to
+  a non-last finish, or one that hands the win to whoever it last attacked. **Mitigation:** accept
+  it as the persona's character, but floor it (a turtle-floor analog) so it still plays.
+- **Encoding/contract skew.** Any new per-frame reward scalar (territory, elims) rides the JS↔Python
+  wire — JS emitter and Python consumer **must change in one commit** with a version bump, same rule
+  as `ENCODING_VERSION` (CLAUDE.md gotcha). A silent mismatch poisons the replay buffer.
+
+---
+
+## 7. Evaluation — behavioral harness, not just the gate
+
+The current gate is **one number**: win% vs `ai_lookahead`. That can't tell you a personality
+_emerged_. We need a **behavioral profile** per bot — and the arena **already records the inputs**
+(`attacksMade`, `placements`, `turnCount` in the match/bot stats):
+
+- **Aggression index** — attacks attempted per turn (or per owned territory).
+- **Territory-over-time curve** — mean owned-territory trajectory across a game.
+- **Elimination count** — players removed by this bot per game.
+- **Avg turns-to-win** — the tempo metric; the Blitz headline.
+- **Placement distribution** — Survivor's signature (rarely 1st, rarely last).
+
+Deliverable: a small harness that runs each persona across a seed sweep and emits this profile, so
+claims are **measured** ("predator eliminates 1.8× the conqueror's rate"), not vibes. This is the
+artifact that makes the roster credible. **The full grounded spec is now
+[EVAL_HARNESS.md](./EVAL_HARNESS.md)** — it adds the metrics this short list omits (most importantly
+**avg dice reserve / dice-per-territory**, the literal turtle signature; plus capture efficiency,
+zero-attack-turn fraction, border exposure), the statistical rigor (MDE/power so "distinct" can't fire
+on a trivial difference; one pre-registered signature per persona with Holm), and the build plan
+(Phase 1 = harness + tests on existing built-ins; Phase 2 = profile the personas once trained). It
+reuses the existing `meanCi`/`pairedDelta`/`rotatedField` machinery and needs **no engine changes**
+(one optional backward-compatible `onTurn` arg recommended).
+
+**On "plays better / more fun against humans" — be honest about what's trainable.** Self-play
+optimizes against _bots_; humans blunder differently, and we have **no human game logs at scale**
+(BC imitates `ai_lookahead`, not people). So "fun vs humans" is **not a reward we can write** — it's
+an **empirical playtest filter**: generate the diverse roster cheaply, Ivan plays them, we keep what's
+fun. The roster makes that filter _possible_; it doesn't automate it.
+
+---
+
+## 8. Execution plan (post-`ppo-long`)
+
+1. **Land the harness first** (§7) — measure today's Conqueror to set the baseline profile.
+2. **Wire the reward knobs:** `--gamma`/`--ent-coef` are already flags (Blitz/Survivor free);
+   add the per-frame territory/elim scalar to the env-server wire (Expansionist/Predator) behind a
+   version bump, off by default (byte-identical to today when unset — the B5/B6 opt-in pattern).
+3. **One persona = one reward config + one schtask**, all **warm-started from `ppo-long`'s final
+   policy** (shared good initialization; reward shaping then specializes), running **concurrently**
+   on shodan (latency-bound, idle hardware). Re-run Conqueror as the matched control.
+4. **Profile + gate each** (behavioral harness + `ppo:gate`), write results to `RESULTS.md`, log
+   the framework decision (`D-27?`) and any wire-contract change (`D-28?`) to `DECISIONS.md`.
+5. **Ship the fun ones as selectable in-game bots** — the `ai_ppo` wiring (PR #74) generalizes:
+   each persona is a weights file + a thin `ai_<persona>.js` alias + an `aiConfig`/`builtInBots`
+   registration. The in-game dropdown gains a characterful roster.
+
+## 9. Open questions for Ivan
+
+- **Roster size for the first concurrent batch** — all 5, or start with Conqueror + Blitz +
+  Predator (the clearest behavioral contrasts) and add the rest once the harness proves out?
+- **Blitz aggression budget** — how much win% are we willing to trade for excitement? (Sets the
+  `gamma` floor and the speed-bonus weight.)
+- **Do personas need to clear any bar at all**, or is "plays legally + is fun + has a measurable
+  distinct profile" the only requirement for a _personality_ bot (vs. the gate bot)?

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "arena": "node scripts/arena.mjs",
     "arena:sweep": "node scripts/arena-sweep.mjs",
     "arena:bc-stopbias": "node scripts/bc-stopbias-sweep.mjs",
+    "behavior:profile": "node scripts/behavior-profile.mjs",
     "new-bot": "node scripts/new-bot.mjs",
     "validate-bot": "node scripts/validate-bot.mjs",
     "benchmark-bot": "node scripts/benchmark-bot.mjs",

--- a/scripts/behavior-profile.mjs
+++ b/scripts/behavior-profile.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+
+/**
+ * Behavioral-Eval Harness — CLI (Phase 1)
+ *
+ * Profiles bots across a seat-fair seed sweep on behavioral axes (aggression, dice
+ * reserve, kills, turns-to-win, placement, …) and reports each axis as mean ± 95% CI,
+ * plus a PAIRED comparison of every profiled bot against a control. This answers "is
+ * the bot DIFFERENT, and how?" — the complement to `ppo:gate`'s "is it STRONGER?".
+ * Full spec + rationale: docs/ml-bot/EVAL_HARNESS.md.
+ *
+ * Pairing is the fixed-standard-field design (agreed): every profiled bot occupies the
+ * one profiled seat in an IDENTICAL opponent field, so all face the same opponents and
+ * the control comparison is paired at the seed/map level (NOT within-game — honest about
+ * its strength). Personas are deliberately NOT pitted against each other.
+ *
+ * Phase 1 runs against existing built-ins (the persona bots don't exist yet). Its
+ * acceptance test: two known-different built-ins separate on the expected axis.
+ *
+ * Usage:
+ *   npm run behavior:profile                                   # defaults: Strategist vs Defensive control
+ *   npm run behavior:profile -- --bots Strategist,Expectimax --control Defensive --runs 10 --games 30
+ *   npm run behavior:profile -- --opponents Default,Adaptive,Example,Expectimax,Lookahead --reference Lookahead
+ *   npm run behavior:profile -- --json > profile.json
+ */
+
+import { runMatch } from '../src/arena/matchRunner.js';
+import { BUILT_IN_BOTS } from '../src/arena/builtInBots.js';
+import { rotatedField } from './lib/ppo-gate-core.mjs';
+import { getArg, hasFlag } from './lib/cli-utils.mjs';
+import {
+  makeCapture,
+  profileGameFromCapture,
+  reduceRun,
+  summarizeAxis,
+  compareToControl,
+  AXES,
+} from './lib/behavior-core.mjs';
+
+const args = process.argv.slice(2);
+
+const runCount = parseInt(getArg(args, 'runs', '10'), 10);
+const gamesPerRun = parseInt(getArg(args, 'games', '30'), 10);
+const referenceName = getArg(args, 'reference', 'Lookahead');
+const controlName = getArg(args, 'control', 'Defensive');
+const botNames = getArg(args, 'bots', 'Strategist')
+  .split(',')
+  .map(s => s.trim())
+  .filter(Boolean);
+const opponentNames = getArg(args, 'opponents', 'Default,Adaptive,Example,Expectimax,Lookahead')
+  .split(',')
+  .map(s => s.trim())
+  .filter(Boolean);
+const quarantine = !hasFlag(args, 'no-quarantine');
+const asJson = hasFlag(args, 'json');
+
+if (!Number.isFinite(runCount) || runCount < 2) {
+  console.error('Invalid --runs: need an integer >= 2 (a CI needs >= 2 runs).');
+  process.exit(1);
+}
+if (!Number.isFinite(gamesPerRun) || gamesPerRun < 1) {
+  console.error('Invalid --games: need a positive integer.');
+  process.exit(1);
+}
+
+// --- Resolve bots from the registry ---
+
+const byName = new Map(BUILT_IN_BOTS.map(b => [b.name, b]));
+const resolve = name => {
+  const b = byName.get(name);
+  if (!b) {
+    console.error(`Unknown bot "${name}". Available: ${[...byName.keys()].join(', ')}`);
+    process.exit(1);
+  }
+  return { name: b.name, fn: b.fn };
+};
+
+const opponents = opponentNames.map(resolve);
+// The control is profiled like any other bot so the comparison shares the same seed blocks.
+const profiledNames = [...new Set([...botNames, controlName])];
+const profiled = profiledNames.map(resolve);
+
+// --- Validate the fixed-field invariants (keeps every field identical in size & opponents) ---
+
+const oppSet = new Set(opponentNames);
+const collide = profiledNames.filter(n => oppSet.has(n));
+if (collide.length) {
+  console.error(
+    `Profiled bot(s) [${collide.join(', ')}] also appear in --opponents. The profiled seat must ` +
+      `be disjoint from the fixed opponent field so every field is identical. Remove them from one side.`
+  );
+  process.exit(1);
+}
+if (!oppSet.has(referenceName)) {
+  console.error(`--reference "${referenceName}" must be one of --opponents (it fills a seat).`);
+  process.exit(1);
+}
+if (opponents.length < 1) {
+  console.error('Need at least one opponent.');
+  process.exit(1);
+}
+
+const fieldSize = opponents.length + 1; // profiled seat + fixed opponents
+const STRIDE = Math.max(1_000_000, gamesPerRun * 1000);
+
+const log = (...a) => console.error(...a); // human output → stderr so --json owns stdout
+
+log(
+  `Behavioral profile: ${runCount} runs × ${gamesPerRun} games × ${fieldSize} rotations ` +
+    `(${runCount * gamesPerRun * fieldSize} matches/bot)`
+);
+log(`  profiled: ${profiledNames.join(', ')}   control: ${controlName}`);
+log(
+  `  field (${fieldSize} seats): [profiled] + ${opponentNames.join(', ')}   ref: ${referenceName}`
+);
+log(`  quarantine forced-end games: ${quarantine ? 'on' : 'off'}\n`);
+
+// --- Sweep: profile each bot in the one profiled seat of an identical field ---
+
+const NULL_RUN = Object.fromEntries(AXES.map(a => [a, null]));
+let quarantined = 0;
+let played = 0;
+
+// Quarantine policy (§3.7): drop a game if ANY seat shows a forced-end signal.
+const isForcedEnd = s => s.errors > 0 || s.invalidMoves > 0 || s.maxMovesHit > 0;
+
+/** Run the full seed×rotation sweep for one profiled bot; returns reduceRun() per run. */
+function sweepBot(bot) {
+  const baseField = [bot, ...opponents]; // profiled bot at index 0
+  const perRun = [];
+  for (let run = 0; run < runCount; run++) {
+    const baseSeed = run * STRIDE + 1;
+    const profiles = [];
+    for (let s = 0; s < gamesPerRun; s++) {
+      const seed = baseSeed + s;
+      for (let rot = 0; rot < fieldSize; rot++) {
+        // Under rotation `rot`, field[0] (the profiled bot) sits at seat `rot`.
+        const field = rotatedField(baseField, rot);
+        const pi = rot;
+        const { capture, onTurn, onStep } = makeCapture(pi);
+        const result = runMatch({ bots: field, seed, onTurn, onStep });
+        played += 1;
+        if (quarantine && result.botStats.some(isForcedEnd)) {
+          quarantined += 1;
+          continue;
+        }
+        profiles.push(profileGameFromCapture(result, pi, capture));
+      }
+    }
+    perRun.push(profiles.length ? reduceRun(profiles) : { ...NULL_RUN });
+    process.stderr.write(`\r  ${bot.name}: run ${run + 1}/${runCount}`); // in-place progress
+  }
+  log('');
+  return perRun;
+}
+
+const start = Date.now();
+const runsByBot = new Map(profiled.map(bot => [bot.name, sweepBot(bot)]));
+const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+log(
+  `\nDone in ${elapsed}s — ${played} matches, ${quarantined} quarantined ` +
+    `(${((quarantined / played) * 100).toFixed(2)}%)\n`
+);
+
+// --- Aggregate + compare ---
+
+const controlRuns = runsByBot.get(controlName);
+const report = {
+  config: {
+    runs: runCount,
+    games: gamesPerRun,
+    rotations: fieldSize,
+    stride: STRIDE,
+    reference: referenceName,
+    control: controlName,
+    opponents: opponentNames,
+    fieldSize,
+    quarantine: { on: quarantine, rate: played ? quarantined / played : 0 },
+  },
+  bots: profiled.map(bot => {
+    const perRun = runsByBot.get(bot.name);
+    const metrics = Object.fromEntries(
+      AXES.map(axis => [axis, summarizeAxis(perRun.map(r => r[axis]))])
+    );
+    const vsControl = bot.name === controlName ? null : compareToControl(perRun, controlRuns);
+    return { name: bot.name, metrics, vsControl };
+  }),
+};
+
+// --- Output ---
+
+if (asJson) process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+
+const fmt = m =>
+  m == null ? '—' : m.ci == null ? m.mean.toFixed(2) : `${m.mean.toFixed(2)}±${m.ci.toFixed(2)}`;
+const headline = ['winPct', 'aggression', 'avgDiceReserve', 'kills', 'turnsToWin', 'avgPlacement'];
+
+log(['Bot'.padEnd(14), ...headline.map(h => h.padStart(16))].join(''));
+log('-'.repeat(14 + headline.length * 16));
+for (const b of report.bots) {
+  log([b.name.padEnd(14), ...headline.map(h => fmt(b.metrics[h]).padStart(16))].join(''));
+}
+log('');
+for (const b of report.bots) {
+  if (!b.vsControl) continue;
+  const moved = AXES.filter(a => b.vsControl[a] && b.vsControl[a].verdict !== 'SAME').map(
+    a => `${a} ${b.vsControl[a].verdict} (Δ${b.vsControl[a].delta.toFixed(2)})`
+  );
+  log(`${b.name} vs ${controlName}: ${moved.length ? moved.join(', ') : 'no axis differs'}`);
+}

--- a/scripts/behavior-profile.mjs
+++ b/scripts/behavior-profile.mjs
@@ -62,6 +62,18 @@ if (!Number.isFinite(gamesPerRun) || gamesPerRun < 1) {
   console.error('Invalid --games: need a positive integer.');
   process.exit(1);
 }
+if (botNames.length === 0) {
+  console.error('Invalid --bots: need at least one bot to profile.');
+  process.exit(1);
+}
+// A duplicate opponent would make every game throw "Bot names must be unique" deep in the sweep;
+// catch the typo here with a message that points at the actual cause.
+if (new Set(opponentNames).size !== opponentNames.length) {
+  console.error(
+    `--opponents has duplicate names: [${opponentNames.join(', ')}]. Each seat must be distinct.`
+  );
+  process.exit(1);
+}
 
 // --- Resolve bots from the registry ---
 
@@ -118,16 +130,24 @@ log(`  quarantine forced-end games: ${quarantine ? 'on' : 'off'}\n`);
 // --- Sweep: profile each bot in the one profiled seat of an identical field ---
 
 const NULL_RUN = Object.fromEntries(AXES.map(a => [a, null]));
-let quarantined = 0;
-let played = 0;
 
 // Quarantine policy (§3.7): drop a game if ANY seat shows a forced-end signal.
 const isForcedEnd = s => s.errors > 0 || s.invalidMoves > 0 || s.maxMovesHit > 0;
 
-/** Run the full seed×rotation sweep for one profiled bot; returns reduceRun() per run. */
+// A NULL_RUN has winPct === null (no game contributed); a live run always has a numeric winPct
+// (0 if it never won). So this counts the runs that actually carry behavioral data.
+const liveRunCount = perRun => perRun.filter(r => r.winPct != null).length;
+
+/**
+ * Run the full seed×rotation sweep for one profiled bot. Returns the per-run reduceRun() plus
+ * per-bot played/quarantined tallies so the report can surface how much sample each bot kept
+ * (a fully-quarantined bot must NOT look like a measured "no difference" — see the output below).
+ */
 function sweepBot(bot) {
   const baseField = [bot, ...opponents]; // profiled bot at index 0
   const perRun = [];
+  let played = 0;
+  let quarantined = 0;
   for (let run = 0; run < runCount; run++) {
     const baseSeed = run * STRIDE + 1;
     const profiles = [];
@@ -138,7 +158,17 @@ function sweepBot(bot) {
         const field = rotatedField(baseField, rot);
         const pi = rot;
         const { capture, onTurn, onStep } = makeCapture(pi);
-        const result = runMatch({ bots: field, seed, onTurn, onStep });
+        let result;
+        try {
+          result = runMatch({ bots: field, seed, onTurn, onStep });
+        } catch (err) {
+          // Surface which game blew up rather than dying with a context-free stack far from its
+          // cause (this is inside runCount×games×rotations×bots iterations).
+          throw new Error(
+            `runMatch threw (bot=${bot.name} seed=${seed} rot=${rot}): ${err.message}`,
+            { cause: err }
+          );
+        }
         played += 1;
         if (quarantine && result.botStats.some(isForcedEnd)) {
           quarantined += 1;
@@ -151,15 +181,18 @@ function sweepBot(bot) {
     process.stderr.write(`\r  ${bot.name}: run ${run + 1}/${runCount}`); // in-place progress
   }
   log('');
-  return perRun;
+  return { perRun, played, quarantined };
 }
 
 const start = Date.now();
-const runsByBot = new Map(profiled.map(bot => [bot.name, sweepBot(bot)]));
+const sweepByBot = new Map(profiled.map(bot => [bot.name, sweepBot(bot)]));
+const runsByBot = new Map([...sweepByBot].map(([name, s]) => [name, s.perRun]));
+const totalPlayed = [...sweepByBot.values()].reduce((a, s) => a + s.played, 0);
+const totalQuarantined = [...sweepByBot.values()].reduce((a, s) => a + s.quarantined, 0);
 const elapsed = ((Date.now() - start) / 1000).toFixed(1);
 log(
-  `\nDone in ${elapsed}s — ${played} matches, ${quarantined} quarantined ` +
-    `(${((quarantined / played) * 100).toFixed(2)}%)\n`
+  `\nDone in ${elapsed}s — ${totalPlayed} matches, ${totalQuarantined} quarantined ` +
+    `(${totalPlayed ? ((totalQuarantined / totalPlayed) * 100).toFixed(2) : '0.00'}%)\n`
 );
 
 // --- Aggregate + compare ---
@@ -175,7 +208,14 @@ const report = {
     control: controlName,
     opponents: opponentNames,
     fieldSize,
-    quarantine: { on: quarantine, rate: played ? quarantined / played : 0 },
+    quarantine: {
+      on: quarantine,
+      rate: totalPlayed ? totalQuarantined / totalPlayed : 0,
+      // Per-bot rate (§3.7): a flaky opponent can gut one bot's sample without moving the pool rate.
+      ratePerBot: Object.fromEntries(
+        [...sweepByBot].map(([name, s]) => [name, s.played ? s.quarantined / s.played : 0])
+      ),
+    },
   },
   bots: profiled.map(bot => {
     const perRun = runsByBot.get(bot.name);
@@ -183,7 +223,7 @@ const report = {
       AXES.map(axis => [axis, summarizeAxis(perRun.map(r => r[axis]))])
     );
     const vsControl = bot.name === controlName ? null : compareToControl(perRun, controlRuns);
-    return { name: bot.name, metrics, vsControl };
+    return { name: bot.name, metrics, vsControl, liveRuns: liveRunCount(perRun) };
   }),
 };
 
@@ -191,9 +231,34 @@ const report = {
 
 if (asJson) process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
 
+// A bare value (no ±) means only ONE run contributed to that axis (winners-only sparsity); mark it
+// `nN` so it isn't mistaken for a tight CI.
 const fmt = m =>
-  m == null ? '—' : m.ci == null ? m.mean.toFixed(2) : `${m.mean.toFixed(2)}±${m.ci.toFixed(2)}`;
+  m == null
+    ? '—'
+    : m.ci == null
+      ? `${m.mean.toFixed(2)} n${m.n}`
+      : `${m.mean.toFixed(2)}±${m.ci.toFixed(2)}`;
 const headline = ['winPct', 'aggression', 'avgDiceReserve', 'kills', 'turnsToWin', 'avgPlacement'];
+
+// Flag any bot whose sample was reduced by quarantine, so a low-n result isn't read as robust.
+for (const b of report.bots) {
+  const rate = report.config.quarantine.ratePerBot[b.name] ?? 0;
+  if (b.liveRuns === 0) {
+    log(
+      `  WARNING: ${b.name} — all ${runCount} runs fully quarantined ` +
+        `(${(rate * 100).toFixed(1)}% of games); no behavioral data.`
+    );
+  } else if (b.liveRuns < runCount) {
+    log(
+      `  NOTE: ${b.name} — only ${b.liveRuns}/${runCount} runs carry data ` +
+        `(quarantine ${(rate * 100).toFixed(1)}%).`
+    );
+  } else if (rate > 0.1) {
+    log(`  NOTE: ${b.name} — quarantine rate ${(rate * 100).toFixed(1)}% (sample reduced).`);
+  }
+}
+log('');
 
 log(['Bot'.padEnd(14), ...headline.map(h => h.padStart(16))].join(''));
 log('-'.repeat(14 + headline.length * 16));
@@ -203,8 +268,25 @@ for (const b of report.bots) {
 log('');
 for (const b of report.bots) {
   if (!b.vsControl) continue;
-  const moved = AXES.filter(a => b.vsControl[a] && b.vsControl[a].verdict !== 'SAME').map(
-    a => `${a} ${b.vsControl[a].verdict} (Δ${b.vsControl[a].delta.toFixed(2)})`
+  // Distinguish "measured, no difference" from "no data to compare" — both used to print the same
+  // "no axis differs" line, hiding a failed measurement as a real null result.
+  const comparable = AXES.filter(a => b.vsControl[a]);
+  if (comparable.length === 0) {
+    log(
+      `${b.name} vs ${controlName}: NO COMPARABLE DATA (insufficient paired runs after quarantine)`
+    );
+    continue;
+  }
+  const moved = comparable
+    .filter(a => b.vsControl[a].verdict !== 'SAME')
+    .map(a => {
+      const c = b.vsControl[a];
+      const nNote = c.n < runCount ? ` n${c.n}` : ''; // paired n below full run count
+      return `${a} ${c.verdict} (Δ${c.delta.toFixed(2)}${nNote})`;
+    });
+  const minN = Math.min(...comparable.map(a => b.vsControl[a].n));
+  const dataNote = minN < runCount ? ` [min paired n=${minN}/${runCount}]` : '';
+  log(
+    `${b.name} vs ${controlName}: ${moved.length ? moved.join(', ') : 'no axis differs'}${dataNote}`
   );
-  log(`${b.name} vs ${controlName}: ${moved.length ? moved.join(', ') : 'no axis differs'}`);
 }

--- a/scripts/behavior-profile.mjs
+++ b/scripts/behavior-profile.mjs
@@ -41,6 +41,8 @@ const args = process.argv.slice(2);
 
 const runCount = parseInt(getArg(args, 'runs', '10'), 10);
 const gamesPerRun = parseInt(getArg(args, 'games', '30'), 10);
+// Phase 1: `reference` is validated as an opponent seat and echoed into the report, but the paired
+// comparison is always against `control` (not the reference). It's a labeled seat + a Phase-2 hook.
 const referenceName = getArg(args, 'reference', 'Lookahead');
 const controlName = getArg(args, 'control', 'Defensive');
 const botNames = getArg(args, 'bots', 'Strategist')
@@ -158,23 +160,26 @@ function sweepBot(bot) {
         const field = rotatedField(baseField, rot);
         const pi = rot;
         const { capture, onTurn, onStep } = makeCapture(pi);
-        let result;
         try {
-          result = runMatch({ bots: field, seed, onTurn, onStep });
+          const result = runMatch({ bots: field, seed, onTurn, onStep });
+          played += 1;
+          if (quarantine && result.botStats.some(isForcedEnd)) {
+            quarantined += 1;
+            continue;
+          }
+          // profileGameFromCapture is in the try too: its contract throws (misaligned capture /
+          // seat mismatch) are genuine engine-contract violations and deserve the same coordinates.
+          profiles.push(profileGameFromCapture(result, pi, capture));
         } catch (err) {
           // Surface which game blew up rather than dying with a context-free stack far from its
           // cause (this is inside runCount×games×rotations×bots iterations).
           throw new Error(
-            `runMatch threw (bot=${bot.name} seed=${seed} rot=${rot}): ${err.message}`,
-            { cause: err }
+            `match failed (bot=${bot.name} seed=${seed} rot=${rot}): ${err.message}`,
+            {
+              cause: err,
+            }
           );
         }
-        played += 1;
-        if (quarantine && result.botStats.some(isForcedEnd)) {
-          quarantined += 1;
-          continue;
-        }
-        profiles.push(profileGameFromCapture(result, pi, capture));
       }
     }
     perRun.push(profiles.length ? reduceRun(profiles) : { ...NULL_RUN });

--- a/scripts/lib/behavior-core.mjs
+++ b/scripts/lib/behavior-core.mjs
@@ -1,0 +1,320 @@
+/**
+ * Pure logic for the behavioral-eval harness — kept out of the CLI so it is unit
+ * testable without spinning up an arena. The harness answers "is this bot DIFFERENT,
+ * and how?" (paired Δ on behavioral axes vs a control) as the complement to
+ * `ppo:gate`'s "is it STRONGER?" (paired Δwin% vs Lookahead). See
+ * `docs/ml-bot/EVAL_HARNESS.md` for the full spec.
+ *
+ * Phase 1 (this file): the metric extraction + aggregation + control comparison,
+ * runnable against existing built-in bots. Phase 2 wires the trained persona bots and
+ * the pre-registered signature gates (the PERSONA_SIGNATURES stub at the bottom).
+ *
+ * Design notes that the spec's review pinned down (do not regress):
+ *   - Active turns are counted from `onTurn` firings attributed to the profiled seat,
+ *     which INCLUDE the victory turn — so aggression is NOT biased upward on won games
+ *     (counting STOP steps would miss the victory turn, which emits none). Relies on the
+ *     `onTurn(turnNumber, state, actingPlayerId)` engine signal.
+ *   - Kills are credited to the acting player of the turn during which an opponent's
+ *     `eliminated` flag flips — O(1) live, no second replay pass.
+ *   - meanCi's n is the RUN count, not the game count: CI width is driven by between-run
+ *     variance / √runs. Aggregate per-game → per-run scalar → meanCi across runs.
+ *
+ * @module scripts/lib/behavior-core
+ */
+
+import { meanCi } from './stats.mjs';
+import { pairedDelta, classifyGate } from './ppo-gate-core.mjs';
+import { isStopMove } from '../../src/arena/trajectoryExport.js';
+
+/**
+ * @typedef {Object} GameCapture
+ * Per-game accumulator filled by the live `onTurn`/`onStep` handlers from {@link makeCapture}.
+ * @property {number}   playerIndex   - the profiled seat this capture follows
+ * @property {number}   activeTurns   - count of the profiled bot's own completed turns (incl. a win)
+ * @property {number[]} territory     - territoryCount at the end of each of the bot's own turns
+ * @property {number[]} dice          - diceCount at the end of each of the bot's own turns
+ * @property {number[]} largestGroup  - largestGroup at the end of each of the bot's own turns
+ * @property {number}   kills         - opponents the bot eliminated (last-territory capture)
+ * @property {number|null} eliminatedAtTurn - turn the bot was itself eliminated, or null if it survived
+ * @property {number}   zeroAttackTurns  - the bot's own turns that ended with 0 attacks (pass turns)
+ * @property {number}   _sinceStop    - internal: attacks since the bot's last STOP (do not read)
+ * @property {Set<number>} _seenEliminated - internal: players already counted as eliminated
+ */
+
+/**
+ * Build a per-game capture plus the `onTurn`/`onStep` handlers to wire into `runMatch`.
+ * Pure: no arena import, so it is unit-tested by feeding synthetic callback calls.
+ *
+ * @param {number} playerIndex - the seat to profile
+ * @returns {{ capture: GameCapture, onTurn: Function, onStep: Function }}
+ */
+export function makeCapture(playerIndex) {
+  const capture = {
+    playerIndex,
+    activeTurns: 0,
+    territory: [],
+    dice: [],
+    largestGroup: [],
+    kills: 0,
+    eliminatedAtTurn: null,
+    zeroAttackTurns: 0,
+    _sinceStop: 0,
+    _seenEliminated: new Set(),
+  };
+
+  // Fires after every player-turn with the post-turn state and the acting player.
+  const onTurn = (turnNumber, state, actingPlayerId) => {
+    // Credit any NEW eliminations this turn to the acting player; record the bot's own death.
+    for (const p of state.players) {
+      if (!p.eliminated || capture._seenEliminated.has(p.id)) continue;
+      capture._seenEliminated.add(p.id);
+      if (p.id === playerIndex) {
+        capture.eliminatedAtTurn = turnNumber;
+      } else if (actingPlayerId === playerIndex) {
+        capture.kills += 1;
+      }
+    }
+    // Board-shape snapshots are taken at the END of the bot's OWN turns ("what it holds").
+    if (actingPlayerId === playerIndex) {
+      capture.activeTurns += 1;
+      const me = state.players[playerIndex];
+      capture.territory.push(me.territoryCount);
+      capture.dice.push(me.diceCount);
+      capture.largestGroup.push(me.largestGroup);
+    }
+  };
+
+  // Fires per applied ATTACK and once per turn-end STOP (the victory turn emits no STOP).
+  const onStep = step => {
+    if (step.playerId !== playerIndex) return;
+    if (isStopMove(step.chosenMove)) {
+      if (capture._sinceStop === 0) capture.zeroAttackTurns += 1;
+      capture._sinceStop = 0;
+    } else {
+      capture._sinceStop += 1;
+    }
+  };
+
+  return { capture, onTurn, onStep };
+}
+
+/** Mean of an array, or null for an empty array (so empty never poisons an average). */
+const meanOrNull = xs => (xs.length === 0 ? null : xs.reduce((a, b) => a + b, 0) / xs.length);
+
+/**
+ * @typedef {Object} GameProfile - per-game behavioral scalars for one bot. `null` where
+ *   undefined for this game (e.g. turnsToWin when the bot did not win).
+ */
+
+/**
+ * Reduce a finished match + its capture to per-game behavioral scalars for the profiled seat.
+ *
+ * @param {import('../../src/arena/matchRunner.js').MatchResult} result
+ * @param {number} playerIndex
+ * @param {GameCapture} capture
+ * @returns {GameProfile}
+ */
+export function profileGameFromCapture(result, playerIndex, capture) {
+  const stat = result.botStats.find(b => b.playerIndex === playerIndex);
+  if (!stat) throw new Error(`profileGameFromCapture: no botStats for seat ${playerIndex}`);
+  if (capture.playerIndex !== playerIndex) {
+    throw new Error(
+      `profileGameFromCapture: capture seat ${capture.playerIndex} != ${playerIndex}`
+    );
+  }
+
+  const won = result.winner === playerIndex;
+  const { attacksMade, attacksWon } = stat;
+  const at = capture.activeTurns;
+
+  const dicePerTerritory = capture.territory.map((t, i) => (t > 0 ? capture.dice[i] / t : 0));
+
+  return {
+    won,
+    placement: stat.placement,
+    turnsToWin: won ? result.turnCount : null,
+    attacksMade,
+    aggression: at > 0 ? attacksMade / at : null,
+    captureEfficiency: attacksMade > 0 ? attacksWon / attacksMade : null,
+    avgDiceReserve: meanOrNull(capture.dice),
+    avgTerritory: meanOrNull(capture.territory),
+    dicePerTerritory: meanOrNull(dicePerTerritory),
+    largestGroup: meanOrNull(capture.largestGroup),
+    kills: capture.kills,
+    // Survived to game end ⇒ survival time is the full game length.
+    survivalTurn: capture.eliminatedAtTurn ?? result.turnCount,
+    zeroAttackTurnFrac: at > 0 ? capture.zeroAttackTurns / at : null,
+  };
+}
+
+/** The behavioral axes, in display order. Each maps a GameProfile field to a per-run scalar. */
+export const AXES = [
+  'winPct',
+  'aggression',
+  'captureEfficiency',
+  'avgDiceReserve',
+  'avgTerritory',
+  'dicePerTerritory',
+  'largestGroup',
+  'kills',
+  'turnsToWin',
+  'survivalTurn',
+  'zeroAttackTurnFrac',
+  'avgPlacement',
+];
+
+/**
+ * Reduce a run's per-game profiles (post-quarantine) to one scalar per axis. Winners-only
+ * and other partial axes yield `null` for the run when no game contributes (handled by the
+ * paired-comparison's null-alignment, never silently dropped on one side only).
+ *
+ * @param {GameProfile[]} profiles - the games in one seed block
+ * @returns {Record<string, number|null>}
+ */
+export function reduceRun(profiles) {
+  if (profiles.length === 0) throw new Error('reduceRun: empty run');
+  const defined = (field, filter = () => true) =>
+    meanOrNull(
+      profiles
+        .filter(filter)
+        .map(p => p[field])
+        .filter(v => v != null)
+    );
+
+  return {
+    winPct: meanOrNull(profiles.map(p => (p.won ? 100 : 0))),
+    aggression: defined('aggression'),
+    captureEfficiency: defined('captureEfficiency'),
+    avgDiceReserve: defined('avgDiceReserve'),
+    avgTerritory: defined('avgTerritory'),
+    dicePerTerritory: defined('dicePerTerritory'),
+    largestGroup: defined('largestGroup'),
+    kills: defined('kills'),
+    turnsToWin: defined('turnsToWin', p => p.won), // null when the bot won nothing this run
+    survivalTurn: defined('survivalTurn'),
+    zeroAttackTurnFrac: defined('zeroAttackTurnFrac'),
+    avgPlacement: defined('placement'),
+  };
+}
+
+/** Mean ± 95% CI of a run array, ignoring null runs. Returns null if < 1 finite run. */
+export function summarizeAxis(perRunValues) {
+  const vals = perRunValues.filter(v => v != null);
+  if (vals.length === 0) return null;
+  if (vals.length === 1) return { mean: vals[0], ci: null, n: 1 };
+  return { ...meanCi(vals), n: vals.length };
+}
+
+/**
+ * Drop run indices where EITHER side is null, keeping the two arrays aligned (so
+ * `pairedDelta`'s positional pairing stays valid). Returns the filtered pair + kept count.
+ *
+ * @param {Array<number|null>} a
+ * @param {Array<number|null>} b
+ * @returns {{ a: number[], b: number[], n: number }}
+ */
+export function alignDropNull(a, b) {
+  if (a.length !== b.length) {
+    throw new Error(`alignDropNull: length mismatch (${a.length} vs ${b.length})`);
+  }
+  const ao = [];
+  const bo = [];
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] == null || b[i] == null) continue;
+    ao.push(a[i]);
+    bo.push(b[i]);
+  }
+  return { a: ao, b: bo, n: ao.length };
+}
+
+/**
+ * Paired persona − control comparison on one axis over matched seed blocks. Null runs are
+ * dropped from both sides first (§3.4). Returns null when fewer than 2 paired runs remain
+ * (pairedDelta needs ≥ 2), so a sparse winners-only axis degrades gracefully.
+ *
+ * @param {Array<number|null>} personaRuns
+ * @param {Array<number|null>} controlRuns
+ * @returns {{ delta:number, ci:number, lo:number, hi:number, verdict:'HIGHER'|'SAME'|'LOWER', n:number } | null}
+ */
+export function compareAxis(personaRuns, controlRuns) {
+  const { a, b, n } = alignDropNull(personaRuns, controlRuns);
+  if (n < 2) return null;
+  const d = pairedDelta(a, b); // { mean, ci, lo, hi }
+  // classifyGate speaks BEAT/TIE/BEHIND; relabel to the direction-neutral HIGHER/SAME/LOWER.
+  const verdict = { BEAT: 'HIGHER', BEHIND: 'LOWER', TIE: 'SAME' }[classifyGate(d)];
+  // Expose the paired mean as `delta` (the spec's field name; what signaturePass/CLI read).
+  return { delta: d.mean, ci: d.ci, lo: d.lo, hi: d.hi, verdict, n };
+}
+
+/**
+ * Compare every axis of a persona's per-run scalars against the control's.
+ *
+ * @param {Array<Record<string, number|null>>} personaRuns - reduceRun() output per run
+ * @param {Array<Record<string, number|null>>} controlRuns - same, for the control, SAME seed blocks
+ * @returns {Record<string, ReturnType<typeof compareAxis>>}
+ */
+export function compareToControl(personaRuns, controlRuns) {
+  const out = {};
+  for (const axis of AXES) {
+    out[axis] = compareAxis(
+      personaRuns.map(r => r[axis]),
+      controlRuns.map(r => r[axis])
+    );
+  }
+  return out;
+}
+
+/**
+ * Whether a persona's pre-registered signature holds: every required axis must clear its
+ * minimum-detectable-effect AND have a CI excluding 0 in the expected direction (§3.2/§3.3).
+ * Two requirements (|Δ| ≥ MDE and significant) guard against a statistically-significant but
+ * behaviorally-trivial "difference" passing.
+ *
+ * @param {{ axes: Array<{axis:string, direction:'HIGHER'|'LOWER'}>, rule:'AND'|'single' }} signature
+ * @param {Record<string, ReturnType<typeof compareAxis>>} vsControl
+ * @param {Record<string, number>} mde - per-axis minimum |Δ| that counts as meaningful
+ * @returns {boolean}
+ */
+export function signaturePass(signature, vsControl, mde) {
+  const checks = signature.axes.map(({ axis, direction }) => {
+    const cmp = vsControl[axis];
+    if (!cmp) return false;
+    const meetsMde = Math.abs(cmp.delta) >= (mde[axis] ?? 0);
+    const sigInDir = direction === 'HIGHER' ? cmp.lo > 0 : cmp.hi < 0;
+    return meetsMde && sigInDir;
+  });
+  // 'single' and 'AND' both require all listed axes; the distinction is documentation of intent.
+  return checks.every(Boolean);
+}
+
+/**
+ * Pre-registered confirmatory signature per persona (§8 of the spec). Phase-2 stub — the
+ * persona bots do not exist yet; this encodes the one hypothesis each will be judged on so
+ * the multiplicity story (≤ 5 confirmatory tests, Holm-adjusted) is fixed in advance.
+ *
+ * @type {Record<string, { axes: Array<{axis:string, direction:'HIGHER'|'LOWER'}>, rule:'AND'|'single' }>}
+ */
+export const PERSONA_SIGNATURES = {
+  Blitz: {
+    axes: [
+      { axis: 'aggression', direction: 'HIGHER' },
+      { axis: 'turnsToWin', direction: 'LOWER' },
+    ],
+    rule: 'AND',
+  },
+  Expansionist: { axes: [{ axis: 'avgTerritory', direction: 'HIGHER' }], rule: 'single' },
+  Predator: { axes: [{ axis: 'kills', direction: 'HIGHER' }], rule: 'single' },
+  Survivor: { axes: [{ axis: 'avgPlacement', direction: 'LOWER' }], rule: 'single' },
+};
+
+/** Placeholder per-axis MDEs (§3.2). Calibrate from a pilot once a persona exists. */
+export const DEFAULT_MDE = {
+  aggression: 1.0,
+  turnsToWin: 5.0,
+  avgTerritory: 3.0,
+  kills: 0.5,
+  avgPlacement: 0.4,
+  avgDiceReserve: 3.0,
+  zeroAttackTurnFrac: 0.1,
+  captureEfficiency: 0.05,
+};

--- a/scripts/lib/behavior-core.mjs
+++ b/scripts/lib/behavior-core.mjs
@@ -127,6 +127,22 @@ export function profileGameFromCapture(result, playerIndex, capture) {
   const { attacksMade, attacksWon } = stat;
   const at = capture.activeTurns;
 
+  // The three board-shape arrays are pushed together once per the bot's own turn, so each must
+  // have exactly `activeTurns` entries. Assert it: a drift would index past the end (e.g.
+  // dice[i] === undefined ⇒ NaN), and NaN slips past every `!= null` guard downstream and reads
+  // as a TIE/SAME verdict rather than erroring. Fail loud here instead, per the file's contract.
+  if (
+    capture.territory.length !== at ||
+    capture.dice.length !== at ||
+    capture.largestGroup.length !== at
+  ) {
+    throw new Error(
+      `profileGameFromCapture: misaligned capture arrays for seat ${playerIndex} ` +
+        `(activeTurns=${at}, territory=${capture.territory.length}, ` +
+        `dice=${capture.dice.length}, largestGroup=${capture.largestGroup.length})`
+    );
+  }
+
   const dicePerTerritory = capture.territory.map((t, i) => (t > 0 ? capture.dice[i] / t : 0));
 
   return {
@@ -274,12 +290,24 @@ export function compareToControl(personaRuns, controlRuns) {
  * @param {Record<string, ReturnType<typeof compareAxis>>} vsControl
  * @param {Record<string, number>} mde - per-axis minimum |Δ| that counts as meaningful
  * @returns {boolean}
+ * @throws if a signature axis has no registered MDE (see below)
  */
 export function signaturePass(signature, vsControl, mde) {
   const checks = signature.axes.map(({ axis, direction }) => {
     const cmp = vsControl[axis];
     if (!cmp) return false;
-    const meetsMde = Math.abs(cmp.delta) >= (mde[axis] ?? 0);
+    // Fail loud on a missing MDE rather than defaulting to 0: an `?? 0` fallback would make
+    // |Δ| ≥ 0 always true, silently collapsing the gate back to a bare significance test — the
+    // exact "trivially-significant pass" this function exists to prevent. A pre-registered
+    // signature axis without a pre-registered MDE is a config error, not a 0-threshold.
+    const axisMde = mde[axis];
+    if (axisMde == null) {
+      throw new Error(
+        `signaturePass: no MDE registered for axis "${axis}" — every pre-registered signature ` +
+          `axis must have an MDE (else the |Δ| ≥ MDE guard is silently disabled).`
+      );
+    }
+    const meetsMde = Math.abs(cmp.delta) >= axisMde;
     const sigInDir = direction === 'HIGHER' ? cmp.lo > 0 : cmp.hi < 0;
     return meetsMde && sigInDir;
   });

--- a/scripts/lib/behavior-core.mjs
+++ b/scripts/lib/behavior-core.mjs
@@ -143,6 +143,8 @@ export function profileGameFromCapture(result, playerIndex, capture) {
     );
   }
 
+  // Per-turn dice density, then averaged below: a mean of per-turn (dice/territory) ratios — NOT
+  // aggregate totalDice/totalTerritory. Both are defensible; this one weights each turn equally.
   const dicePerTerritory = capture.territory.map((t, i) => (t > 0 ? capture.dice[i] / t : 0));
 
   return {
@@ -189,12 +191,14 @@ export const AXES = [
  */
 export function reduceRun(profiles) {
   if (profiles.length === 0) throw new Error('reduceRun: empty run');
+  // Number.isFinite (not `!= null`) so a stray NaN/Infinity is dropped like missing data rather
+  // than averaged in — a non-finite scalar must never survive to read as a real measurement.
   const defined = (field, filter = () => true) =>
     meanOrNull(
       profiles
         .filter(filter)
         .map(p => p[field])
-        .filter(v => v != null)
+        .filter(v => Number.isFinite(v))
     );
 
   return {
@@ -213,17 +217,19 @@ export function reduceRun(profiles) {
   };
 }
 
-/** Mean ± 95% CI of a run array, ignoring null runs. Returns null if < 1 finite run. */
+/** Mean ± 95% CI of a run array, ignoring null/non-finite runs. Returns null if < 1 finite run. */
 export function summarizeAxis(perRunValues) {
-  const vals = perRunValues.filter(v => v != null);
+  const vals = perRunValues.filter(v => Number.isFinite(v));
   if (vals.length === 0) return null;
   if (vals.length === 1) return { mean: vals[0], ci: null, n: 1 };
   return { ...meanCi(vals), n: vals.length };
 }
 
 /**
- * Drop run indices where EITHER side is null, keeping the two arrays aligned (so
- * `pairedDelta`'s positional pairing stays valid). Returns the filtered pair + kept count.
+ * Drop run indices where EITHER side is null or non-finite, keeping the two arrays aligned (so
+ * `pairedDelta`'s positional pairing stays valid). Returns the filtered pair + kept count. Treating
+ * a NaN/Infinity as a dropped index (not a paired value) keeps it out of `pairedDelta`, where it
+ * would otherwise produce a NaN CI that `classifyGate` reads as a bogus SAME at full n.
  *
  * @param {Array<number|null>} a
  * @param {Array<number|null>} b
@@ -236,7 +242,7 @@ export function alignDropNull(a, b) {
   const ao = [];
   const bo = [];
   for (let i = 0; i < a.length; i++) {
-    if (a[i] == null || b[i] == null) continue;
+    if (!Number.isFinite(a[i]) || !Number.isFinite(b[i])) continue;
     ao.push(a[i]);
     bo.push(b[i]);
   }

--- a/src/arena/matchRunner.js
+++ b/src/arena/matchRunner.js
@@ -210,7 +210,12 @@ function runBotTurn(state, botFn, botName, stats, onStep) {
  * @param {MatchBotConfig[]} config.bots - Bot configurations (length = player count)
  * @param {number}  [config.seed]        - RNG seed (random if omitted)
  * @param {number}  [config.maxTurns=500] - Max turns before stalemate
- * @param {Function} [config.onTurn]     - Callback after each turn: (turnNumber, state)
+ * @param {(turnNumber:number, state:import('../engine/types.js').GameState, actingPlayerId:number)=>void} [config.onTurn] -
+ *   Callback after each player-turn: the turn count, the post-turn state, and the player
+ *   whose turn just completed (the acting player). The third arg lets a consumer attribute
+ *   the turn — e.g. count a bot's own active turns, or credit an elimination during that turn
+ *   to the attacker — without re-deriving the actor. It fires for the victory turn too (after
+ *   the move loop returns a GAME_OVER state). Backward-compatible: older 2-arg callers ignore it.
  * @param {(step: import('./trajectoryExport.js').TrajectoryStep) => void} [config.onStep] -
  *   Per-decision callback (see runBotTurn). For custom streaming sinks.
  * @param {boolean} [config.recordTrajectory] - When true, capture a self-play trajectory and
@@ -322,7 +327,7 @@ export function runMatch(config) {
     }
 
     turnCount++;
-    if (onTurn) onTurn(turnCount, state);
+    if (onTurn) onTurn(turnCount, state, currentPlayerId);
   }
 
   // Calculate placements

--- a/tests/behaviorCore.test.js
+++ b/tests/behaviorCore.test.js
@@ -1,0 +1,330 @@
+/**
+ * Behavioral-eval harness — Phase 1 core tests.
+ *
+ * Covers the pure metric extraction / aggregation / control-comparison logic of
+ * `scripts/lib/behavior-core.mjs`, plus a real-engine smoke that pins the §6 engine
+ * signal (`onTurn(turnNumber, state, actingPlayerId)`) the harness depends on. See
+ * docs/ml-bot/EVAL_HARNESS.md.
+ *
+ * Node env is fine (no DOM). Run scoped: `npx vitest run tests/behaviorCore.test.js`.
+ */
+import {
+  makeCapture,
+  profileGameFromCapture,
+  reduceRun,
+  summarizeAxis,
+  alignDropNull,
+  compareAxis,
+  signaturePass,
+} from '../scripts/lib/behavior-core.mjs';
+import { runMatch } from '../src/arena/matchRunner.js';
+import { BUILT_IN_BOTS } from '../src/arena/builtInBots.js';
+
+const STOP = { type: 'END_TURN' };
+const attack = (from = 1, to = 2) => ({ from, to });
+const player = (
+  id,
+  over = { territoryCount: 4, diceCount: 8, largestGroup: 3, eliminated: false }
+) => ({
+  id,
+  ...over,
+});
+
+/** A synthetic post-turn state: 3 players with given (territory/dice/largest/eliminated). */
+const stateOf = specs => ({ players: specs.map((s, i) => player(i, s)) });
+
+describe('makeCapture — onTurn/onStep accumulation', () => {
+  it('counts the victory turn as an active turn (the aggression-bias fix)', () => {
+    const { capture, onTurn, onStep } = makeCapture(0);
+
+    // Turn 1: bot 0 attacks twice then STOPs (a normal, non-winning turn).
+    onStep({ playerId: 0, chosenMove: attack() });
+    onStep({ playerId: 0, chosenMove: attack() });
+    onStep({ playerId: 0, chosenMove: STOP });
+    onTurn(
+      1,
+      stateOf([{ territoryCount: 5, diceCount: 10, largestGroup: 4, eliminated: false }, {}, {}]),
+      0
+    );
+
+    // Turn 2: opponent 1 eliminates opponent 2 — NOT the profiled bot's kill.
+    onTurn(
+      2,
+      stateOf([{}, {}, { territoryCount: 0, diceCount: 0, largestGroup: 0, eliminated: true }]),
+      1
+    );
+
+    // Turn 3: bot 0 makes the winning capture (eliminates 1). A victory turn emits NO STOP step.
+    onStep({ playerId: 0, chosenMove: attack() });
+    onTurn(
+      3,
+      stateOf([
+        { territoryCount: 9, diceCount: 15, largestGroup: 7, eliminated: false },
+        { territoryCount: 0, diceCount: 0, largestGroup: 0, eliminated: true },
+        {},
+      ]),
+      0
+    );
+
+    expect(capture.activeTurns).toBe(2); // turns 1 and 3 — the win is counted (no STOP undercount)
+    expect(capture.kills).toBe(1); // only player 1 (player 2 was opponent-1's kill)
+    expect(capture.zeroAttackTurns).toBe(0);
+    expect(capture.eliminatedAtTurn).toBeNull(); // the bot itself was never eliminated
+    expect(capture.territory).toEqual([5, 9]);
+    expect(capture.dice).toEqual([10, 15]);
+    expect(capture.largestGroup).toEqual([4, 7]);
+  });
+
+  it('records the bot being eliminated and a zero-attack (pass) turn', () => {
+    const { capture, onTurn, onStep } = makeCapture(0);
+
+    // Bot 0 passes its turn (STOP with no attacks).
+    onStep({ playerId: 0, chosenMove: STOP });
+    onTurn(
+      1,
+      stateOf([{ territoryCount: 2, diceCount: 3, largestGroup: 1, eliminated: false }, {}, {}]),
+      0
+    );
+
+    // Opponent 1's turn eliminates bot 0.
+    onTurn(
+      2,
+      stateOf([{ territoryCount: 0, diceCount: 0, largestGroup: 0, eliminated: true }, {}, {}]),
+      1
+    );
+
+    expect(capture.activeTurns).toBe(1);
+    expect(capture.zeroAttackTurns).toBe(1);
+    expect(capture.eliminatedAtTurn).toBe(2);
+    expect(capture.kills).toBe(0);
+  });
+
+  it('ignores steps and turns for other seats', () => {
+    const { capture, onTurn, onStep } = makeCapture(0);
+    onStep({ playerId: 1, chosenMove: attack() });
+    onTurn(1, stateOf([{}, {}, {}]), 1);
+    expect(capture.activeTurns).toBe(0);
+    expect(capture.territory).toEqual([]);
+  });
+});
+
+describe('profileGameFromCapture', () => {
+  const baseResult = (overrides = {}) => ({
+    winner: 0,
+    turnCount: 3,
+    botStats: [
+      {
+        playerIndex: 0,
+        placement: 1,
+        attacksMade: 3,
+        attacksWon: 3,
+        errors: 0,
+        invalidMoves: 0,
+        maxMovesHit: 0,
+      },
+      {
+        playerIndex: 1,
+        placement: 2,
+        attacksMade: 1,
+        attacksWon: 0,
+        errors: 0,
+        invalidMoves: 0,
+        maxMovesHit: 0,
+      },
+    ],
+    ...overrides,
+  });
+
+  it('derives per-game scalars; aggression uses the actor-counted active turns', () => {
+    const capture = {
+      playerIndex: 0,
+      activeTurns: 2,
+      territory: [5, 9],
+      dice: [10, 16],
+      largestGroup: [4, 7],
+      kills: 1,
+      eliminatedAtTurn: null,
+      zeroAttackTurns: 0,
+    };
+    const p = profileGameFromCapture(baseResult(), 0, capture);
+    expect(p.won).toBe(true);
+    expect(p.turnsToWin).toBe(3);
+    expect(p.aggression).toBeCloseTo(3 / 2); // 1.5, NOT 3 (which a STOP-count denominator would give)
+    expect(p.captureEfficiency).toBe(1);
+    expect(p.avgDiceReserve).toBe(13);
+    expect(p.avgTerritory).toBe(7);
+    expect(p.dicePerTerritory).toBeCloseTo((10 / 5 + 16 / 9) / 2);
+    expect(p.largestGroup).toBe(5.5);
+    expect(p.kills).toBe(1);
+    expect(p.survivalTurn).toBe(3); // survived ⇒ full game length
+  });
+
+  it('turnsToWin is null when the bot did not win; survivalTurn is the death turn', () => {
+    const capture = {
+      playerIndex: 0,
+      activeTurns: 1,
+      territory: [2],
+      dice: [3],
+      largestGroup: [1],
+      kills: 0,
+      eliminatedAtTurn: 2,
+      zeroAttackTurns: 1,
+    };
+    const result = baseResult({
+      winner: 1,
+      turnCount: 5,
+      botStats: [
+        {
+          playerIndex: 0,
+          placement: 3,
+          attacksMade: 0,
+          attacksWon: 0,
+          errors: 0,
+          invalidMoves: 0,
+          maxMovesHit: 0,
+        },
+      ],
+    });
+    const p = profileGameFromCapture(result, 0, capture);
+    expect(p.won).toBe(false);
+    expect(p.turnsToWin).toBeNull();
+    expect(p.captureEfficiency).toBeNull(); // 0 attacks ⇒ undefined, not 0/0
+    expect(p.aggression).toBe(0); // 0 attacks over 1 active turn
+    expect(p.zeroAttackTurnFrac).toBe(1);
+    expect(p.survivalTurn).toBe(2);
+  });
+});
+
+describe('reduceRun', () => {
+  const won = {
+    won: true,
+    placement: 1,
+    turnsToWin: 20,
+    aggression: 4,
+    captureEfficiency: 0.7,
+    avgDiceReserve: 9,
+    avgTerritory: 8,
+    dicePerTerritory: 1.2,
+    largestGroup: 6,
+    kills: 2,
+    survivalTurn: 20,
+    zeroAttackTurnFrac: 0.1,
+  };
+  const lost = {
+    won: false,
+    placement: 3,
+    turnsToWin: null,
+    aggression: 2,
+    captureEfficiency: 0.5,
+    avgDiceReserve: 5,
+    avgTerritory: 4,
+    dicePerTerritory: 1.0,
+    largestGroup: 3,
+    kills: 0,
+    survivalTurn: 12,
+    zeroAttackTurnFrac: 0.3,
+  };
+
+  it('reduces to per-run scalars; winners-only axis ignores losses', () => {
+    const r = reduceRun([won, lost, lost, won]);
+    expect(r.winPct).toBe(50);
+    expect(r.aggression).toBe(3); // mean(4,2,2,4)
+    expect(r.turnsToWin).toBe(20); // only the two wins (both 20)
+    expect(r.avgPlacement).toBe(2); // mean(1,3,3,1)
+  });
+
+  it('turnsToWin is null for a run with no wins (the null-run case)', () => {
+    expect(reduceRun([lost, lost]).turnsToWin).toBeNull();
+  });
+});
+
+describe('alignDropNull + compareAxis (paired control comparison)', () => {
+  it('drops run indices where either side is null, preserving alignment', () => {
+    const { a, b, n } = alignDropNull([1, null, 3, 4], [10, 20, null, 40]);
+    expect(a).toEqual([1, 4]);
+    expect(b).toEqual([10, 40]);
+    expect(n).toBe(2);
+  });
+
+  it('classifies a real positive paired delta as HIGHER', () => {
+    const cmp = compareAxis([5, 6, 7, 5, 6], [2, 3, 2, 3, 2]);
+    expect(cmp.verdict).toBe('HIGHER');
+    expect(cmp.lo).toBeGreaterThan(0);
+    expect(cmp.n).toBe(5);
+  });
+
+  it('classifies a negative paired delta as LOWER and an overlapping one as SAME', () => {
+    expect(compareAxis([1, 2, 1, 2, 1], [5, 6, 5, 6, 5]).verdict).toBe('LOWER');
+    expect(compareAxis([5, 1, 6, 2, 5], [4, 2, 5, 3, 4]).verdict).toBe('SAME');
+  });
+
+  it('returns null when fewer than 2 paired runs survive null-alignment', () => {
+    expect(compareAxis([1, null, null], [null, 2, null])).toBeNull();
+  });
+});
+
+describe('signaturePass — MDE gate prevents trivial-but-significant passes', () => {
+  const vsControl = { aggression: compareAxis([5, 6, 7, 5, 6], [2, 3, 2, 3, 2]) }; // Δ ≈ +3.4, CI > 0
+  const sig = { axes: [{ axis: 'aggression', direction: 'HIGHER' }], rule: 'single' };
+
+  it('passes when |Δ| >= MDE AND the CI excludes 0 in the expected direction', () => {
+    expect(signaturePass(sig, vsControl, { aggression: 1.0 })).toBe(true);
+  });
+
+  it('fails a statistically-significant but behaviorally-trivial (sub-MDE) difference', () => {
+    expect(signaturePass(sig, vsControl, { aggression: 10.0 })).toBe(false);
+  });
+
+  it('fails when the significant difference is in the wrong direction', () => {
+    const wrongDir = { axes: [{ axis: 'aggression', direction: 'LOWER' }], rule: 'single' };
+    expect(signaturePass(wrongDir, vsControl, { aggression: 1.0 })).toBe(false);
+  });
+
+  it('AND rule requires every listed axis', () => {
+    const both = {
+      aggression: compareAxis([5, 6, 7, 5, 6], [2, 3, 2, 3, 2]), // HIGHER, big
+      turnsToWin: compareAxis([20, 21, 20, 21, 20], [19, 20, 19, 20, 19]), // HIGHER, tiny — fails LOWER
+    };
+    const blitz = {
+      axes: [
+        { axis: 'aggression', direction: 'HIGHER' },
+        { axis: 'turnsToWin', direction: 'LOWER' },
+      ],
+      rule: 'AND',
+    };
+    expect(signaturePass(blitz, both, { aggression: 1, turnsToWin: 1 })).toBe(false);
+  });
+});
+
+describe('§6 engine signal — runMatch passes actingPlayerId to onTurn', () => {
+  const field = BUILT_IN_BOTS.slice(0, 3).map(b => ({ name: b.name, fn: b.fn }));
+
+  it('every onTurn firing carries the acting player (in seat range)', () => {
+    const actors = [];
+    runMatch({
+      bots: field,
+      seed: 42,
+      onTurn: (_t, _s, actingPlayerId) => actors.push(actingPlayerId),
+    });
+    expect(actors.length).toBeGreaterThan(0);
+    for (const a of actors) {
+      expect(Number.isInteger(a)).toBe(true);
+      expect(a).toBeGreaterThanOrEqual(0);
+      expect(a).toBeLessThan(field.length);
+    }
+  });
+
+  it('drives a real game through makeCapture/profileGameFromCapture without throwing', () => {
+    const { capture, onTurn, onStep } = makeCapture(0);
+    const result = runMatch({ bots: field, seed: 7, onTurn, onStep });
+    const p = profileGameFromCapture(result, 0, capture);
+    expect(p.placement).toBeGreaterThanOrEqual(1);
+    expect(p.placement).toBeLessThanOrEqual(field.length);
+    expect(typeof p.kills).toBe('number');
+    expect(p.survivalTurn).toBeGreaterThan(0);
+    // summarizeAxis tolerates a single run (ci null, n 1).
+    const s = summarizeAxis([reduceRun([p]).avgPlacement]);
+    expect(s.n).toBe(1);
+    expect(s.ci).toBeNull();
+  });
+});

--- a/tests/behaviorCore.test.js
+++ b/tests/behaviorCore.test.js
@@ -15,7 +15,11 @@ import {
   summarizeAxis,
   alignDropNull,
   compareAxis,
+  compareToControl,
   signaturePass,
+  AXES,
+  PERSONA_SIGNATURES,
+  DEFAULT_MDE,
 } from '../scripts/lib/behavior-core.mjs';
 import { runMatch } from '../src/arena/matchRunner.js';
 import { BUILT_IN_BOTS } from '../src/arena/builtInBots.js';
@@ -32,6 +36,9 @@ const player = (
 
 /** A synthetic post-turn state: 3 players with given (territory/dice/largest/eliminated). */
 const stateOf = specs => ({ players: specs.map((s, i) => player(i, s)) });
+
+/** A full per-run reduced record (every AXES key finite); override specific axes per test. */
+const reduceShape = (over = {}) => ({ ...Object.fromEntries(AXES.map(a => [a, 1])), ...over });
 
 describe('makeCapture — onTurn/onStep accumulation', () => {
   it('counts the victory turn as an active turn (the aggression-bias fix)', () => {
@@ -105,6 +112,34 @@ describe('makeCapture — onTurn/onStep accumulation', () => {
     onTurn(1, stateOf([{}, {}, {}]), 1);
     expect(capture.activeTurns).toBe(0);
     expect(capture.territory).toEqual([]);
+  });
+
+  it('credits multiple eliminations in one turn, and never double-counts (the _seenEliminated dedup)', () => {
+    const { capture, onTurn } = makeCapture(0);
+
+    // Bot 0's turn eliminates BOTH opponents 1 and 2 in a single sweep (a late-game finish).
+    onTurn(
+      1,
+      stateOf([
+        { territoryCount: 9, diceCount: 15, largestGroup: 8, eliminated: false },
+        { territoryCount: 0, diceCount: 0, largestGroup: 0, eliminated: true },
+        { territoryCount: 0, diceCount: 0, largestGroup: 0, eliminated: true },
+      ]),
+      0
+    );
+    expect(capture.kills).toBe(2); // both kills credited to the acting bot
+
+    // A later turn that re-presents the same eliminated players must NOT re-credit them.
+    onTurn(
+      2,
+      stateOf([
+        { territoryCount: 9, diceCount: 15, largestGroup: 8, eliminated: false },
+        { territoryCount: 0, diceCount: 0, largestGroup: 0, eliminated: true },
+        { territoryCount: 0, diceCount: 0, largestGroup: 0, eliminated: true },
+      ]),
+      0
+    );
+    expect(capture.kills).toBe(2); // unchanged — dedup holds
   });
 });
 
@@ -192,6 +227,63 @@ describe('profileGameFromCapture', () => {
     expect(p.aggression).toBe(0); // 0 attacks over 1 active turn
     expect(p.zeroAttackTurnFrac).toBe(1);
     expect(p.survivalTurn).toBe(2);
+  });
+
+  it('a bot that never acted (0 active turns) degrades every rate axis to null, not garbage', () => {
+    const capture = {
+      playerIndex: 0,
+      activeTurns: 0,
+      territory: [],
+      dice: [],
+      largestGroup: [],
+      kills: 0,
+      eliminatedAtTurn: 1,
+      zeroAttackTurns: 0,
+    };
+    const result = baseResult({
+      winner: 1,
+      turnCount: 4,
+      botStats: [
+        {
+          playerIndex: 0,
+          placement: 3,
+          attacksMade: 0,
+          attacksWon: 0,
+          errors: 0,
+          invalidMoves: 0,
+          maxMovesHit: 0,
+        },
+      ],
+    });
+    const p = profileGameFromCapture(result, 0, capture);
+    expect(p.aggression).toBeNull();
+    expect(p.zeroAttackTurnFrac).toBeNull();
+    expect(p.avgTerritory).toBeNull();
+    expect(p.avgDiceReserve).toBeNull();
+    expect(p.survivalTurn).toBe(1); // death turn still valid
+    expect(p.placement).toBe(3);
+  });
+
+  it('throws on a missing botStats entry, a seat mismatch, and misaligned capture arrays (fail loud)', () => {
+    const aligned = {
+      playerIndex: 0,
+      activeTurns: 1,
+      territory: [5],
+      dice: [10],
+      largestGroup: [4],
+      kills: 0,
+      eliminatedAtTurn: null,
+      zeroAttackTurns: 0,
+    };
+    // No botStats for seat 5.
+    expect(() => profileGameFromCapture(baseResult(), 5, aligned)).toThrow(
+      /no botStats for seat 5/
+    );
+    // Capture built for a different seat than requested.
+    expect(() => profileGameFromCapture(baseResult(), 1, aligned)).toThrow(/capture seat 0 != 1/);
+    // territory/dice/largestGroup lengths disagree with activeTurns ⇒ would index past end → NaN.
+    const misaligned = { ...aligned, dice: [10, 99] }; // length 2 vs activeTurns 1
+    expect(() => profileGameFromCapture(baseResult(), 0, misaligned)).toThrow(/misaligned capture/);
   });
 });
 
@@ -294,6 +386,27 @@ describe('signaturePass — MDE gate prevents trivial-but-significant passes', (
     };
     expect(signaturePass(blitz, both, { aggression: 1, turnsToWin: 1 })).toBe(false);
   });
+
+  it('throws when a signature axis has no registered MDE (never silently disables the guard)', () => {
+    // An empty MDE map would have let `?? 0` make |Δ| ≥ 0 always true — the bug this guards.
+    expect(() => signaturePass(sig, vsControl, {})).toThrow(
+      /no MDE registered for axis "aggression"/
+    );
+  });
+
+  it('fails closed when a required axis has no comparison (compareAxis returned null)', () => {
+    // e.g. a rarely-winning persona yields mostly-null turnsToWin runs → compareAxis null.
+    const blitz = {
+      axes: [
+        { axis: 'aggression', direction: 'HIGHER' },
+        { axis: 'turnsToWin', direction: 'LOWER' },
+      ],
+      rule: 'AND',
+    };
+    const partial = { aggression: vsControl.aggression, turnsToWin: null };
+    expect(() => signaturePass(blitz, partial, { aggression: 1, turnsToWin: 5 })).not.toThrow();
+    expect(signaturePass(blitz, partial, { aggression: 1, turnsToWin: 5 })).toBe(false);
+  });
 });
 
 describe('§6 engine signal — runMatch passes actingPlayerId to onTurn', () => {
@@ -314,7 +427,25 @@ describe('§6 engine signal — runMatch passes actingPlayerId to onTurn', () =>
     }
   });
 
-  it('drives a real game through makeCapture/profileGameFromCapture without throwing', () => {
+  it('actor firings round-robin across seats and match each seat-0 active turn', () => {
+    // Cross-check the §6 actor against the engine: capture.activeTurns for seat 0 must equal the
+    // number of onTurn firings where actor === 0. A wrong-actor regression (e.g. passing
+    // currentPlayerIndex instead of currentPlayerId, or any off-by-one) breaks this — a bare
+    // in-range check would not. Also assert every seat acts at least once (round-robin sanity).
+    const { capture, onTurn, onStep } = makeCapture(0);
+    const seenActors = new Set();
+    let seat0Firings = 0;
+    const wrapped = (t, s, actor) => {
+      seenActors.add(actor);
+      if (actor === 0) seat0Firings += 1;
+      onTurn(t, s, actor);
+    };
+    runMatch({ bots: field, seed: 11, onTurn: wrapped, onStep });
+    expect(seat0Firings).toBe(capture.activeTurns);
+    for (let seat = 0; seat < field.length; seat++) expect(seenActors.has(seat)).toBe(true);
+  });
+
+  it('drives a real game and produces populated, finite capture metrics (not a no-op)', () => {
     const { capture, onTurn, onStep } = makeCapture(0);
     const result = runMatch({ bots: field, seed: 7, onTurn, onStep });
     const p = profileGameFromCapture(result, 0, capture);
@@ -322,9 +453,84 @@ describe('§6 engine signal — runMatch passes actingPlayerId to onTurn', () =>
     expect(p.placement).toBeLessThanOrEqual(field.length);
     expect(typeof p.kills).toBe('number');
     expect(p.survivalTurn).toBeGreaterThan(0);
+    // The capture must actually populate from the real engine — guards against a wrong-actor
+    // regression that would leave activeTurns at 0 and every board axis null while still "passing".
+    expect(capture.activeTurns).toBeGreaterThan(0);
+    expect(Number.isFinite(p.aggression)).toBe(true);
+    expect(Number.isFinite(p.avgTerritory)).toBe(true);
+    expect(Number.isFinite(p.avgDiceReserve)).toBe(true);
     // summarizeAxis tolerates a single run (ci null, n 1).
     const s = summarizeAxis([reduceRun([p]).avgPlacement]);
     expect(s.n).toBe(1);
     expect(s.ci).toBeNull();
+  });
+});
+
+describe('summarizeAxis', () => {
+  it('summarizes ≥2 finite runs to mean ± CI with the run count', () => {
+    const s = summarizeAxis([4, 6, 5]);
+    expect(s.mean).toBe(5);
+    expect(s.n).toBe(3);
+    expect(s.ci).toBeGreaterThan(0);
+  });
+
+  it('ignores null runs in the count, and returns null when nothing is finite', () => {
+    expect(summarizeAxis([3, null, 5]).n).toBe(2);
+    expect(summarizeAxis([null, null])).toBeNull();
+    expect(summarizeAxis([])).toBeNull();
+  });
+});
+
+describe('compareToControl', () => {
+  // Three runs each; persona is clearly higher on aggression, identical-ish elsewhere, and has a
+  // winners-only axis (turnsToWin) that is all-null for the persona → that axis must compare null.
+  const personaRuns = [
+    { ...reduceShape(), aggression: 5, turnsToWin: null },
+    { ...reduceShape(), aggression: 6, turnsToWin: null },
+    { ...reduceShape(), aggression: 7, turnsToWin: null },
+  ];
+  const controlRuns = [
+    { ...reduceShape(), aggression: 2, turnsToWin: 30 },
+    { ...reduceShape(), aggression: 3, turnsToWin: 31 },
+    { ...reduceShape(), aggression: 2, turnsToWin: 30 },
+  ];
+
+  it('keys every output by AXES, reports HIGHER on the moved axis, and null on an all-null axis', () => {
+    const out = compareToControl(personaRuns, controlRuns);
+    expect(Object.keys(out).sort()).toEqual([...AXES].sort());
+    expect(out.aggression.verdict).toBe('HIGHER');
+    expect(out.aggression.lo).toBeGreaterThan(0);
+    expect(out.turnsToWin).toBeNull(); // persona never won → no paired runs survive
+  });
+});
+
+describe('config invariants — AXES is the single source of truth', () => {
+  it('every PERSONA_SIGNATURES axis is an AXES key with a direction and a DEFAULT_MDE entry', () => {
+    // If this fails, the offending persona/axis is named in the assertion's received value.
+    for (const sig of Object.values(PERSONA_SIGNATURES)) {
+      for (const { axis, direction } of sig.axes) {
+        expect(AXES).toContain(axis);
+        expect(['HIGHER', 'LOWER']).toContain(direction);
+        expect(typeof DEFAULT_MDE[axis]).toBe('number');
+      }
+    }
+  });
+
+  it('reduceRun produces exactly the AXES key set', () => {
+    const sample = {
+      won: true,
+      placement: 1,
+      turnsToWin: 20,
+      aggression: 4,
+      captureEfficiency: 0.7,
+      avgDiceReserve: 9,
+      avgTerritory: 8,
+      dicePerTerritory: 1.2,
+      largestGroup: 6,
+      kills: 2,
+      survivalTurn: 20,
+      zeroAttackTurnFrac: 0.1,
+    };
+    expect(Object.keys(reduceRun([sample])).sort()).toEqual([...AXES].sort());
   });
 });

--- a/tests/behaviorCore.test.js
+++ b/tests/behaviorCore.test.js
@@ -23,6 +23,7 @@ import {
 } from '../scripts/lib/behavior-core.mjs';
 import { runMatch } from '../src/arena/matchRunner.js';
 import { BUILT_IN_BOTS } from '../src/arena/builtInBots.js';
+import { isStopMove } from '../src/arena/trajectoryExport.js';
 
 const STOP = { type: 'END_TURN' };
 const attack = (from = 1, to = 2) => ({ from, to });
@@ -353,6 +354,24 @@ describe('alignDropNull + compareAxis (paired control comparison)', () => {
   it('returns null when fewer than 2 paired runs survive null-alignment', () => {
     expect(compareAxis([1, null, null], [null, 2, null])).toBeNull();
   });
+
+  it('treats a non-finite (NaN/Infinity) run as dropped data, not a paired value', () => {
+    // A NaN must never reach pairedDelta: it would yield a NaN CI that classifyGate reads as a
+    // bogus SAME at full n — the "failed measurement masquerading as no-difference" the harness
+    // exists to prevent. alignDropNull drops the index from BOTH sides.
+    expect(alignDropNull([1, NaN, 3, 4], [10, 20, 30, 40])).toEqual({
+      a: [1, 3, 4],
+      b: [10, 30, 40],
+      n: 3,
+    });
+    expect(alignDropNull([1, Infinity, 3], [10, 20, 30]).n).toBe(2);
+    // One NaN among otherwise-significant runs degrades to a clean comparison on the rest, never NaN.
+    const cmp = compareAxis([5, NaN, 7, 5, 6], [2, 3, 2, 3, 2]);
+    expect(Number.isFinite(cmp.delta)).toBe(true);
+    expect(cmp.n).toBe(4);
+    // Too few finite runs after dropping NaNs ⇒ null (no comparison), not a NaN verdict.
+    expect(compareAxis([5, NaN, NaN], [2, 3, 2])).toBeNull();
+  });
 });
 
 describe('signaturePass — MDE gate prevents trivial-but-significant passes', () => {
@@ -427,22 +446,55 @@ describe('§6 engine signal — runMatch passes actingPlayerId to onTurn', () =>
     }
   });
 
-  it('actor firings round-robin across seats and match each seat-0 active turn', () => {
-    // Cross-check the §6 actor against the engine: capture.activeTurns for seat 0 must equal the
-    // number of onTurn firings where actor === 0. A wrong-actor regression (e.g. passing
-    // currentPlayerIndex instead of currentPlayerId, or any off-by-one) breaks this — a bare
-    // in-range check would not. Also assert every seat acts at least once (round-robin sanity).
-    const { capture, onTurn, onStep } = makeCapture(0);
+  it('the onTurn actor is exactly the player who acted that turn — cross-checked vs onStep.playerId', () => {
+    // onStep.playerId is set in buildStep (turnOrder[currentPlayerIndex], DURING the turn); the
+    // onTurn actor is currentPlayerId captured in runMatch's loop — two INDEPENDENT call sites.
+    // A seat-index-vs-id swap or a next-player off-by-one in the onTurn arg desyncs them. A
+    // single-source check like `seat0Firings === capture.activeTurns` cannot catch that: both
+    // counters read the SAME actor arg, so they stay equal for any actor stream (correct OR wrong).
+    const mismatches = [];
     const seenActors = new Set();
-    let seat0Firings = 0;
-    const wrapped = (t, s, actor) => {
-      seenActors.add(actor);
-      if (actor === 0) seat0Firings += 1;
-      onTurn(t, s, actor);
-    };
-    runMatch({ bots: field, seed: 11, onTurn: wrapped, onStep });
-    expect(seat0Firings).toBe(capture.activeTurns);
+    let turnsChecked = 0;
+    let stepIds = new Set();
+    runMatch({
+      bots: field,
+      seed: 11,
+      onStep: step => stepIds.add(step.playerId),
+      onTurn: (_t, _s, actor) => {
+        turnsChecked += 1;
+        seenActors.add(actor);
+        // Every step this turn is by the acting player → exactly one distinct id, equal to `actor`.
+        const ids = [...stepIds];
+        if (ids.length !== 1 || ids[0] !== actor) {
+          mismatches.push({ turn: turnsChecked, actor, ids });
+        }
+        stepIds = new Set();
+      },
+    });
+    expect(mismatches).toEqual([]);
+    expect(turnsChecked).toBeGreaterThan(field.length); // drove a real multi-turn game, not a no-op
     for (let seat = 0; seat < field.length; seat++) expect(seenActors.has(seat)).toBe(true);
+  });
+
+  it('onStep populates from the real engine: seat-0 non-STOP steps reconcile with attacksMade', () => {
+    // Pins the real TrajectoryStep shape (step.playerId + step.chosenMove) end-to-end and exercises
+    // the _sinceStop/zeroAttackTurns wiring against the engine — the synthetic makeCapture tests
+    // fabricate steps, so without this a renamed/reshaped step field would silently early-return in
+    // onStep (leaving zeroAttackTurns at 0) with no test noticing.
+    const { capture, onTurn, onStep } = makeCapture(0);
+    let nonStopSteps = 0;
+    const result = runMatch({
+      bots: field,
+      seed: 11,
+      onTurn,
+      onStep: step => {
+        onStep(step);
+        if (step.playerId === 0 && !isStopMove(step.chosenMove)) nonStopSteps += 1;
+      },
+    });
+    expect(nonStopSteps).toBe(result.botStats[0].attacksMade);
+    // Each zero-attack turn is one of the bot's own turns, so it can't exceed the active-turn count.
+    expect(capture.zeroAttackTurns).toBeLessThanOrEqual(capture.activeTurns);
   });
 
   it('drives a real game and produces populated, finite capture metrics (not a no-op)', () => {
@@ -478,6 +530,14 @@ describe('summarizeAxis', () => {
     expect(summarizeAxis([3, null, 5]).n).toBe(2);
     expect(summarizeAxis([null, null])).toBeNull();
     expect(summarizeAxis([])).toBeNull();
+  });
+
+  it('ignores non-finite runs (NaN/Infinity) so a stray value never poisons the mean/CI', () => {
+    const s = summarizeAxis([4, NaN, 6, Infinity, 5]);
+    expect(s.n).toBe(3); // only the three finite runs
+    expect(s.mean).toBe(5);
+    expect(Number.isFinite(s.ci)).toBe(true);
+    expect(summarizeAxis([NaN, Infinity])).toBeNull();
   });
 });
 


### PR DESCRIPTION
## What

Plan + Phase-1 measurement scaffolding for a future roster of PPO bots trained with
different reward objectives ("personalities"). **Parked** for after `ppo-long` — nothing
here touches training, and the harness runs against existing built-in bots today.

### Design docs (parked)
- **`docs/ml-bot/PERSONAS.md`** — reward-shaped persona roster: Conqueror (control), Blitz
  (tempo), Expansionist, Predator, Survivor. The tempo idea = **lowering `gamma`** (the
  current `0.999` is why the PPO bot turtles); multiplicative time-discount is the safe
  formulation (an additive step penalty can make the bot throw games to end them). Covers
  reward divergence-from-win, reward-hacking failure modes, and the two orthogonal axes
  (reward objective × opponent field).
- **`docs/ml-bot/EVAL_HARNESS.md`** — behavioral-eval harness spec, grounded via a parallel
  code-map + a feasibility/completeness review. Adds the **dice-reserve "turtle" axis** the
  win% gate can't see, plus statistical rigor (MDE/power so "distinct" can't fire on a
  trivial difference; Holm over one pre-registered signature per persona; null-run policy;
  honest seed-level pairing).

### Harness (Phase 1 — built, validated on built-ins)
- **`src/arena/matchRunner.js`** — `onTurn` now passes `actingPlayerId` (3rd arg,
  backward-compatible). Fixes an aggression metric bias (a winning turn emits no STOP step →
  STOP-counting undercounts active turns exactly on won games) and enables O(1) kill
  attribution without a second replay pass.
- **`scripts/lib/behavior-core.mjs`** — pure logic: per-game metric extraction, per-run
  aggregation, paired persona-vs-control comparison, MDE-gated `signaturePass` +
  `PERSONA_SIGNATURES`/`DEFAULT_MDE` stubs for Phase 2.
- **`scripts/behavior-profile.mjs`** — `npm run behavior:profile`. Fixed standard field
  (personas are **not** pitted against each other), seat-fair rotation, paired vs a control.
- **`tests/behaviorCore.test.js`** — 17 tests.

## Why

The `ppo:gate` answers "is it stronger?"; it is blind to play-style. This harness answers
"is it different, and how?" so a personality roster can be measured rather than asserted.

## Verification
- ✅ Full suite **1180 passing** (78 files); lint + prettier clean; build OK.
- ✅ Live acceptance: `Strategist` vs `Defensive` separate on aggression (CI excludes 0).
- ✅ Adversarially reviewed against the engine's elimination semantics — no correctness bugs.
- The `onTurn` arity change is backward-compatible; all `onTurn` consumers (incl. the
  ppo-env server) stay green.

## Scope note
The five persona bots don't exist yet — Phase 2 wires their trained weights into the
`PERSONA_SIGNATURES` stubs. This PR is the plan + the harness that will measure them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
