### PR TITLE
feat(ml): behavior-eval harness can gate a persona (weight-file loading + signature verdict + MDE calibration)

### DIFF
--- a/docs/ml-bot/EVAL_HARNESS.md
+++ b/docs/ml-bot/EVAL_HARNESS.md
@@ -18,15 +18,23 @@
 >
 > - **Phase 1 — ✅ BUILT (2026-06-28):** the harness + its tests, validated on _existing built-ins_.
 >   Shipped: the §6 engine signal (`onTurn(…, actingPlayerId)` in `matchRunner.js`),
->   `scripts/lib/behavior-core.mjs` (pure logic, 17 unit tests), `scripts/behavior-profile.mjs`
+>   `scripts/lib/behavior-core.mjs` (pure logic, 42 unit tests as of bite E1), `scripts/behavior-profile.mjs`
 >   (`npm run behavior:profile`), `tests/behaviorCore.test.js`. Acceptance check (a **manual pilot**,
 >   not an automated assertion — the exact Δ depends on field & budget): `Strategist` vs `Defensive`
 >   separate on aggression / zero-attack-turn fraction with a CI excluding 0 at a small pilot budget.
 >   Adversarially reviewed (kill-attribution timing, seat mapping, null-alignment) — clean.
-> - **Phase 2 (after the personas are trained):** point it at the persona weight files and produce the
->   signature table. The persona rows in §8 are **aspirational** until those bots exist; the
->   `PERSONA_SIGNATURES` / `DEFAULT_MDE` stubs in `behavior-core.mjs` already encode the pre-registered
->   hypotheses so the multiplicity story is fixed in advance.
+> - **Phase 2a — ✅ BUILT (2026-06-29, "bite E1"):** the harness can now load a freshly-exported
+>   persona and gate it. `--bots`/`--control` accept a `Name=path/to/weights.js` spec, loaded +
+>   parity-checked via the same `loadExportedPolicy → makeBC` path as `ppo:gate` (`parseBotSpec` in
+>   `behavior-core.mjs`); when a profiled bot's name matches a `PERSONA_SIGNATURES` key, its
+>   pre-registered signature is gated **PASS/FAIL** in the console + JSON (`signatureDetail`), with the
+>   placeholder MDEs calibratable from the pilot via `--mde axis:value,...` (`parseMdeOverrides`).
+>   Smoke-verified end-to-end against a persona-named export. So the §8 persona rows are now
+>   **runnable** the moment the weight files exist — no harness code change needed.
+> - **Phase 2b (still TODO — separable follow-ups):** Holm adjustment across the ≤5 confirmatory tests
+>   (a no-op for a 1–2-persona pilot), §3.6 determinism enforcement in the loader, the §3.8
+>   training-field-match assertion, the §3.5 `--melee` persona×persona separation matrix, `--csv`, the
+>   territory _curve_/AUC + border-exposure axes, and the with/without-quarantine dual pass.
 
 ---
 
@@ -253,32 +261,38 @@ summarizeAxis(perRunValues[]) -> { mean, ci, n } | null // mean ± 95% CI; n = R
 alignDropNull(a[], b[]) -> { a[], b[], n }              // drop indices null on either side (§3.4)
 compareAxis(personaRuns[], controlRuns[]) -> { delta, ci, lo, hi, verdict, n } | null  // paired Δ
 compareToControl(personaRuns[], controlRuns[]) -> Record<axis, compareAxis-result | null>
-signaturePass(signature, vsControl, mde) -> boolean     // §3.2 MDE AND CI-excludes-0; THROWS w/o MDE
+signatureDetail(signature, vsControl, mde) -> { pass, rule, axes[] }  // per-axis meetsMde/sigInDir/ok
+signaturePass(signature, vsControl, mde) -> boolean     // = signatureDetail(...).pass; THROWS w/o MDE
+parseBotSpec(spec) -> { name, weightsPath|null }        // "Name" (built-in) vs "Name=weights.js"
+parseMdeOverrides(str, base=DEFAULT_MDE) -> Record<axis, number>  // "--mde axis:val,..." merged over base
 
 AXES                // the canonical axis-key list (single source of truth)
-PERSONA_SIGNATURES  // persona -> { axes: [{ axis, direction }], rule: 'AND'|'single' }   (Phase-2 stub)
+PERSONA_SIGNATURES  // persona -> { axes: [{ axis, direction }], rule: 'AND'|'single' }   (gated when a profiled bot's name matches)
 DEFAULT_MDE         // partial Record<axis, number>; a signature axis MUST have an entry (else throws)
 ```
 
-> **Not yet built (Phase 2 / future):** `aggregateCurves` (territory _curve_ alignment/padding),
+> **Not yet built (Phase 2b / future):** `aggregateCurves` (territory _curve_ alignment/padding),
 > `separationMatrix` (§3.5 persona×persona melee), Holm adjustment across the 5 confirmatory tests, and
 > the `--melee`/`--csv` CLI modes. The shipped `summarizeAxis` is the `aggregateRuns` thin-`meanCi`
 > wrapper the draft named. The terminal-stat math (`avgPlacement`, win%, capture-efficiency) is computed
 > in `behavior-core.mjs` directly; extracting a shared helper from `arenaRunner.js:130-168` remains a
-> **TODO** (the one duplication the review flagged).
+> **TODO** (the one duplication the review flagged). Weight-file bot loading + the signature PASS/FAIL
+> verdict + `--mde` calibration are **now built** (Phase 2a, "bite E1").
 
 ### CLI
 
 ```
 node scripts/behavior-profile.mjs \
-  --bots PPO,Blitz,Expansionist,Predator,Survivor \   # profiled seats (Phase 2)
+  --bots Blitz=ml/runs/ppo-blitz/blitz.weights.js \   # profiled seat(s): built-in name OR Name=weights.js
+  --control Conqueror=ml/runs/ppo-conqueror/conqueror.weights.js \  # matched control; auto-injected into the profiled set
   --opponents Default,Defensive,Strategist,Adaptive,Expectimax,Lookahead \  # fixed FFA filler; MUST include the reference
   --reference Lookahead \                              # win%-vs-ref; one of --opponents (fills a seat in every field)
-  --control Conqueror \                               # auto-injected into the profiled set if absent
-  --runs 20 --games 150 \                             # CALIBRATE via §3.2 pilot, don't hard-code
+  --mde aggression:1.5,turnsToWin:8 \                 # CALIBRATE the signature thresholds from the §3.2 pilot
+  --runs 20 --games 150 \                             # CALIBRATE runs/games via the §3.2 pilot, don't hard-code
   --no-quarantine \                                   # run a second, unfiltered pass (§3.7)
   --json                                              # JSON->stdout, human table->stderr
