### PR TITLE
docs: list ai_ppo (and ai_bc) in the roster docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,10 +115,11 @@ DiceWarsJS is a turn-based strategy game where players compete to conquer territ
   - ai_defensive: Prioritizes protecting vulnerable territories
   - ai_example: Basic implementation for educational purposes
   - ai_adaptive: Adapts strategy based on game conditions
-  - ai_strategist: Expected-value strategy using exact dice odds and connectivity economics (strongest in arena benchmarks; authored by Claude Opus 4.8)
+  - ai_strategist: Expected-value strategy using exact dice odds and connectivity economics (strongest hand-written/heuristic bot; authored by Claude Opus 4.8)
   - ai_lookahead: Standalone shallow-expectimax search over win/loss branches with board-value evaluation (authored by GPT-5.5)
   - ai_expectimax: Chance-node expectimax over the exact battle distribution — the "search-first" ML-bot baseline (docs/ml-bot/), at parity with ai_lookahead
-  - ai_bc: Behavioral-cloning net that imitates ai_lookahead, running in-browser via a pure-JS forward pass (bcForward.js) over exported weights (bcPolicyWeights.js); ml-bot Phase 2
+  - ai_bc: Behavioral-cloning net that imitates ai_lookahead, running in-browser via a pure-JS forward pass (bcForward.js) over exported weights (bcPolicyWeights.js); ml-bot Phase 2 (arena/tournament entrant; not in the in-game picker)
+  - ai_ppo: Self-play PPO net (ml-bot Phase 3) — trained by reinforcement learning against a PFSP league, running in-browser via the same pure-JS forward pass (bcForward.js) over its own exported weights (ppoPolicyWeights.js, distinct from bcPolicyWeights.js). The first ML bot to beat ai_lookahead head-to-head (seat-fair win-rate Δ +27.7 pp); selectable in-game at difficulty 5 and a default tournament/leaderboard entrant
 
 - **Bot Arena** (src/arena/): Headless bot-vs-bot tournament system — ELO ratings (elo.js), match/tournament runners, custom-bot compilation & validation, replay format. Powers `npm run arena`, the in-game Arena screen, and the CLI bot tooling. See docs/BOT_GUIDE.md for authoring a bot (a function: state → { from, to } | null).
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Built on the original [Dice Wars](https://www.gamedesign.jp/games/dicewars/) by 
 - **Configurable map size** — pick Small (20×24), Medium (28×32, default) or Large (36×40) before each game
 - **Bot SDK** — write a bot in a single function and compete in the arena
 - **Arena mode** — run tournaments with ELO ratings and match replays
-- **7 built-in AI strategies** — from random to exact-odds EV and chance-node search
+- **9 built-in AI strategies** — from random to exact-odds EV, chance-node search, and self-play neural nets
 - **PixiJS rendering** — WebGL-accelerated hex grid with dice animations
 - **Mobile-friendly** — responsive design with touch support
 
@@ -97,7 +97,7 @@ src/
 ├── renderer/     PixiJS rendering (hex grid, dice, animations)
 ├── ui/           Preact components (screens, HUD, overlays)
 ├── arena/        Bot SDK (validation, execution, tournaments, ELO, replays)
-├── ai/           7 AI strategies (example, default, defensive, adaptive, Strategist, Lookahead, Expectimax)
+├── ai/           9 AI strategies (example, default, defensive, adaptive, Strategist, Lookahead, Expectimax, BC, PPO)
 ├── store/        Observable GameStore (pub/sub shared state)
 ├── controller/   GameController (game loop orchestrator)
 ├── audio/        Web Audio sound manager
@@ -117,10 +117,12 @@ See [Architecture](docs/ARCHITECTURE.md) for how data flows through the system.
 | **Strategist** (`ai_strategist.js`) | Exact expected value using odds and income                |
 | **Lookahead** (`ai_lookahead.js`)   | Shallow expectimax over win/loss branches                 |
 | **Expectimax** (`ai_expectimax.js`) | Chance-node expectimax over the exact battle distribution |
+| **BC** (`ai_bc.js`)                 | Neural net imitating Lookahead (arena/tournament only)    |
+| **PPO** (`ai_ppo.js`)               | Self-play neural net — the strongest built-in bot         |
 
-> **Strategist** and **Lookahead** are the two strongest built-in bots, each authored by an AI coding assistant: Strategist by **Claude Opus 4.8** and Lookahead by **GPT-5.5**. The names describe their technique (expected-value scoring vs. shallow search) rather than the tool that wrote them.
+> **Strategist** and **Lookahead** are the strongest _heuristic_ built-in bots, each authored by an AI coding assistant: Strategist by **Claude Opus 4.8** and Lookahead by **GPT-5.5**. The names describe their technique (expected-value scoring vs. shallow search) rather than the tool that wrote them.
 >
-> **Expectimax** is the search-first baseline of the [ML-bot initiative](docs/ml-bot/) — a depth-2 chance-node search that scores the positions resulting from each attack's win/loss outcomes, weighted by exact dice odds.
+> **Expectimax**, **BC**, and **PPO** make up the [ML-bot initiative](docs/ml-bot/). **Expectimax** is the search-first baseline — a depth-2 chance-node search that scores the positions resulting from each attack's win/loss outcomes, weighted by exact dice odds. **BC** imitates Lookahead from a self-play corpus (an arena/tournament bot, not in the in-game picker). **PPO** is a neural net trained by self-play reinforcement learning against a league of opponents — the first ML bot to beat Lookahead head-to-head (a +27.7-point win-rate edge in seat-fair play) and now the strongest built-in bot, selectable in-game at difficulty 5.
 
 ## Documentation
 

--- a/src/README.md
+++ b/src/README.md
@@ -39,6 +39,10 @@ Built-in strategies live in `src/ai/`, registered with metadata in `aiConfig.js`
 - `ai_adaptive` — adapts to game conditions
 - `ai_strategist` — exact expected-value using dice odds and connectivity economics (authored by Claude Opus 4.8)
 - `ai_lookahead` — standalone shallow expectimax over win/loss branches (authored by GPT-5.5)
+- `ai_expectimax` — chance-node expectimax over the exact battle distribution (the ML-bot search baseline)
+- `ai_ppo` — self-play PPO neural net trained against a league of bots; the strongest built-in bot and the first ML bot to beat `ai_lookahead` head-to-head (ml-bot Phase 3)
+
+A behavioral-cloning net, `ai_bc` (ml-bot Phase 2, imitates `ai_lookahead` via a pure-JS forward pass), also ships as an arena/tournament bot — it's registered in `src/arena/builtInBots.js` rather than `aiConfig.js`, so it isn't selectable in the in-game opponent picker.
 
 ### Writing an AI
 


### PR DESCRIPTION
Closes the pre-existing PR #74 roster-docs gap, now relevant after #78 made `ai_ppo` the deployed (and strongest) built-in bot. **Docs only** — no code touched.

## What changed

- **`README.md`** — add **BC** and **PPO** rows to the AI Strategies table; rewrite the explanatory note as the ML-bot trajectory (Expectimax search baseline → BC imitation → PPO self-play, the first ML bot to beat Lookahead head-to-head, +27.7 pp seat-fair win-rate edge); bump "**7** built-in AI strategies"→**9** and the `src/ai` tree comment.
- **`CLAUDE.md`** — add the `ai_ppo` bullet (Phase 3, own `ppoPolicyWeights.js` distinct from `bcPolicyWeights.js`, beats `ai_lookahead`, in-game difficulty 5 + tournament entrant); annotate `ai_bc` as arena/tournament-only; qualify `ai_strategist` as the strongest *heuristic* bot (PPO now wins on head-to-head win rate).
- **`src/README.md`** — add `ai_expectimax` + `ai_ppo` to the dev list (both registered in `aiConfig.js`); add a note that `ai_bc` ships via `src/arena/builtInBots.js`, **not** `aiConfig.js`, so it isn't in the in-game opponent picker.

## Accuracy notes

Verified against the live wiring before writing:
- `ai_ppo` is in **both** `aiConfig.js` (in-game picker, difficulty 5) **and** `builtInBots.js` (arena/tournament).
- `ai_bc` is in `builtInBots.js` **only** (arena/tournament) — *not* in the in-game picker. The docs now state this precisely rather than implying it's selectable in-game.
- `BOT_GUIDE.md` is an SDK/authoring guide that doesn't enumerate the roster by bot name, so there was nothing to add there (the #74 follow-up note's "BOT_GUIDE" was imprecise).

## Verification

`prettier --check README.md CLAUDE.md src/README.md` clean (also enforced by the husky pre-commit hook). No code, no tests affected.