### PR TITLE
ci: bump GitHub Actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
         node-version: [22.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -58,7 +58,7 @@ jobs:
           npm run ppo:booking-smoke
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage
           path: coverage

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,11 +25,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
       - name: Install dependencies
@@ -37,7 +37,7 @@ jobs:
       - name: Build
         run: npm run build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: './dist'
 
@@ -51,4 +51,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/ml-ci.yml
+++ b/.github/workflows/ml-ci.yml
@@ -23,10 +23,10 @@ jobs:
         working-directory: ml
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/tournament.yml
+++ b/.github/workflows/tournament.yml
@@ -23,14 +23,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Admin-scoped PAT so the results push bypasses the branch ruleset
           # (default GITHUB_TOKEN is github-actions[bot], which isn't an admin).
           token: ${{ secrets.TOURNAMENT_PAT }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 

--- a/.github/workflows/validate-bots.yml
+++ b/.github/workflows/validate-bots.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout base
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout PR community-bots only
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: pr-bots
@@ -27,7 +27,7 @@ jobs:
         run: cp -r pr-bots/community-bots/* community-bots/
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 
@@ -40,7 +40,7 @@ jobs:
 
       - name: Comment validation results on PR
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
## What

Bumps every first-party GitHub Action to its latest stable major that targets the **Node 24** runtime, clearing the Node-20 deprecation warning surfaced on CI (`checkout@v4` / `setup-node@v4` / `upload-artifact@v4` were already being force-run on Node 24).

| Action | From | To | Notes |
| --- | --- | --- | --- |
| `actions/checkout` | v4 | **v5** (×7) | capped — see below |
| `actions/setup-node` | v4 | **v6** (×4) | |
| `actions/upload-artifact` | v4 | **v7** | v5 is a trap (still node20); v6 is the first node24 major |
| `actions/setup-python` | v5 | **v6** | `ml-ci.yml` |
| `actions/github-script` | v7 | **v8** | `validate-bots.yml` |
| `actions/configure-pages` | v4 | **v6** | `deploy.yml` |
| `actions/deploy-pages` | v4 | **v5** | `deploy.yml` |
| `actions/upload-pages-artifact` | v3 | **v5** | `deploy.yml`; composite, bundles `upload-artifact@v7` |

All target tags were confirmed to exist with `runs.using: node24` via the GitHub API (`upload-pages-artifact@v5` is `composite`, as expected).

## Why checkout is capped at v5 (not the newest major)

An adversarial review of each bump caught two breaking changes that a naive "go to latest" would have hit:
- **v6** persists git credentials to a separate file → would break `tournament.yml`'s later `git push` with the persisted `TOURNAMENT_PAT`.
- **v7** blocks fork-PR checkout under `pull_request_target` → would break `validate-bots.yml`'s second checkout of the PR head SHA.

So `checkout` stays at **v5** (the first node24 major), preserving both behaviors.

## Scope / safety

- Version-string-only changes — **no `with:` migrations required**. The inputs we use (`token`, `ref`/`path`/`sparse-checkout`, `cache`/`cache-dependency-path`, `node-version`, `python-version`, the `github-script` body) are unchanged across these majors.
- The Pages trio (`configure-pages@v6` / `upload-pages-artifact@v5` / `deploy-pages@v5`) is the matched current set.
- `anthropics/claude-code-action@beta` is intentionally left on its moving tag (not a Node-runtime concern).
- All six workflows parse as valid YAML; Prettier clean.

CI on this PR will exercise `checkout@v5` / `setup-node@v6` / `upload-artifact@v7` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)