-  # --melee (§3.5 persona×persona) is NOT yet implemented — Phase 2.
+  # A weights bot named `Blitz` opts into PERSONA_SIGNATURES.Blitz → a PASS/FAIL verdict vs the control.
+  # --melee (§3.5 persona×persona) is NOT yet implemented — Phase 2b.
 ```
 
 Above is a 7-seat field (6 opponents incl. the reference + 1 profiled seat). The reference **must** be
@@ -314,24 +328,24 @@ The **control is always profiled** with identical run/game/rotation config (auto
 
 ## 5. Reused utilities (exact)
 
-| Function                                 | File:line                                             | Use                                                                                     |
-| ---------------------------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| `runMatch` + `onTurn`/`onStep`           | `matchRunner.js:229-366` (cb `:213/:219`)             | run each game, stream board + step signals                                              |
-| `botStats`                               | `matchRunner.js:341-352`                              | (a num),(d),(e),(g),(i), quarantine                                                     |
-| `MatchResult` winner/turnCount           | `matchRunner.js:355/:357`                             | (d),(f)                                                                                 |
-| `calculatePlacements`                    | `matchRunner.js:375-395`                              | placement ranks (already applied)                                                       |
-| `recalcPlayerStats`                      | `StateManager.js:108-117`                             | territoryCount (b), diceCount (g)                                                       |
-| `applyAction`                            | `StateManager.js:161-173`                             | replay re-sim (kills fallback)                                                          |
-| `trajectoryFromReplay` / `replayToState` | `trajectoryExport.js:246` / `replayFormat.js:198-208` | kill-attribution fallback (no §6)                                                       |
-| `isStopMove` / `buildStep`               | `trajectoryExport.js:61` / `:129-140`                 | ATTACK vs STOP in `onStep`                                                              |
-| `botState` isBorder/connected            | `botState.js:50` / `:74`                              | (k) border, (l) largest group                                                           |
-| `meanCi` / `tCrit` / `mean`              | `stats.mjs:60-66 / :50 / :53`                         | mean ± 95% CI — **CI math reused**                                                      |
-| `pairedDelta` / `classifyGate`           | `ppo-gate-core.mjs:31-41 / :53-57`                    | paired Δ + HIGHER/SAME/LOWER                                                            |
-| `rotatedField` / `buildGateField`        | `ppo-gate-core.mjs:127-132 / :103-112`                | seat fairness, field guardrails                                                         |
-| arenaRunner accumulators                 | `arenaRunner.js:130-168`                              | **extract** shared terminal-stat helper                                                 |
-| `BUILT_IN_BOTS`                          | `builtInBots.js:21`                                   | built-in enumeration (`ai_ppo` `:44`)                                                   |
-| `resolveBot`/`loadBot`/`getArg`          | `cli-utils.mjs:49/:37`, `cli-args.mjs:25`             | arg parsing (`getArg`/`hasFlag`) now; `resolveBot`/`loadBot` = Phase-2 weight-file bots |
-| JSON-stdout / table-stderr               | `_tune.mjs:130-142`                                   | dual output                                                                             |
+| Function                                           | File:line                                                    | Use                                                                                             |
+| -------------------------------------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| `runMatch` + `onTurn`/`onStep`                     | `matchRunner.js:229-366` (cb `:213/:219`)                    | run each game, stream board + step signals                                                      |
+| `botStats`                                         | `matchRunner.js:341-352`                                     | (a num),(d),(e),(g),(i), quarantine                                                             |
+| `MatchResult` winner/turnCount                     | `matchRunner.js:355/:357`                                    | (d),(f)                                                                                         |
+| `calculatePlacements`                              | `matchRunner.js:375-395`                                     | placement ranks (already applied)                                                               |
+| `recalcPlayerStats`                                | `StateManager.js:108-117`                                    | territoryCount (b), diceCount (g)                                                               |
+| `applyAction`                                      | `StateManager.js:161-173`                                    | replay re-sim (kills fallback)                                                                  |
+| `trajectoryFromReplay` / `replayToState`           | `trajectoryExport.js:246` / `replayFormat.js:198-208`        | kill-attribution fallback (no §6)                                                               |
+| `isStopMove` / `buildStep`                         | `trajectoryExport.js:61` / `:129-140`                        | ATTACK vs STOP in `onStep`                                                                      |
+| `botState` isBorder/connected                      | `botState.js:50` / `:74`                                     | (k) border, (l) largest group                                                                   |
+| `meanCi` / `tCrit` / `mean`                        | `stats.mjs:60-66 / :50 / :53`                                | mean ± 95% CI — **CI math reused**                                                              |
+| `pairedDelta` / `classifyGate`                     | `ppo-gate-core.mjs:31-41 / :53-57`                           | paired Δ + HIGHER/SAME/LOWER                                                                    |
+| `rotatedField` / `buildGateField`                  | `ppo-gate-core.mjs:127-132 / :103-112`                       | seat fairness, field guardrails                                                                 |
+| arenaRunner accumulators                           | `arenaRunner.js:130-168`                                     | **extract** shared terminal-stat helper                                                         |
+| `BUILT_IN_BOTS`                                    | `builtInBots.js:21`                                          | built-in enumeration (`ai_ppo` `:44`)                                                           |
+| `getArg`/`hasFlag` + `loadExportedPolicy`/`makeBC` | `cli-utils.mjs:37/:49`, `load-bc-policy.mjs:163`, `ai_bc.js` | arg parsing; weight-file bots loaded + parity-checked exactly like `ppo:gate` (Phase-2a, built) |
+| JSON-stdout / table-stderr                         | `_tune.mjs:130-142`                                          | dual output                                                                                     |
 
 ---
 

--- a/docs/ml-bot/EVAL_HARNESS.md
+++ b/docs/ml-bot/EVAL_HARNESS.md
@@ -328,24 +328,24 @@ The **control is always profiled** with identical run/game/rotation config (auto
 
 ## 5. Reused utilities (exact)
 
-| Function                                           | File:line                                                    | Use                                                                                             |
-| -------------------------------------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
-| `runMatch` + `onTurn`/`onStep`                     | `matchRunner.js:229-366` (cb `:213/:219`)                    | run each game, stream board + step signals                                                      |
-| `botStats`                                         | `matchRunner.js:341-352`                                     | (a num),(d),(e),(g),(i), quarantine                                                             |
-| `MatchResult` winner/turnCount                     | `matchRunner.js:355/:357`                                    | (d),(f)                                                                                         |
-| `calculatePlacements`                              | `matchRunner.js:375-395`                                     | placement ranks (already applied)                                                               |
-| `recalcPlayerStats`                                | `StateManager.js:108-117`                                    | territoryCount (b), diceCount (g)                                                               |
-| `applyAction`                                      | `StateManager.js:161-173`                                    | replay re-sim (kills fallback)                                                                  |
-| `trajectoryFromReplay` / `replayToState`           | `trajectoryExport.js:246` / `replayFormat.js:198-208`        | kill-attribution fallback (no §6)                                                               |
-| `isStopMove` / `buildStep`                         | `trajectoryExport.js:61` / `:129-140`                        | ATTACK vs STOP in `onStep`                                                                      |
-| `botState` isBorder/connected                      | `botState.js:50` / `:74`                                     | (k) border, (l) largest group                                                                   |
-| `meanCi` / `tCrit` / `mean`                        | `stats.mjs:60-66 / :50 / :53`                                | mean ± 95% CI — **CI math reused**                                                              |
-| `pairedDelta` / `classifyGate`                     | `ppo-gate-core.mjs:31-41 / :53-57`                           | paired Δ + HIGHER/SAME/LOWER                                                                    |
-| `rotatedField` / `buildGateField`                  | `ppo-gate-core.mjs:127-132 / :103-112`                       | seat fairness, field guardrails                                                                 |
-| arenaRunner accumulators                           | `arenaRunner.js:130-168`                                     | **extract** shared terminal-stat helper                                                         |
-| `BUILT_IN_BOTS`                                    | `builtInBots.js:21`                                          | built-in enumeration (`ai_ppo` `:44`)                                                           |
-| `getArg`/`hasFlag` + `loadExportedPolicy`/`makeBC` | `cli-utils.mjs:37/:49`, `load-bc-policy.mjs:163`, `ai_bc.js` | arg parsing; weight-file bots loaded + parity-checked exactly like `ppo:gate` (Phase-2a, built) |
-| JSON-stdout / table-stderr                         | `_tune.mjs:130-142`                                          | dual output                                                                                     |
+| Function                                           | File:line                                                      | Use                                                                                             |
+| -------------------------------------------------- | -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `runMatch` + `onTurn`/`onStep`                     | `matchRunner.js:229-366` (cb `:213/:219`)                      | run each game, stream board + step signals                                                      |
+| `botStats`                                         | `matchRunner.js:341-352`                                       | (a num),(d),(e),(g),(i), quarantine                                                             |
+| `MatchResult` winner/turnCount                     | `matchRunner.js:355/:357`                                      | (d),(f)                                                                                         |
+| `calculatePlacements`                              | `matchRunner.js:375-395`                                       | placement ranks (already applied)                                                               |
+| `recalcPlayerStats`                                | `StateManager.js:108-117`                                      | territoryCount (b), diceCount (g)                                                               |
+| `applyAction`                                      | `StateManager.js:161-173`                                      | replay re-sim (kills fallback)                                                                  |
+| `trajectoryFromReplay` / `replayToState`           | `trajectoryExport.js:246` / `replayFormat.js:198-208`          | kill-attribution fallback (no §6)                                                               |
+| `isStopMove` / `buildStep`                         | `trajectoryExport.js:61` / `:129-140`                          | ATTACK vs STOP in `onStep`                                                                      |
+| `botState` isBorder/connected                      | `botState.js:50` / `:74`                                       | (k) border, (l) largest group                                                                   |
+| `meanCi` / `tCrit` / `mean`                        | `stats.mjs:60-66 / :50 / :53`                                  | mean ± 95% CI — **CI math reused**                                                              |
+| `pairedDelta` / `classifyGate`                     | `ppo-gate-core.mjs:31-41 / :53-57`                             | paired Δ + HIGHER/SAME/LOWER                                                                    |
+| `rotatedField` / `buildGateField`                  | `ppo-gate-core.mjs:127-132 / :103-112`                         | seat fairness, field guardrails                                                                 |
+| arenaRunner accumulators                           | `arenaRunner.js:130-168`                                       | **extract** shared terminal-stat helper                                                         |
+| `BUILT_IN_BOTS`                                    | `builtInBots.js:21`                                            | built-in enumeration (`ai_ppo` `:44`)                                                           |
+| `getArg`/`hasFlag` + `loadExportedPolicy`/`makeBC` | `cli-args.mjs:25/:59`, `load-bc-policy.mjs:163`, `ai_bc.js:67` | arg parsing; weight-file bots loaded + parity-checked exactly like `ppo:gate` (Phase-2a, built) |
+| JSON-stdout / table-stderr                         | `_tune.mjs:130-142`                                            | dual output                                                                                     |
 
 ---
 

--- a/scripts/behavior-profile.mjs
+++ b/scripts/behavior-profile.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Behavioral-Eval Harness — CLI (Phase 1)
+ * Behavioral-Eval Harness — CLI
  *
  * Profiles bots across a seat-fair seed sweep on behavioral axes (aggression, dice
  * reserve, kills, turns-to-win, placement, …) and reports each axis as mean ± 95% CI,
@@ -14,19 +14,29 @@
  * the control comparison is paired at the seed/map level (NOT within-game — honest about
  * its strength). Personas are deliberately NOT pitted against each other.
  *
- * Phase 1 runs against existing built-ins (the persona bots don't exist yet). Its
- * acceptance test: two known-different built-ins separate on the expected axis.
+ * A profiled/control entry is either a built-in name (`Lookahead`) OR a freshly-exported
+ * persona weights file as `Name=path/to/weights.js` — the same loadExportedPolicy→makeBC
+ * path (parity-checked) `ppo:gate` uses. When a profiled bot's name matches a
+ * PERSONA_SIGNATURES entry (e.g. `Blitz`), its pre-registered signature is gated PASS/FAIL
+ * against the control (|Δ| ≥ MDE AND significant in the expected direction). The placeholder
+ * MDEs are calibrated from a pilot via `--mde axis:value,...`.
  *
  * Usage:
  *   npm run behavior:profile                                   # defaults: Strategist vs Defensive control
  *   npm run behavior:profile -- --bots Strategist,Expectimax --control Defensive --runs 10 --games 30
  *   npm run behavior:profile -- --opponents Default,Adaptive,Example,Expectimax,Lookahead --reference Lookahead
+ *   # Gate a freshly-trained persona's exported weights against the matched Conqueror control:
+ *   npm run behavior:profile -- --bots Blitz=ml/runs/ppo-blitz/blitz.weights.js \
+ *                               --control Conqueror=ml/runs/ppo-conqueror/conqueror.weights.js \
+ *                               --mde aggression:1.5,turnsToWin:8
  *   npm run behavior:profile -- --json > profile.json
  */
 
 import { runMatch } from '../src/arena/matchRunner.js';
 import { BUILT_IN_BOTS } from '../src/arena/builtInBots.js';
+import { makeBC } from '../src/ai/ai_bc.js';
 import { rotatedField } from './lib/ppo-gate-core.mjs';
+import { loadExportedPolicy, siblingFixturePath } from './lib/load-bc-policy.mjs';
 import { getArg, hasFlag } from './lib/cli-utils.mjs';
 import {
   makeCapture,
@@ -34,7 +44,12 @@ import {
   reduceRun,
   summarizeAxis,
   compareToControl,
+  signatureDetail,
+  parseBotSpec,
+  parseMdeOverrides,
   AXES,
+  PERSONA_SIGNATURES,
+  DEFAULT_MDE,
 } from './lib/behavior-core.mjs';
 
 const args = process.argv.slice(2);
@@ -44,17 +59,32 @@ const gamesPerRun = parseInt(getArg(args, 'games', '30'), 10);
 // Phase 1: `reference` is validated as an opponent seat and echoed into the report, but the paired
 // comparison is always against `control` (not the reference). It's a labeled seat + a Phase-2 hook.
 const referenceName = getArg(args, 'reference', 'Lookahead');
-const controlName = getArg(args, 'control', 'Defensive');
-const botNames = getArg(args, 'bots', 'Strategist')
+// --bots / --control / --opponents entries are each `Name` (built-in) or `Name=weights.js` specs.
+const controlSpec = parseBotSpec(getArg(args, 'control', 'Defensive'));
+const controlName = controlSpec.name;
+const botSpecs = getArg(args, 'bots', 'Strategist')
   .split(',')
   .map(s => s.trim())
-  .filter(Boolean);
-const opponentNames = getArg(args, 'opponents', 'Default,Adaptive,Example,Expectimax,Lookahead')
+  .filter(Boolean)
+  .map(parseBotSpec);
+const opponentSpecs = getArg(args, 'opponents', 'Default,Adaptive,Example,Expectimax,Lookahead')
   .split(',')
   .map(s => s.trim())
-  .filter(Boolean);
+  .filter(Boolean)
+  .map(parseBotSpec);
+const botNames = botSpecs.map(s => s.name);
+const opponentNames = opponentSpecs.map(s => s.name);
 const quarantine = !hasFlag(args, 'no-quarantine');
 const asJson = hasFlag(args, 'json');
+
+// Calibrated per-axis MDEs for the signature gate (defaults are placeholders until a pilot).
+let mde;
+try {
+  mde = parseMdeOverrides(getArg(args, 'mde', ''), DEFAULT_MDE);
+} catch (err) {
+  console.error(`Invalid --mde: ${err.message}`);
+  process.exit(1);
+}
 
 if (!Number.isFinite(runCount) || runCount < 2) {
   console.error('Invalid --runs: need an integer >= 2 (a CI needs >= 2 runs).');
@@ -77,25 +107,56 @@ if (new Set(opponentNames).size !== opponentNames.length) {
   process.exit(1);
 }
 
-// --- Resolve bots from the registry ---
+// --- Resolve bots: built-in by name, or a parity-checked weights file (Name=path) ---
 
 const byName = new Map(BUILT_IN_BOTS.map(b => [b.name, b]));
-const resolve = name => {
-  const b = byName.get(name);
-  if (!b) {
-    console.error(`Unknown bot "${name}". Available: ${[...byName.keys()].join(', ')}`);
+// Per-weights-bot {params, parity} so the header can show what was loaded (mirrors ppo:gate).
+const loadedBots = [];
+
+/**
+ * Resolve one parsed spec to `{ name, fn }`. A bare name hits the built-in registry; a
+ * `Name=weights.js` spec is dynamic-imported + parity-checked (fail loud) and wrapped exactly
+ * like the in-browser bot via `makeBC({ policy })`. Exits with a clear message on any failure.
+ */
+async function resolveSpec({ name, weightsPath }) {
+  if (!name) {
+    console.error('A bot spec has an empty name (expected `Name` or `Name=path/to/weights.js`).');
     process.exit(1);
   }
-  return { name: b.name, fn: b.fn };
-};
-
-const opponents = opponentNames.map(resolve);
-// The control is profiled like any other bot so the comparison shares the same seed blocks.
-const profiledNames = [...new Set([...botNames, controlName])];
-const profiled = profiledNames.map(resolve);
+  if (weightsPath == null) {
+    const b = byName.get(name);
+    if (!b) {
+      console.error(
+        `Unknown bot "${name}". Available built-ins: ${[...byName.keys()].join(', ')} ` +
+          `(or pass a weights file as ${name}=path/to/weights.js).`
+      );
+      process.exit(1);
+    }
+    return { name: b.name, fn: b.fn };
+  }
+  if (!weightsPath) {
+    console.error(`Weights bot "${name}" has an empty path (expected ${name}=path/to/weights.js).`);
+    process.exit(1);
+  }
+  // The exported persona weights follow the capacity-probe layout: foo.weights.js ↔ foo.fixture.json.
+  const fixturePath = siblingFixturePath(weightsPath);
+  try {
+    const { policy, parity, params } = await loadExportedPolicy({
+      weightsPath,
+      fixturePath,
+      label: name,
+    });
+    loadedBots.push({ name, params, parity, weightsPath });
+    return { name, fn: makeBC({ policy }) };
+  } catch (err) {
+    console.error(`\nFailed to load weights bot "${name}" (${weightsPath}): ${err.message}`);
+    process.exit(1);
+  }
+}
 
 // --- Validate the fixed-field invariants (keeps every field identical in size & opponents) ---
 
+const profiledNames = [...new Set([...botNames, controlName])];
 const oppSet = new Set(opponentNames);
 const collide = profiledNames.filter(n => oppSet.has(n));
 if (collide.length) {
@@ -109,10 +170,21 @@ if (!oppSet.has(referenceName)) {
   console.error(`--reference "${referenceName}" must be one of --opponents (it fills a seat).`);
   process.exit(1);
 }
-if (opponents.length < 1) {
+if (opponentSpecs.length < 1) {
   console.error('Need at least one opponent.');
   process.exit(1);
 }
+
+// Resolve after validation. Profiled = the requested bots + the control (deduped by name, first
+// spec wins), each profiled in the same field so the control comparison shares seed blocks.
+const opponents = [];
+for (const spec of opponentSpecs) opponents.push(await resolveSpec(spec));
+const profiledSpecByName = new Map();
+for (const spec of [...botSpecs, controlSpec]) {
+  if (!profiledSpecByName.has(spec.name)) profiledSpecByName.set(spec.name, spec);
+}
+const profiled = [];
+for (const spec of profiledSpecByName.values()) profiled.push(await resolveSpec(spec));
 
 const fieldSize = opponents.length + 1; // profiled seat + fixed opponents
 const STRIDE = Math.max(1_000_000, gamesPerRun * 1000);
@@ -127,6 +199,12 @@ log(`  profiled: ${profiledNames.join(', ')}   control: ${controlName}`);
 log(
   `  field (${fieldSize} seats): [profiled] + ${opponentNames.join(', ')}   ref: ${referenceName}`
 );
+for (const lb of loadedBots) {
+  log(
+    `  loaded ${lb.name}: ${lb.params.toLocaleString()} params, ` +
+      `parity ${lb.parity.toExponential(1)} (${lb.weightsPath})`
+  );
+}
 log(`  quarantine forced-end games: ${quarantine ? 'on' : 'off'}\n`);
 
 // --- Sweep: profile each bot in the one profiled seat of an identical field ---
@@ -213,6 +291,7 @@ const report = {
     control: controlName,
     opponents: opponentNames,
     fieldSize,
+    mde, // the (possibly calibrated) per-axis thresholds the signature gate used
     quarantine: {
       on: quarantine,
       rate: totalPlayed ? totalQuarantined / totalPlayed : 0,
@@ -228,7 +307,12 @@ const report = {
       AXES.map(axis => [axis, summarizeAxis(perRun.map(r => r[axis]))])
     );
     const vsControl = bot.name === controlName ? null : compareToControl(perRun, controlRuns);
-    return { name: bot.name, metrics, vsControl, liveRuns: liveRunCount(perRun) };
+    // Gate the pre-registered signature when the profiled bot's name names a persona (and it
+    // isn't the control). DEFAULT_MDE covers every signature axis, so signatureDetail won't throw.
+    const sig = PERSONA_SIGNATURES[bot.name];
+    const signature =
+      sig && vsControl ? { persona: bot.name, ...signatureDetail(sig, vsControl, mde) } : null;
+    return { name: bot.name, metrics, vsControl, signature, liveRuns: liveRunCount(perRun) };
   }),
 };
 
@@ -294,4 +378,25 @@ for (const b of report.bots) {
   log(
     `${b.name} vs ${controlName}: ${moved.length ? moved.join(', ') : 'no axis differs'}${dataNote}`
   );
+}
+
+// --- Pre-registered persona signature verdicts (the "ships when distinct" gate, §3.2/§3.3) ---
+const signed = report.bots.filter(b => b.signature);
+if (signed.length) {
+  log('');
+  for (const b of signed) {
+    const s = b.signature;
+    const detail = s.axes
+      .map(a => {
+        const dir = a.direction === 'HIGHER' ? '↑' : '↓';
+        if (a.delta == null) return `${a.axis}${dir} no data`;
+        // Why this axis did/didn't pass: sub-MDE vs not-significant vs both-clear (ok).
+        const why = a.ok ? 'ok' : !a.meetsMde ? `|Δ|<MDE(${a.mde})` : 'CI∌0';
+        return `${a.axis}${dir} Δ${a.delta.toFixed(2)} [${a.lo.toFixed(2)},${a.hi.toFixed(2)}] ${why}`;
+      })
+      .join('; ');
+    log(
+      `${s.persona} signature (${s.rule}) vs ${controlName}: ${s.pass ? 'PASS ✓' : 'FAIL ✗'} — ${detail}`
+    );
+  }
 }

--- a/scripts/behavior-profile.mjs
+++ b/scripts/behavior-profile.mjs
@@ -56,8 +56,8 @@ const args = process.argv.slice(2);
 
 const runCount = parseInt(getArg(args, 'runs', '10'), 10);
 const gamesPerRun = parseInt(getArg(args, 'games', '30'), 10);
-// Phase 1: `reference` is validated as an opponent seat and echoed into the report, but the paired
-// comparison is always against `control` (not the reference). It's a labeled seat + a Phase-2 hook.
+// `reference` is validated as an opponent seat and echoed into the report, but the paired
+// comparison is always against `control` (not the reference) — it's a labeled seat only.
 const referenceName = getArg(args, 'reference', 'Lookahead');
 // --bots / --control / --opponents entries are each `Name` (built-in) or `Name=weights.js` specs.
 const controlSpec = parseBotSpec(getArg(args, 'control', 'Defensive'));
@@ -149,7 +149,13 @@ async function resolveSpec({ name, weightsPath }) {
     loadedBots.push({ name, params, parity, weightsPath });
     return { name, fn: makeBC({ policy }) };
   } catch (err) {
-    console.error(`\nFailed to load weights bot "${name}" (${weightsPath}): ${err.message}`);
+    // loadExportedPolicy throws precise, user-facing messages for every EXPECTED failure (missing
+    // file/fixture, no BC_POLICY, each parity mode). For those the message is enough; for an
+    // UNEXPECTED loader bug (e.g. a TypeError) keep the stack so it isn't permanently disguised as
+    // a bad-weights-file error.
+    console.error(
+      `\nFailed to load weights bot "${name}" (${weightsPath}): ${err.stack ?? err.message}`
+    );
     process.exit(1);
   }
 }
@@ -185,6 +191,25 @@ for (const spec of [...botSpecs, controlSpec]) {
 }
 const profiled = [];
 for (const spec of profiledSpecByName.values()) profiled.push(await resolveSpec(spec));
+
+// Fail FAST on a missing MDE, not post-sweep. Every non-control profiled bot whose name matches a
+// PERSONA_SIGNATURES key gets its signature gated below (signatureDetail), which THROWS if a
+// signature axis has no MDE. DEFAULT_MDE covers today's personas so this can't fire now, but if a
+// future signature axis lacks an MDE this would otherwise surface as an uncaught stack AFTER the
+// full runs×games×field sweep — minutes wasted. Catch it here with the other config errors instead.
+for (const bot of profiled) {
+  if (bot.name === controlName) continue;
+  const sig = PERSONA_SIGNATURES[bot.name];
+  if (!sig) continue;
+  const missing = sig.axes.map(a => a.axis).filter(axis => mde[axis] == null);
+  if (missing.length) {
+    console.error(
+      `Persona "${bot.name}" has signature axes with no registered MDE: [${missing.join(', ')}]. ` +
+        `Add them to DEFAULT_MDE or pass --mde ${missing.map(a => `${a}:<value>`).join(',')}.`
+    );
+    process.exit(1);
+  }
+}
 
 const fieldSize = opponents.length + 1; // profiled seat + fixed opponents
 const STRIDE = Math.max(1_000_000, gamesPerRun * 1000);

--- a/scripts/lib/behavior-core.mjs
+++ b/scripts/lib/behavior-core.mjs
@@ -287,21 +287,38 @@ export function compareToControl(personaRuns, controlRuns) {
 }
 
 /**
- * Whether a persona's pre-registered signature holds: every required axis must clear its
- * minimum-detectable-effect AND have a CI excluding 0 in the expected direction (§3.2/§3.3).
- * Two requirements (|Δ| ≥ MDE and significant) guard against a statistically-significant but
- * behaviorally-trivial "difference" passing.
+ * Per-axis breakdown of a persona's pre-registered signature: for each required axis, whether
+ * it clears its minimum-detectable-effect (|Δ| ≥ MDE) AND is significant in the expected
+ * direction (CI excludes 0 the right way). The boolean gate {@link signaturePass} is just
+ * `detail.pass`; the CLI uses the per-axis `axes` to EXPLAIN a PASS/FAIL. Two requirements
+ * (MDE and significance) guard against a statistically-significant but behaviorally-trivial
+ * "difference" passing.
  *
  * @param {{ axes: Array<{axis:string, direction:'HIGHER'|'LOWER'}>, rule:'AND'|'single' }} signature
  * @param {Record<string, ReturnType<typeof compareAxis>>} vsControl
  * @param {Record<string, number>} mde - per-axis minimum |Δ| that counts as meaningful
- * @returns {boolean}
- * @throws if a signature axis has no registered MDE (see below)
+ * @returns {{ pass:boolean, rule:string, axes:Array<{axis:string, direction:string, delta:number|null, lo:number|null, hi:number|null, mde:number|null, meetsMde:boolean, sigInDir:boolean, ok:boolean}> }}
+ * @throws if a signature axis HAS a comparison but no registered MDE (see below)
  */
-export function signaturePass(signature, vsControl, mde) {
-  const checks = signature.axes.map(({ axis, direction }) => {
+export function signatureDetail(signature, vsControl, mde) {
+  const axes = signature.axes.map(({ axis, direction }) => {
     const cmp = vsControl[axis];
-    if (!cmp) return false;
+    // Fail CLOSED (not throw) when a required axis has no comparison: a persona that rarely wins
+    // yields all-null turnsToWin runs → compareAxis null → the signature simply does not hold.
+    // (Checked before the MDE lookup so a null-cmp axis never trips the missing-MDE throw.)
+    if (!cmp) {
+      return {
+        axis,
+        direction,
+        delta: null,
+        lo: null,
+        hi: null,
+        mde: mde[axis] ?? null,
+        meetsMde: false,
+        sigInDir: false,
+        ok: false,
+      };
+    }
     // Fail loud on a missing MDE rather than defaulting to 0: an `?? 0` fallback would make
     // |Δ| ≥ 0 always true, silently collapsing the gate back to a bare significance test — the
     // exact "trivially-significant pass" this function exists to prevent. A pre-registered
@@ -315,10 +332,35 @@ export function signaturePass(signature, vsControl, mde) {
     }
     const meetsMde = Math.abs(cmp.delta) >= axisMde;
     const sigInDir = direction === 'HIGHER' ? cmp.lo > 0 : cmp.hi < 0;
-    return meetsMde && sigInDir;
+    return {
+      axis,
+      direction,
+      delta: cmp.delta,
+      lo: cmp.lo,
+      hi: cmp.hi,
+      mde: axisMde,
+      meetsMde,
+      sigInDir,
+      ok: meetsMde && sigInDir,
+    };
   });
   // 'single' and 'AND' both require all listed axes; the distinction is documentation of intent.
-  return checks.every(Boolean);
+  return { pass: axes.every(a => a.ok), rule: signature.rule, axes };
+}
+
+/**
+ * Whether a persona's pre-registered signature holds — the boolean gate. Thin wrapper over
+ * {@link signatureDetail} (the single decision path; this stays the stable, widely-used entry
+ * point). See {@link signatureDetail} for the per-axis requirements and the throw contract.
+ *
+ * @param {{ axes: Array<{axis:string, direction:'HIGHER'|'LOWER'}>, rule:'AND'|'single' }} signature
+ * @param {Record<string, ReturnType<typeof compareAxis>>} vsControl
+ * @param {Record<string, number>} mde - per-axis minimum |Δ| that counts as meaningful
+ * @returns {boolean}
+ * @throws if a signature axis has no registered MDE (see {@link signatureDetail})
+ */
+export function signaturePass(signature, vsControl, mde) {
+  return signatureDetail(signature, vsControl, mde).pass;
 }
 
 /**
@@ -352,3 +394,55 @@ export const DEFAULT_MDE = {
   zeroAttackTurnFrac: 0.1,
   captureEfficiency: 0.05,
 };
+
+/**
+ * Parse a `--bots`/`--control` entry. A bare name (`Lookahead`) is a built-in registry lookup;
+ * a `Name=path/to/weights.js` entry is a weights-file bot the CLI loads + parity-checks via the
+ * same `loadExportedPolicy → makeBC` path as `ppo:gate`. The display name doubles as the
+ * {@link PERSONA_SIGNATURES} key, so naming a weights bot `Blitz` opts it into the Blitz gate.
+ * Splits on the FIRST `=` only, so a weights path may itself contain `=`.
+ *
+ * @param {string} spec
+ * @returns {{ name: string, weightsPath: string|null }} weightsPath null ⇒ built-in lookup
+ */
+export function parseBotSpec(spec) {
+  const s = String(spec).trim();
+  const eq = s.indexOf('=');
+  if (eq === -1) return { name: s, weightsPath: null };
+  return { name: s.slice(0, eq).trim(), weightsPath: s.slice(eq + 1).trim() };
+}
+
+/**
+ * Parse a `--mde axis:value,...` override string, merged OVER a base MDE map (never deletes a
+ * base entry, so every signature axis always keeps an MDE). This is how the placeholder
+ * {@link DEFAULT_MDE} thresholds get CALIBRATED from a pilot at the CLI without a code edit.
+ * Throws on a malformed entry, an unknown axis, or a negative/non-finite value so a typo can't
+ * silently widen or disable a gate.
+ *
+ * @param {string} str - e.g. "aggression:1.5,turnsToWin:8"
+ * @param {Record<string, number>} [base=DEFAULT_MDE]
+ * @returns {Record<string, number>} a fresh merged map (base is not mutated)
+ */
+export function parseMdeOverrides(str, base = DEFAULT_MDE) {
+  const out = { ...base };
+  const trimmed = (str ?? '').trim();
+  if (!trimmed) return out;
+  for (const pair of trimmed.split(',')) {
+    const part = pair.trim();
+    if (!part) continue;
+    const colon = part.indexOf(':');
+    if (colon === -1) {
+      throw new Error(`--mde entry "${part}" is not of the form axis:value`);
+    }
+    const axis = part.slice(0, colon).trim();
+    const value = Number(part.slice(colon + 1).trim());
+    if (!AXES.includes(axis)) {
+      throw new Error(`--mde axis "${axis}" is not a known axis (${AXES.join(', ')})`);
+    }
+    if (!Number.isFinite(value) || value < 0) {
+      throw new Error(`--mde value for "${axis}" must be a non-negative number (got "${part}")`);
+    }
+    out[axis] = value;
+  }
+  return out;
+}

--- a/scripts/lib/behavior-core.mjs
+++ b/scripts/lib/behavior-core.mjs
@@ -5,9 +5,10 @@
  * `ppo:gate`'s "is it STRONGER?" (paired Δwin% vs Lookahead). See
  * `docs/ml-bot/EVAL_HARNESS.md` for the full spec.
  *
- * Phase 1 (this file): the metric extraction + aggregation + control comparison,
- * runnable against existing built-in bots. Phase 2 wires the trained persona bots and
- * the pre-registered signature gates (the PERSONA_SIGNATURES stub at the bottom).
+ * This file: the metric extraction + aggregation + control comparison, the pre-registered
+ * signature gate (`signatureDetail`/`signaturePass` over PERSONA_SIGNATURES), and the CLI
+ * spec/MDE parsing (`parseBotSpec`/`parseMdeOverrides`). All runnable today; the only thing
+ * still pending is the persona *weight files* the CLI points at (see PERSONA_SIGNATURES below).
  *
  * Design notes that the spec's review pinned down (do not regress):
  *   - Active turns are counted from `onTurn` firings attributed to the profiled seat,
@@ -326,7 +327,7 @@ export function signatureDetail(signature, vsControl, mde) {
     const axisMde = mde[axis];
     if (axisMde == null) {
       throw new Error(
-        `signaturePass: no MDE registered for axis "${axis}" — every pre-registered signature ` +
+        `signatureDetail: no MDE registered for axis "${axis}" — every pre-registered signature ` +
           `axis must have an MDE (else the |Δ| ≥ MDE guard is silently disabled).`
       );
     }
@@ -349,9 +350,10 @@ export function signatureDetail(signature, vsControl, mde) {
 }
 
 /**
- * Whether a persona's pre-registered signature holds — the boolean gate. Thin wrapper over
- * {@link signatureDetail} (the single decision path; this stays the stable, widely-used entry
- * point). See {@link signatureDetail} for the per-axis requirements and the throw contract.
+ * Whether a persona's pre-registered signature holds — the boolean gate. Thin convenience
+ * wrapper over {@link signatureDetail} (the single decision path), retained as the public
+ * boolean entry point. See {@link signatureDetail} for the per-axis requirements and the
+ * throw contract.
  *
  * @param {{ axes: Array<{axis:string, direction:'HIGHER'|'LOWER'}>, rule:'AND'|'single' }} signature
  * @param {Record<string, ReturnType<typeof compareAxis>>} vsControl
@@ -364,9 +366,10 @@ export function signaturePass(signature, vsControl, mde) {
 }
 
 /**
- * Pre-registered confirmatory signature per persona (§8 of the spec). Phase-2 stub — the
- * persona bots do not exist yet; this encodes the one hypothesis each will be judged on so
- * the multiplicity story (≤ 5 confirmatory tests, Holm-adjusted) is fixed in advance.
+ * Pre-registered confirmatory signature per persona (§8 of the spec). Actively gated: when a
+ * profiled bot's name matches a key here, `signatureDetail` judges it PASS/FAIL. The persona
+ * weight files don't exist yet, so this still encodes the one hypothesis each will be judged on
+ * — fixing the multiplicity story (≤ 5 confirmatory tests, Holm-adjusted) in advance.
  *
  * @type {Record<string, { axes: Array<{axis:string, direction:'HIGHER'|'LOWER'}>, rule:'AND'|'single' }>}
  */
@@ -416,8 +419,9 @@ export function parseBotSpec(spec) {
  * Parse a `--mde axis:value,...` override string, merged OVER a base MDE map (never deletes a
  * base entry, so every signature axis always keeps an MDE). This is how the placeholder
  * {@link DEFAULT_MDE} thresholds get CALIBRATED from a pilot at the CLI without a code edit.
- * Throws on a malformed entry, an unknown axis, or a negative/non-finite value so a typo can't
- * silently widen or disable a gate.
+ * Throws on a malformed entry, an unknown axis, or a non-positive/non-finite value so a typo can't
+ * silently widen or disable a gate (in particular `axis:0`, which would collapse it to a bare
+ * significance test).
  *
  * @param {string} str - e.g. "aggression:1.5,turnsToWin:8"
  * @param {Record<string, number>} [base=DEFAULT_MDE]
@@ -439,8 +443,16 @@ export function parseMdeOverrides(str, base = DEFAULT_MDE) {
     if (!AXES.includes(axis)) {
       throw new Error(`--mde axis "${axis}" is not a known axis (${AXES.join(', ')})`);
     }
-    if (!Number.isFinite(value) || value < 0) {
-      throw new Error(`--mde value for "${axis}" must be a non-negative number (got "${part}")`);
+    if (!Number.isFinite(value) || value <= 0) {
+      // Reject 0, not just negatives: an MDE of 0 makes `|Δ| ≥ 0` always true in signatureDetail,
+      // silently collapsing the gate to a bare significance test — the exact "trivially-significant
+      // pass" the missing-MDE throw exists to prevent. A 0 here is the unsafe direction (it ships a
+      // non-distinct persona); a too-large MDE merely fails closed. So the calibration path must
+      // refuse it too, not just the implicit `?? 0` fallback signatureDetail already avoids.
+      throw new Error(
+        `--mde value for "${axis}" must be a positive number (got "${part}") — 0 disables the ` +
+          `|Δ| ≥ MDE guard and collapses the signature to a bare significance test.`
+      );
     }
     out[axis] = value;
   }

--- a/tests/behaviorCore.test.js
+++ b/tests/behaviorCore.test.js
@@ -17,6 +17,9 @@ import {
   compareAxis,
   compareToControl,
   signaturePass,
+  signatureDetail,
+  parseBotSpec,
+  parseMdeOverrides,
   AXES,
   PERSONA_SIGNATURES,
   DEFAULT_MDE,
@@ -425,6 +428,110 @@ describe('signaturePass — MDE gate prevents trivial-but-significant passes', (
     const partial = { aggression: vsControl.aggression, turnsToWin: null };
     expect(() => signaturePass(blitz, partial, { aggression: 1, turnsToWin: 5 })).not.toThrow();
     expect(signaturePass(blitz, partial, { aggression: 1, turnsToWin: 5 })).toBe(false);
+  });
+});
+
+describe('signatureDetail — per-axis breakdown behind signaturePass', () => {
+  const vsControl = {
+    aggression: compareAxis([5, 6, 7, 5, 6], [2, 3, 2, 3, 2]), // Δ ≈ +3.4, CI > 0
+    turnsToWin: compareAxis([20, 21, 20, 21, 20], [19, 20, 19, 20, 19]), // HIGHER, tiny
+  };
+  const blitz = PERSONA_SIGNATURES.Blitz; // aggression HIGHER AND turnsToWin LOWER
+
+  it('returns pass plus an ok/why breakdown per axis, and pass agrees with signaturePass', () => {
+    const sig = { axes: [{ axis: 'aggression', direction: 'HIGHER' }], rule: 'single' };
+    const d = signatureDetail(sig, vsControl, { aggression: 1.0 });
+    expect(d.pass).toBe(true);
+    expect(d.rule).toBe('single');
+    expect(d.axes).toHaveLength(1);
+    expect(d.axes[0]).toMatchObject({
+      axis: 'aggression',
+      meetsMde: true,
+      sigInDir: true,
+      ok: true,
+    });
+    expect(Number.isFinite(d.axes[0].delta)).toBe(true);
+    // The boolean wrapper must equal detail.pass (single decision path).
+    expect(signaturePass(sig, vsControl, { aggression: 1.0 })).toBe(d.pass);
+  });
+
+  it('marks a sub-MDE axis meetsMde:false and fails the gate', () => {
+    const sig = { axes: [{ axis: 'aggression', direction: 'HIGHER' }], rule: 'single' };
+    const d = signatureDetail(sig, vsControl, { aggression: 10.0 });
+    expect(d.axes[0].meetsMde).toBe(false);
+    expect(d.axes[0].ok).toBe(false);
+    expect(d.pass).toBe(false);
+  });
+
+  it('AND rule: the wrong-direction turnsToWin axis fails the whole signature', () => {
+    const d = signatureDetail(blitz, vsControl, { aggression: 1, turnsToWin: 1 });
+    expect(d.pass).toBe(false);
+    const ttw = d.axes.find(a => a.axis === 'turnsToWin');
+    expect(ttw.direction).toBe('LOWER');
+    expect(ttw.sigInDir).toBe(false); // CI is on the HIGHER side, so the LOWER hypothesis is unmet
+  });
+
+  it('fails closed (no throw) on a null comparison, even when that axis has no MDE', () => {
+    const partial = { aggression: vsControl.aggression, turnsToWin: null };
+    let d;
+    expect(() => {
+      d = signatureDetail(blitz, partial, { aggression: 1 }); // turnsToWin MDE intentionally absent
+    }).not.toThrow();
+    expect(d.pass).toBe(false);
+    const ttw = d.axes.find(a => a.axis === 'turnsToWin');
+    expect(ttw).toMatchObject({ delta: null, ok: false });
+  });
+
+  it('throws when a present-comparison axis has no MDE (the guard signaturePass relies on)', () => {
+    const sig = { axes: [{ axis: 'aggression', direction: 'HIGHER' }], rule: 'single' };
+    expect(() => signatureDetail(sig, vsControl, {})).toThrow(/no MDE registered for axis/);
+  });
+});
+
+describe('parseBotSpec — built-in name vs Name=weights.js', () => {
+  it('treats a bare name as a built-in lookup (weightsPath null)', () => {
+    expect(parseBotSpec('Lookahead')).toEqual({ name: 'Lookahead', weightsPath: null });
+  });
+
+  it('splits a Name=path spec into name + weightsPath, trimming whitespace', () => {
+    expect(parseBotSpec(' Blitz = ml/runs/ppo-blitz/blitz.weights.js ')).toEqual({
+      name: 'Blitz',
+      weightsPath: 'ml/runs/ppo-blitz/blitz.weights.js',
+    });
+  });
+
+  it('splits on the FIRST = only, so a path may contain =', () => {
+    expect(parseBotSpec('X=a/b=c.weights.js')).toEqual({
+      name: 'X',
+      weightsPath: 'a/b=c.weights.js',
+    });
+  });
+});
+
+describe('parseMdeOverrides — calibrate signature thresholds without a code edit', () => {
+  it('returns a copy of the base when the string is empty/whitespace (base not mutated)', () => {
+    const base = { ...DEFAULT_MDE };
+    const out = parseMdeOverrides('', base);
+    expect(out).toEqual(DEFAULT_MDE);
+    expect(out).not.toBe(base); // fresh object
+    out.aggression = 999;
+    expect(base.aggression).toBe(DEFAULT_MDE.aggression); // base untouched
+  });
+
+  it('merges overrides over the base, leaving other axes at their default', () => {
+    const out = parseMdeOverrides('aggression:1.5, turnsToWin:8', DEFAULT_MDE);
+    expect(out.aggression).toBe(1.5);
+    expect(out.turnsToWin).toBe(8);
+    expect(out.kills).toBe(DEFAULT_MDE.kills); // untouched
+  });
+
+  it('throws on a malformed entry, an unknown axis, or a negative/non-finite value', () => {
+    expect(() => parseMdeOverrides('aggression', DEFAULT_MDE)).toThrow(
+      /not of the form axis:value/
+    );
+    expect(() => parseMdeOverrides('bogus:1', DEFAULT_MDE)).toThrow(/not a known axis/);
+    expect(() => parseMdeOverrides('aggression:-1', DEFAULT_MDE)).toThrow(/non-negative number/);
+    expect(() => parseMdeOverrides('aggression:abc', DEFAULT_MDE)).toThrow(/non-negative number/);
   });
 });
 

--- a/tests/behaviorCore.test.js
+++ b/tests/behaviorCore.test.js
@@ -471,6 +471,18 @@ describe('signatureDetail — per-axis breakdown behind signaturePass', () => {
     expect(ttw.sigInDir).toBe(false); // CI is on the HIGHER side, so the LOWER hypothesis is unmet
   });
 
+  it('AND rule: PASSES when BOTH axes clear MDE in the right direction (the headline happy path)', () => {
+    const passingBlitz = {
+      aggression: compareAxis([5, 6, 7, 5, 6], [2, 3, 2, 3, 2]), // Δ ≈ +3.4, CI > 0 (HIGHER ✓)
+      turnsToWin: compareAxis([10, 11, 10, 11, 10], [20, 21, 20, 21, 20]), // Δ ≈ -10, CI < 0 (LOWER ✓)
+    };
+    const mde = { aggression: 1, turnsToWin: 5 };
+    const d = signatureDetail(blitz, passingBlitz, mde);
+    expect(d.pass).toBe(true);
+    expect(d.axes.every(a => a.ok)).toBe(true); // every required axis cleared
+    expect(signaturePass(blitz, passingBlitz, mde)).toBe(true);
+  });
+
   it('fails closed (no throw) on a null comparison, even when that axis has no MDE', () => {
     const partial = { aggression: vsControl.aggression, turnsToWin: null };
     let d;
@@ -506,6 +518,19 @@ describe('parseBotSpec — built-in name vs Name=weights.js', () => {
       weightsPath: 'a/b=c.weights.js',
     });
   });
+
+  // The null (bare name) vs '' (has '=' but empty path) distinction is load-bearing: resolveSpec
+  // routes weightsPath==null to the built-in registry and an empty-but-non-null path to its
+  // "empty path" error. Pin both, plus the empty-name case its first guard catches.
+  it('distinguishes a bare name (weightsPath null) from an empty path (weightsPath "")', () => {
+    expect(parseBotSpec('Blitz=')).toEqual({ name: 'Blitz', weightsPath: '' });
+    expect(parseBotSpec('Blitz').weightsPath).toBeNull();
+  });
+
+  it('yields an empty name for "" or "=foo" (resolveSpec rejects these loudly)', () => {
+    expect(parseBotSpec('')).toEqual({ name: '', weightsPath: null });
+    expect(parseBotSpec('=foo.weights.js')).toEqual({ name: '', weightsPath: 'foo.weights.js' });
+  });
 });
 
 describe('parseMdeOverrides — calibrate signature thresholds without a code edit', () => {
@@ -525,13 +550,19 @@ describe('parseMdeOverrides — calibrate signature thresholds without a code ed
     expect(out.kills).toBe(DEFAULT_MDE.kills); // untouched
   });
 
-  it('throws on a malformed entry, an unknown axis, or a negative/non-finite value', () => {
+  it('throws on a malformed entry, an unknown axis, or a non-positive/non-finite value', () => {
     expect(() => parseMdeOverrides('aggression', DEFAULT_MDE)).toThrow(
       /not of the form axis:value/
     );
     expect(() => parseMdeOverrides('bogus:1', DEFAULT_MDE)).toThrow(/not a known axis/);
-    expect(() => parseMdeOverrides('aggression:-1', DEFAULT_MDE)).toThrow(/non-negative number/);
-    expect(() => parseMdeOverrides('aggression:abc', DEFAULT_MDE)).toThrow(/non-negative number/);
+    expect(() => parseMdeOverrides('aggression:-1', DEFAULT_MDE)).toThrow(/positive number/);
+    expect(() => parseMdeOverrides('aggression:abc', DEFAULT_MDE)).toThrow(/positive number/);
+  });
+
+  it('rejects an explicit 0 — it would collapse the |Δ|≥MDE gate to a bare significance test', () => {
+    // A 0 MDE makes Math.abs(delta) >= 0 always true; this is the exact silent gate-disable the
+    // missing-MDE throw guards against, so the calibration path must refuse it too (not just `<0`).
+    expect(() => parseMdeOverrides('aggression:0', DEFAULT_MDE)).toThrow(/positive number/);
   });
 });
 

--- a/tests/scripts/behaviorProfile.test.js
+++ b/tests/scripts/behaviorProfile.test.js
@@ -1,0 +1,66 @@
+import { execSync } from 'node:child_process';
+import path from 'node:path';
+
+const projectRoot = path.resolve(import.meta.dirname, '../..');
+
+/**
+ * Spawn the behavior-profile CLI and capture its exit code + stderr. Mirrors the
+ * `benchmark-bot.test.js` pattern. Every case here is a CONFIG-error branch that exits
+ * BEFORE the (slow) arena sweep, so the suite stays fast — no match is ever run. The
+ * deep weight-loading path is covered by `loadBcPolicy.test.js` + the `behavior-core`
+ * unit tests; this file pins the CLI's argument-validation exit codes (the one layer the
+ * unit tests can't reach), which is the project convention for sibling CLIs.
+ */
+function run(args, expectFail = true) {
+  try {
+    const stdout = execSync(`node scripts/behavior-profile.mjs ${args}`, {
+      cwd: projectRoot,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 30000,
+    });
+    return { stdout, stderr: '', exitCode: 0 };
+  } catch (err) {
+    if (!expectFail) throw err;
+    return { stdout: err.stdout || '', stderr: err.stderr || '', exitCode: err.status };
+  }
+}
+
+describe('behavior-profile CLI — fail-fast config validation (no sweep)', () => {
+  it('rejects --mde axis:0 (the gate-collapse guard) end-to-end', () => {
+    const { stderr, exitCode } = run('--mde aggression:0');
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toMatch(/positive number/);
+  });
+
+  it('rejects an unknown --mde axis', () => {
+    const { stderr, exitCode } = run('--mde bogus:1');
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toMatch(/not a known axis/);
+  });
+
+  it('rejects --runs below 2 (a CI needs >= 2 runs)', () => {
+    const { stderr, exitCode } = run('--runs 1');
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toMatch(/Invalid --runs/);
+  });
+
+  it('rejects an unknown built-in bot name', () => {
+    const { stderr, exitCode } = run('--bots Nonexistent');
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toMatch(/Unknown bot/);
+  });
+
+  it('rejects a weights spec with an empty path (Name=)', () => {
+    const { stderr, exitCode } = run('--bots Blitz=');
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toMatch(/empty path/);
+  });
+
+  it('rejects a profiled bot that also appears in --opponents', () => {
+    // Lookahead is in the default opponent field, so profiling it collides.
+    const { stderr, exitCode } = run('--bots Lookahead');
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toMatch(/also appear in --opponents/);
+  });
+});


### PR DESCRIPTION
## What & why

First slice of the **eval half** of the reward-persona roster (ml-bot "bite E1"). With the 20M PPO net shipped (#78), the next initiative is training several PPO bots with distinct *play-styles*. Gating those personas needs the behavioral-eval harness to (a) load a freshly-exported persona's weights and (b) emit its pre-registered **PASS/FAIL** signature. The harness already had the metric/aggregation/comparison logic and a unit-tested `signaturePass` gate — but the CLI could only resolve `BUILT_IN_BOTS` and only printed raw per-axis deltas. This closes those two gaps.

## Changes

- **Weight-file bot loading** — `--bots`/`--control` accept a `Name=path/to/weights.js` spec, dynamic-imported + **parity-checked** via the same `loadExportedPolicy → makeBC` path `ppo:gate` uses (new pure `parseBotSpec`). Built-in names still work unchanged. The display name doubles as the `PERSONA_SIGNATURES` key, so naming a weights bot `Blitz` opts it into the Blitz gate.
- **Signature verdict surfaced** — new `signatureDetail` returns the per-axis `meetsMde`/`sigInDir`/`ok` breakdown; `signaturePass` now delegates to it (single decision path, throw/fail-closed contract preserved). The CLI prints `Blitz signature (AND) vs <control>: PASS ✓ / FAIL ✗` with each axis's `Δ [lo,hi]` and *why* it did/didn't pass (`|Δ|<MDE` vs `CI∌0`), and the JSON `report.bots[].signature` carries the structured detail.
- **MDE calibration** — `--mde axis:value,...` merges over `DEFAULT_MDE` (new pure `parseMdeOverrides`) so the placeholder thresholds get calibrated from the pilot without a code edit. `report.config.mde` records what was used.

## Verification

- `tests/behaviorCore.test.js`: 17 → **42 tests** (new: `signatureDetail`, `parseBotSpec`, `parseMdeOverrides`).
- Full suite **1205 green**; `lint` + `prettier --check` clean.
- Smoke-tested end-to-end both ways: built-in field works; a persona-named export (`Blitz=…weights.js`) correctly **FAILs** the Blitz signature — the turtle PPO net is *less* aggressive than the control, exactly the right rejection.

## Scope / follow-ups (Phase-2b, deliberately separate)

Holm adjustment (a no-op for a ≤2-persona pilot), §3.6 determinism enforcement in the loader, the §3.8 training-field-match assertion, the §3.5 `--melee` persona×persona separation matrix, `--csv`, and the territory-curve/border-exposure axes remain TODO. `EVAL_HARNESS.md` is updated to mark Phase-2a BUILT and list these.