### PR TITLE
feat(ml): wire-free reward-mode knob for the persona roster (Conqueror/Survivor/Blitz)

### DIFF
--- a/docs/ml-bot/PERSONAS.md
+++ b/docs/ml-bot/PERSONAS.md
@@ -11,6 +11,14 @@
 > equally-trained bots with deliberately different play styles**, some of which are _supposed_ to
 > sacrifice win% for character. New decisions this implies are flagged `D-27?` etc. (next free
 > number after D-26) and should be promoted to `DECISIONS.md` if/when accepted.
+>
+> **Built since (2026-06-29, "bite D"):** the **wire-free reward knob** now exists. `train.py` gained
+> `--reward-mode {win,placement}` plus `--terminal-speed-bonus B`/`--speed-ref T`, computed by
+> `dicewars_ppo.env.terminal_reward`. This makes **Conqueror** (`win`, the default), **Survivor**
+> (`placement`), and **Blitz** (lower `--gamma`, optionally `--terminal-speed-bonus`) runnable
+> **with no wire change**. The dense **Expansionist**/**Predator** rewards still need the per-frame
+> wire scalar ("bite G"). The eval-harness side ("bite E1") can already gate a persona's exported
+> weights. So the §2 "the reward is one line" framing below is now historical — see that knob.
 
 ---
 
@@ -48,10 +56,16 @@ almost always one of:
 
 ## 2. Where the reward lives (implementation surface)
 
-The reward is **one line**:
+> **Now built (bite D):** the terminal reward is no longer a single hard-coded line — it is
+> `dicewars_ppo.env.terminal_reward(...)`, selected by `--reward-mode {win,placement}` and an
+> optional win-gated `--terminal-speed-bonus B`/`--speed-ref T`. The default (`win`, bonus 0) is
+> byte-identical to the line below. The rest of this section is the original analysis that motivated
+> that knob.
+
+Originally the reward was **one line**:
 
 ```python
-# ml/dicewars_ppo/env.py:205
+# ml/dicewars_ppo/env.py (pre-bite-D)
 reward = float(frame.won)   # +1 if learner won, else 0  (sparse terminal-win, D-19)
 ```
 
@@ -62,16 +76,18 @@ more terminal signal than the reward uses**:
 | ------------------------------------------- | ------------------------------------ | ----------------------------------------------------------------------------- |
 | `won` (1/0)                                 | ✅ (used)                            | —                                                                             |
 | `winner` (seat/-1)                          | ✅                                   | free                                                                          |
-| `placement` (1=1st…0=last, range-validated) | ✅ (unused)                          | **free** — Survivor persona                                                   |
+| `placement` (1=1st…0=last, range-validated) | ✅                                   | **built** — `--reward-mode placement` (Survivor)                              |
 | `truncated` (stalemate cap)                 | ✅                                   | free                                                                          |
-| game `turnCount`                            | ✅ (`finalize()`, JS side)           | cheap — Blitz terminal speed-bonus                                            |
+| `turn_number` (terminal frame)              | ✅                                   | **built** — `--terminal-speed-bonus`/`--speed-ref` (Blitz)                    |
 | Δterritory / turn                           | ❌                                   | small: env-server emits a per-frame scalar → wire/header field + version bump |
 | elimination event                           | ❌ (derivable from placement deltas) | small, same as above                                                          |
 
-So **placement-, tempo-, and turn-count-based personas are essentially free** (signal already
-plumbed + a `--gamma` flag). Dense-territory and elimination-bounty personas need the **JS
-env-server to emit a per-frame scalar** — a wire/header addition carrying the same discipline as
-the encoding contract (bump a version constant; JS emitter and Python consumer change in one commit).
+So **placement-, tempo-, and turn-count-based personas are now runnable with no wire change** —
+the signals were already plumbed and bite D added the trainer flags that consume them
+(`--reward-mode`, `--terminal-speed-bonus`, plus the long-standing `--gamma`). Dense-territory and
+elimination-bounty personas still need the **JS env-server to emit a per-frame scalar** — a
+wire/header addition carrying the same discipline as the encoding contract (bump a version
+constant; JS emitter and Python consumer change in one commit). That is "bite G".
 
 ---
 
@@ -94,10 +110,10 @@ can't attribute the behavioral difference. This note holds axis 2 fixed at the c
 | Persona           | Reward change                               | Expected tendency                  | Diverges from win via                   | Impl cost          | Gate expectation          |
 | ----------------- | ------------------------------------------- | ---------------------------------- | --------------------------------------- | ------------------ | ------------------------- |
 | **Conqueror**     | `frame.won` (today)                         | Balanced; turtle→strike            | — (control)                             | none               | the bar (pure-wins)       |
-| **Blitz / Tempo** | lower `gamma` (+ opt. terminal speed-bonus) | Fast, aggressive, early pressure   | multiplicative-time                     | **free** (flag)    | likely **below** bar; fun |
+| **Blitz / Tempo** | lower `gamma` (+ opt. terminal speed-bonus) | Fast, aggressive, early pressure   | multiplicative-time                     | **built** (flags)  | likely **below** bar; fun |
 | **Expansionist**  | dense Δ(net territory)/turn                 | Grabs land now; overextends        | dense + net                             | small (wire field) | below bar                 |
 | **Predator**      | bounty per player eliminated                | Hunts kills; takes risky finishers | dense + net                             | small (wire field) | below/near bar            |
-| **Survivor**      | `placement` instead of binary win           | Conservative; plays for 2nd/3rd    | rank ≠ win (the "ELO trap", repurposed) | **free** (on wire) | high ELO, lower win%      |
+| **Survivor**      | `placement` instead of binary win           | Conservative; plays for 2nd/3rd    | rank ≠ win (the "ELO trap", repurposed) | **built** (flag)   | high ELO, lower win%      |
 
 ### Conqueror (control)
 
@@ -111,9 +127,10 @@ The intuition: scale the win reward _down_ by game length so a 1-turn win is wor
 1000-turn win, coaxing aggression. **This is principled** — see §6 for the full treatment. Short
 version: the current `gamma=0.999` is _why_ the bot turtles (a slow win is worth ~82% of a fast one
 — almost no tempo pressure), so the cleanest first cut is **just lower gamma** (e.g. 0.99 → a
-200-turn win worth ~13% of an instant win). Optional escalation: an explicit bounded terminal
-speed-bonus keyed on `turnCount`. Foregrounded because it directly targets the turtle Ivan saw and
-costs zero new code.
+200-turn win worth ~13% of an instant win). Optional escalation: the explicit bounded terminal
+speed-bonus, now `--terminal-speed-bonus B`/`--speed-ref T` (bite D), keyed on the terminal frame's
+`turn_number`. Foregrounded because it directly targets the turtle Ivan saw and is now a flag, not
+new code.
 
 ### Expansionist
 
@@ -132,7 +149,8 @@ described. Derivable from placement deltas without a new territory field.
 [D-19] explicitly avoided placement reward for the gate bot, calling it **"the ELO trap"**:
 optimizing rank rather than the win produces a bot that plays for 2nd/3rd instead of going for 1st
 — great ELO, mediocre win%. For a _personality_ bot that conservative, survive-don't-conquer style
-**is the deliverable.** Costs nothing — `placement` is already on the wire.
+**is the deliverable.** Now a one-flag run — `--reward-mode placement` (bite D); the `placement`
+signal was already on the wire, so it cost no wire change.
 
 ---
 
@@ -168,7 +186,8 @@ There are two ways to say "win fast":
 So Ivan's multiplicative framing is exactly the _safe_ formulation. **Recommended Blitz config:**
 lower `gamma` first (0.99, maybe 0.97); if that isn't punchy enough, add a small **bounded**
 terminal speed-bonus `reward = won × (1 + b·clip(1 − turns/T_ref, 0, 1))` with `b` modest (e.g.
-0.5) so it never dominates the win/loss ordering. **Secondary knob:** `ent_coef` — the applicable
+0.5) so it never dominates the win/loss ordering — now `--terminal-speed-bonus 0.5 --speed-ref T`
+(bite D; `terminal_reward` implements exactly this formula, win-gated). **Secondary knob:** `ent_coef` — the applicable
 default for the **warm-started** personas is **0.0** (`_train_common.py:153`; `0.01` is only the
 _from-scratch_ fallback at `:340`). More entropy = more exploration = less likely to settle into the
 safe turtle; bump it (e.g. toward `0.01`) for Blitz, but it's a training-dynamics knob, not a reward,
@@ -236,9 +255,12 @@ fun. The roster makes that filter _possible_; it doesn't automate it.
 ## 8. Execution plan (post-`ppo-long`)
 
 1. **Land the harness first** (§7) — measure today's Conqueror to set the baseline profile.
-2. **Wire the reward knobs:** `--gamma`/`--ent-coef` are already flags (Blitz/Survivor free);
-   add the per-frame territory/elim scalar to the env-server wire (Expansionist/Predator) behind a
-   version bump, off by default (byte-identical to today when unset — the B5/B6 opt-in pattern).
+   _(Bite E1 — done: the harness can load a persona's exported weights and gate its signature.)_
+2. **Wire the reward knobs:** ✅ _bite D_ — `--reward-mode {win,placement}` +
+   `--terminal-speed-bonus`/`--speed-ref` (plus the long-standing `--gamma`/`--ent-coef`) make
+   Conqueror/Blitz/Survivor runnable with no wire change. **Still TODO (bite G):** add the per-frame
+   territory/elim scalar to the env-server wire (Expansionist/Predator) behind a version bump, off by
+   default (byte-identical to today when unset — the B5/B6 opt-in pattern).
 3. **One persona = one reward config + one schtask**, all **warm-started from `ppo-long`'s final
    policy** (shared good initialization; reward shaping then specializes), running **concurrently**
    on shodan (latency-bound, idle hardware). Re-run Conqueror as the matched control.

--- a/docs/ml-bot/PERSONAS.md
+++ b/docs/ml-bot/PERSONAS.md
@@ -77,7 +77,7 @@ more terminal signal than the reward uses**:
 | `won` (1/0)                                 | ✅ (used)                            | —                                                                             |
 | `winner` (seat/-1)                          | ✅                                   | free                                                                          |
 | `placement` (1=1st…0=last, range-validated) | ✅                                   | **built** — `--reward-mode placement` (Survivor)                              |
-| `truncated` (stalemate cap)                 | ✅                                   | free                                                                          |
+| `truncated` (stalemate cap)                 | ✅ (used)                            | **built** — gates the terminal payout to 0 (bite D; avoids double-counting)   |
 | `turn_number` (terminal frame)              | ✅                                   | **built** — `--terminal-speed-bonus`/`--speed-ref` (Blitz)                    |
 | Δterritory / turn                           | ❌                                   | small: env-server emits a per-frame scalar → wire/header field + version bump |
 | elimination event                           | ❌ (derivable from placement deltas) | small, same as above                                                          |
@@ -152,13 +152,29 @@ optimizing rank rather than the win produces a bot that plays for 2nd/3rd instea
 **is the deliverable.** Now a one-flag run — `--reward-mode placement` (bite D); the `placement`
 signal was already on the wire, so it cost no wire change.
 
+**Truncation must pay 0 (a bite-D correctness point).** A `maxTurns` stalemate cap is a Gym
+_truncation_, not a realized terminal: `step()` returns `truncated=True` so SB3 **bootstraps**
+`V(s)`. `terminal_reward` therefore pays **0 on a truncation in every mode** — paying the non-zero
+rank-at-cap `placement` there too would _double-count_ the survival signal (reward **plus** a
+bootstrapped value that already estimates the eventual placement) and reward **stalling to the
+cap** — precisely the passivity failure §6 warns about. `win` mode is 0 on a cap regardless (a cap
+can't be a win), so this only disciplines the placement path. Survivor still gets a dense placement
+signal from the decisive majority of games that end in a genuine `GAME_OVER`.
+
+**Warm-start critic note.** A Survivor warm-started from `ppo-long`'s win-trained value head starts
+**miscalibrated**: that head predicts ≈win-rate (mostly 0, ~0.25 mean for 4p), but placement is a
+denser signal with mean ≈0.5. PPO's per-batch advantage normalization absorbs most of the shift,
+but expect a noisier first stretch; a short value-head warmup or a higher initial `value-coef` may
+speed convergence. Reward scale is otherwise comparable (both objectives top out at 1.0 pre-bonus),
+so shared `lr`/clip/`value-coef` stay reasonable — no normalization change is _required_.
+
 ---
 
 ## 5. The tempo lever in depth (Blitz)
 
 Ivan's framing: _"win in 1 turn → 1000 points; win in 1000 turns → 1 point."_ That's a
 **multiplicative terminal time-bonus**, and it's the sharper cousin of the discount factor `gamma`,
-which the trainer already exposes as `--gamma` (default **0.999**, `_train_common.py:149`).
+which the trainer already exposes as `--gamma` (default **0.999**, in `_train_common.build_parser`).
 
 **Why gamma is the principled lever.** With sparse `+1` terminal-win and discount `γ`, the value of
 a state that wins in `T` steps is `γ^T · P(win)`. So `γ` _is_ a smooth "win fast" multiplier:
@@ -188,8 +204,9 @@ lower `gamma` first (0.99, maybe 0.97); if that isn't punchy enough, add a small
 terminal speed-bonus `reward = won × (1 + b·clip(1 − turns/T_ref, 0, 1))` with `b` modest (e.g.
 0.5) so it never dominates the win/loss ordering — now `--terminal-speed-bonus 0.5 --speed-ref T`
 (bite D; `terminal_reward` implements exactly this formula, win-gated). **Secondary knob:** `ent_coef` — the applicable
-default for the **warm-started** personas is **0.0** (`_train_common.py:153`; `0.01` is only the
-_from-scratch_ fallback at `:340`). More entropy = more exploration = less likely to settle into the
+default for the **warm-started** personas is **0.0** (the `--ent-coef` default in
+`_train_common.build_parser`; `0.01` is only the _from-scratch_ fallback in `resolve_from_scratch`).
+More entropy = more exploration = less likely to settle into the
 safe turtle; bump it (e.g. toward `0.01`) for Blitz, but it's a training-dynamics knob, not a reward,
 so tune it second.
 

--- a/ml/dicewars_ppo/_train_common.py
+++ b/ml/dicewars_ppo/_train_common.py
@@ -28,7 +28,7 @@ import math
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from .env import DiceWarsEnv
+from .env import REWARD_MODES, DiceWarsEnv
 
 if TYPE_CHECKING:  # annotation-only; never imported at runtime (keeps this module torch-free)
     from dicewars_bc.model import ModelConfig
@@ -77,11 +77,12 @@ def _make_env_thunk(cfg: ModelConfig, args: argparse.Namespace, env_index: int):
         str(Path(args.snapshot_dir) / "manifest.json") if args.snapshot_dir else None
     )
 
-    # Reward shaping (persona roster, [D-bite]). train.py-only flags read via getattr so the tracer
-    # (whose parser lacks them) stays byte-identical: an absent flag yields the [D-19] sparse-win
-    # defaults. All three are primitives (str/float/int|None) so the torch-free thunk stays
-    # primitive-only, and they are env-construction kwargs (reward is computed Python-side in
-    # env.step()), so NOTHING reaches the Node server_kwargs and the wire is untouched.
+    # Reward shaping (persona roster, bite D — docs/ml-bot/PERSONAS.md). train.py-only flags read
+    # via getattr so the tracer (whose parser lacks them) stays byte-identical: an absent flag
+    # yields the [D-19] sparse-win defaults. All three are primitives (str/float/int|None) so the
+    # torch-free thunk stays primitive-only, and they are env-construction kwargs (reward is
+    # computed Python-side in env.step()), so NOTHING reaches the Node server_kwargs and the wire
+    # is untouched.
     reward_mode = getattr(args, "reward_mode", "win")
     terminal_speed_bonus = getattr(args, "terminal_speed_bonus", 0.0)
     speed_ref = getattr(args, "speed_ref", None)
@@ -353,14 +354,21 @@ def resolve_from_scratch(args: argparse.Namespace) -> None:
 
 
 def validate_reward_args(args: argparse.Namespace) -> None:
-    """Validate the persona reward-shaping flags ([D-bite]) at launch (torch-free → lean-testable).
+    """Validate the persona reward-shaping flags (bite D) at launch (torch-free → lean-testable).
 
-    train.py-only flags, read via ``getattr`` so this is a safe no-op for any caller (the tracer)
-    that lacks them. Front-runs the env's own ``ValueError`` (raised when ``DiceWarsEnv`` is built
-    inside a ``SubprocVecEnv`` worker) so a misconfig fails HERE with a clear ``SystemExit`` at
+    Reads the flags via ``getattr`` so this is a safe no-op for a caller whose ``Namespace`` lacks
+    them — e.g. a programmatic/test ``Namespace`` built without them. (The tracer doesn't call this:
+    it shares only ``_validate_args``/``_make_env_thunk``; ``train.py`` is the sole caller and it
+    owns these flags.) Front-runs all THREE of the env's own constructor ``ValueError``\\ s (which
+    would otherwise fire when ``DiceWarsEnv`` is built inside a ``SubprocVecEnv`` worker and surface
+    as an opaque worker-startup failure) so a misconfig fails HERE with a clear ``SystemExit`` at
     launch — before any worker/Node server spawns — mirroring how ``_validate_args`` front-runs the
-    Node league guards. ``--reward-mode`` itself is constrained by argparse ``choices``.
+    Node league guards. ``--reward-mode`` membership is also enforced by argparse ``choices`` on the
+    CLI path; the explicit check here additionally covers a non-CLI ``Namespace``.
     """
+    reward_mode = getattr(args, "reward_mode", "win")
+    if reward_mode not in REWARD_MODES:
+        raise SystemExit(f"--reward-mode must be one of {REWARD_MODES} (got {reward_mode!r}).")
     speed_bonus = getattr(args, "terminal_speed_bonus", 0.0)
     speed_ref = getattr(args, "speed_ref", None)
     if speed_bonus < 0:

--- a/ml/dicewars_ppo/_train_common.py
+++ b/ml/dicewars_ppo/_train_common.py
@@ -77,10 +77,22 @@ def _make_env_thunk(cfg: ModelConfig, args: argparse.Namespace, env_index: int):
         str(Path(args.snapshot_dir) / "manifest.json") if args.snapshot_dir else None
     )
 
+    # Reward shaping (persona roster, [D-bite]). train.py-only flags read via getattr so the tracer
+    # (whose parser lacks them) stays byte-identical: an absent flag yields the [D-19] sparse-win
+    # defaults. All three are primitives (str/float/int|None) so the torch-free thunk stays
+    # primitive-only, and they are env-construction kwargs (reward is computed Python-side in
+    # env.step()), so NOTHING reaches the Node server_kwargs and the wire is untouched.
+    reward_mode = getattr(args, "reward_mode", "win")
+    terminal_speed_bonus = getattr(args, "terminal_speed_bonus", 0.0)
+    speed_ref = getattr(args, "speed_ref", None)
+
     def _thunk() -> DiceWarsEnv:
         return DiceWarsEnv(
             max_areas=max_areas,
             player_count=player_count,
+            reward_mode=reward_mode,
+            terminal_speed_bonus=terminal_speed_bonus,
+            speed_ref=speed_ref,
             server_kwargs={
                 "opponents": args.opponents,
                 "max_turns": args.max_turns,
@@ -338,6 +350,26 @@ def resolve_from_scratch(args: argparse.Namespace) -> None:
         args.lr = 1e-3 if from_scratch else 1e-4
     if getattr(args, "ent_coef", None) is None:
         args.ent_coef = 0.01 if from_scratch else 0.0
+
+
+def validate_reward_args(args: argparse.Namespace) -> None:
+    """Validate the persona reward-shaping flags ([D-bite]) at launch (torch-free → lean-testable).
+
+    train.py-only flags, read via ``getattr`` so this is a safe no-op for any caller (the tracer)
+    that lacks them. Front-runs the env's own ``ValueError`` (raised when ``DiceWarsEnv`` is built
+    inside a ``SubprocVecEnv`` worker) so a misconfig fails HERE with a clear ``SystemExit`` at
+    launch — before any worker/Node server spawns — mirroring how ``_validate_args`` front-runs the
+    Node league guards. ``--reward-mode`` itself is constrained by argparse ``choices``.
+    """
+    speed_bonus = getattr(args, "terminal_speed_bonus", 0.0)
+    speed_ref = getattr(args, "speed_ref", None)
+    if speed_bonus < 0:
+        raise SystemExit(f"--terminal-speed-bonus must be >= 0 (got {speed_bonus}).")
+    if speed_bonus > 0 and not (speed_ref is not None and speed_ref > 0):
+        raise SystemExit(
+            "--speed-ref must be a positive integer when --terminal-speed-bonus > 0 "
+            f"(got {speed_ref})."
+        )
 
 
 def _remaining_timesteps(total: int, num_timesteps: int) -> int:

--- a/ml/dicewars_ppo/env.py
+++ b/ml/dicewars_ppo/env.py
@@ -18,9 +18,13 @@ chosen index is sent verbatim to the server, which decodes it against its own
 ``board`` ``[5]``, ``edge_feat`` ``[MAX_EDGES, 7]``, ``edge_from``/``edge_to``
 ``[MAX_EDGES]`` (territory ids, pad → 0), ``edge_mask`` ``[MAX_EDGES]`` (1 legal).
 
-**Reward** — sparse terminal-win only ([D-19] decision 3): ``+1`` if the learner
-won, else ``0``; ``0`` on every non-terminal step. Potential-based shaping is a
-later step and is deliberately NOT here.
+**Reward** — sparse terminal-win by default ([D-19] decision 3): ``+1`` if the
+learner won, else ``0``; ``0`` on every non-terminal step. The persona roster
+(``docs/ml-bot/PERSONAS.md``) selects an alternate terminal objective via
+``reward_mode`` (``"placement"`` = Survivor) and/or a win-gated
+``terminal_speed_bonus`` (Blitz) — see :func:`terminal_reward`. All such modes
+read wire fields already present, so they are wire-contract-free (no
+``ENCODING_VERSION`` bump); the defaults are byte-identical to the sparse win.
 
 **Episode model.** The server streams episodes back-to-back over one connection:
 a run of obs frames (``terminal == 0``), each answered with an action, then one
@@ -50,6 +54,47 @@ from .constants import (
 from .env_server import EnvServerProcess
 from .wire import ObsFrame, expected_frame_bytes, recv_frame, send_action
 
+REWARD_MODES = ("win", "placement")
+
+
+def terminal_reward(
+    *,
+    won: int,
+    placement: float,
+    turn_number: int,
+    reward_mode: str = "win",
+    speed_bonus: float = 0.0,
+    speed_ref: int | None = None,
+) -> float:
+    """The terminal-frame reward from already-validated wire fields (pure → lean-testable).
+
+    Every input (``won``/``placement``/``turn_number``) is already on the obs-frame wire today,
+    so all of these modes are **wire-contract-free** — no ``ENCODING_VERSION`` bump. The persona
+    roster (``docs/ml-bot/PERSONAS.md``) uses this to specialize play-style without touching the
+    encoder.
+
+    Modes:
+      - ``"win"`` — sparse terminal-win (``+1`` win else ``0``), the [D-19] default (Conqueror).
+      - ``"placement"`` — the scaled finishing rank in ``[0, 1]`` (1=first … 0=last) — the
+        Survivor objective (the "ELO trap" [D-19] avoided for the gate bot, repurposed here).
+
+    Optional bounded terminal SPEED bonus (Blitz's secondary lever; lower ``--gamma`` first)::
+
+        reward *= 1 + speed_bonus * clip(1 - turn_number / speed_ref, 0, 1)
+
+    It is **multiplicative and win-gated**: a faster WIN is worth strictly more, while a loss is
+    untouched. An additive per-step time PENALTY would instead let the bot throw games just to
+    end them sooner — exactly why [D-19] keeps the base reward sparse and lets time only scale a
+    win. ``speed_ref`` must be a positive turn count when ``speed_bonus > 0`` (callers validate).
+    """
+    base = float(placement) if reward_mode == "placement" else float(won)
+    if speed_bonus > 0.0 and won:
+        # speed_ref is guaranteed positive when speed_bonus > 0 (validated at construction).
+        frac = 1.0 - (turn_number / speed_ref)
+        frac = min(1.0, max(0.0, frac))  # clip to [0, 1]: no bonus once turn_number >= speed_ref
+        base *= 1.0 + speed_bonus * frac
+    return base
+
 
 class DiceWarsEnv(gym.Env):
     """Single-agent masked env wrapping one Node self-play env-server."""
@@ -70,6 +115,11 @@ class DiceWarsEnv(gym.Env):
         server_kwargs: dict[str, Any] | None = None,
         connect_timeout_s: float = 30.0,
         read_timeout_s: float = 180.0,
+        # Reward shaping (persona roster, docs/ml-bot/PERSONAS.md). All wire-free (see
+        # terminal_reward); the defaults reproduce the [D-19] sparse terminal-win exactly.
+        reward_mode: str = "win",
+        terminal_speed_bonus: float = 0.0,
+        speed_ref: int | None = None,
     ) -> None:
         super().__init__()
         self.max_areas = max_areas
@@ -81,6 +131,18 @@ class DiceWarsEnv(gym.Env):
         self._server_kwargs = dict(server_kwargs or {})
         self._connect_timeout_s = connect_timeout_s
         self._read_timeout_s = read_timeout_s
+
+        if reward_mode not in REWARD_MODES:
+            raise ValueError(f"reward_mode must be one of {REWARD_MODES}, got {reward_mode!r}")
+        if terminal_speed_bonus < 0.0:
+            raise ValueError(f"terminal_speed_bonus must be >= 0 (got {terminal_speed_bonus})")
+        if terminal_speed_bonus > 0.0 and not (speed_ref is not None and speed_ref > 0):
+            raise ValueError(
+                f"speed_ref must be a positive int when terminal_speed_bonus > 0 (got {speed_ref})"
+            )
+        self._reward_mode = reward_mode
+        self._speed_bonus = float(terminal_speed_bonus)
+        self._speed_ref = speed_ref
 
         if not managed and (host is None or port is None):
             raise ValueError("managed=False requires explicit host and port.")
@@ -162,9 +224,7 @@ class DiceWarsEnv(gym.Env):
         self._awaiting_reset = False
         return self._frame_to_obs(frame), self._info(frame)
 
-    def step(
-        self, action: int
-    ) -> tuple[dict[str, np.ndarray], float, bool, bool, dict[str, Any]]:
+    def step(self, action: int) -> tuple[dict[str, np.ndarray], float, bool, bool, dict[str, Any]]:
         if self._awaiting_reset:
             raise RuntimeError("step() called before reset() (or after a terminal step).")
         action = int(action)
@@ -202,7 +262,14 @@ class DiceWarsEnv(gym.Env):
                     f"truncated={frame.truncated}) — a maxTurns stalemate cap cannot be a win; "
                     "summarizeOutcome regression or wire corruption?"
                 )
-            reward = float(frame.won)
+            reward = terminal_reward(
+                won=frame.won,
+                placement=frame.placement,
+                turn_number=frame.turn_number,
+                reward_mode=self._reward_mode,
+                speed_bonus=self._speed_bonus,
+                speed_ref=self._speed_ref,
+            )
             # A maxTurns stalemate cap is a Gym TRUNCATION, not a real terminal: the game did
             # not actually end, so SB3 must bootstrap V(s) here (it keys off `truncated` via the
             # gym→VecEnv shim's `TimeLimit.truncated` info). A win or the learner's elimination is

--- a/ml/dicewars_ppo/env.py
+++ b/ml/dicewars_ppo/env.py
@@ -62,21 +62,30 @@ def terminal_reward(
     won: int,
     placement: float,
     turn_number: int,
+    truncated: int = 0,
     reward_mode: str = "win",
     speed_bonus: float = 0.0,
     speed_ref: int | None = None,
 ) -> float:
     """The terminal-frame reward from already-validated wire fields (pure → lean-testable).
 
-    Every input (``won``/``placement``/``turn_number``) is already on the obs-frame wire today,
-    so all of these modes are **wire-contract-free** — no ``ENCODING_VERSION`` bump. The persona
-    roster (``docs/ml-bot/PERSONAS.md``) uses this to specialize play-style without touching the
-    encoder.
+    Every input (``won``/``placement``/``turn_number``/``truncated``) is already on the obs-frame
+    wire today, so all of these modes are **wire-contract-free** — no ``ENCODING_VERSION`` bump.
+    The persona roster (``docs/ml-bot/PERSONAS.md``) uses this to specialize play-style without
+    touching the encoder.
 
     Modes:
       - ``"win"`` — sparse terminal-win (``+1`` win else ``0``), the [D-19] default (Conqueror).
       - ``"placement"`` — the scaled finishing rank in ``[0, 1]`` (1=first … 0=last) — the
         Survivor objective (the "ELO trap" [D-19] avoided for the gate bot, repurposed here).
+
+    A ``maxTurns`` stalemate cap (``truncated``) pays **0 in every mode**. The cap is an artificial
+    Gym truncation, not a realized outcome, so ``step()`` bootstraps ``V(s)`` there (it returns
+    ``truncated=True``). Paying a non-zero terminal reward too — the rank-at-cap that ``placement``
+    mode would otherwise yield — AND bootstrapping would *double-count* the outcome (the value head
+    already estimates the eventual placement) and bias the Survivor toward stalling to the cap.
+    ``win`` mode is 0 here regardless (a cap can't be a win, enforced upstream by ``step()``), so
+    the early return only changes the ``placement`` path; it keeps truncation handling uniform.
 
     Optional bounded terminal SPEED bonus (Blitz's secondary lever; lower ``--gamma`` first)::
 
@@ -87,9 +96,14 @@ def terminal_reward(
     end them sooner — exactly why [D-19] keeps the base reward sparse and lets time only scale a
     win. ``speed_ref`` must be a positive turn count when ``speed_bonus > 0`` (callers validate).
     """
+    if truncated:
+        # Artificial cap → no realized outcome; step() bootstraps V(s). A non-zero payout here
+        # would double-count placement and reward stalling to the cap (see docstring).
+        return 0.0
     base = float(placement) if reward_mode == "placement" else float(won)
     if speed_bonus > 0.0 and won:
-        # speed_ref is guaranteed positive when speed_bonus > 0 (validated at construction).
+        # speed_ref is positive when speed_bonus > 0 — callers validate (DiceWarsEnv.__init__ /
+        # validate_reward_args); a direct call that breaks this raises TypeError/ZeroDivisionError.
         frac = 1.0 - (turn_number / speed_ref)
         frac = min(1.0, max(0.0, frac))  # clip to [0, 1]: no bonus once turn_number >= speed_ref
         base *= 1.0 + speed_bonus * frac
@@ -238,8 +252,9 @@ class DiceWarsEnv(gym.Env):
         frame = recv_frame(self._sock, self._max_frame_bytes)
 
         if frame.is_terminal:
-            # Sparse terminal-win reward ([D-19] decision 3). Validate the wire values
-            # so an encoder/server regression fails loud here instead of feeding a
+            # Terminal reward — sparse win by default ([D-19] decision 3); persona modes
+            # (placement / speed bonus) are selected via `terminal_reward`. Validate the wire
+            # values so an encoder/server regression fails loud here instead of feeding a
             # poisoned reward into the replay buffer.
             if frame.won not in (0, 1):
                 raise ValueError(
@@ -266,6 +281,7 @@ class DiceWarsEnv(gym.Env):
                 won=frame.won,
                 placement=frame.placement,
                 turn_number=frame.turn_number,
+                truncated=frame.truncated,
                 reward_mode=self._reward_mode,
                 speed_bonus=self._speed_bonus,
                 speed_ref=self._speed_ref,

--- a/ml/dicewars_ppo/train.py
+++ b/ml/dicewars_ppo/train.py
@@ -143,7 +143,7 @@ def build_parser() -> argparse.ArgumentParser:
         "50000 (the same default as --snapshot-every, but NOT dynamically coupled to it — set this "
         "explicitly if you change --snapshot-every and want checkpoints to follow).",
     )
-    # Reward shaping for the persona roster ([D-bite], docs/ml-bot/PERSONAS.md). All wire-free and
+    # Reward shaping for the persona roster (bite D, docs/ml-bot/PERSONAS.md). All wire-free and
     # default to the [D-19] sparse terminal-win, so an omitted flag is byte-identical to today.
     p.add_argument(
         "--reward-mode",
@@ -176,6 +176,15 @@ def build_parser() -> argparse.ArgumentParser:
 def _validate(args: argparse.Namespace) -> None:
     _train_common._validate_args(args)
     _train_common.resolve_from_scratch(args)
+    # train.py OWNS the reward-shaping flags, so they must be present on this path. Both
+    # _make_env_thunk and validate_reward_args read them via getattr (to tolerate the flag-less
+    # tracer/test Namespaces), which means a rename that decoupled a flag from its getattr key would
+    # SILENTLY fall back to the sparse-win default and train the wrong objective for a multi-hour
+    # persona run. Fail loud here instead — a missing attr on THIS path is a wiring bug, not a
+    # tolerated absence.
+    for _attr in ("reward_mode", "terminal_speed_bonus", "speed_ref"):
+        if not hasattr(args, _attr):
+            raise SystemExit(f"internal: train.py arg '{_attr}' missing — flag/getattr key drift?")
     _train_common.validate_reward_args(args)
     if args.checkpoint_every <= 0:
         raise SystemExit(f"--checkpoint-every must be > 0 (got {args.checkpoint_every}).")

--- a/ml/dicewars_ppo/train.py
+++ b/ml/dicewars_ppo/train.py
@@ -143,12 +143,40 @@ def build_parser() -> argparse.ArgumentParser:
         "50000 (the same default as --snapshot-every, but NOT dynamically coupled to it — set this "
         "explicitly if you change --snapshot-every and want checkpoints to follow).",
     )
+    # Reward shaping for the persona roster ([D-bite], docs/ml-bot/PERSONAS.md). All wire-free and
+    # default to the [D-19] sparse terminal-win, so an omitted flag is byte-identical to today.
+    p.add_argument(
+        "--reward-mode",
+        choices=("win", "placement"),
+        default="win",
+        help="Terminal reward objective: 'win' = sparse terminal-win ([D-19] default, Conqueror); "
+        "'placement' = scaled finishing rank in [0,1] (Survivor). Reads wire fields already "
+        "present — no ENCODING_VERSION bump.",
+    )
+    p.add_argument(
+        "--terminal-speed-bonus",
+        type=float,
+        default=0.0,
+        help="Blitz's optional secondary lever: scale a WIN by how fast it came — "
+        "reward *= 1 + b*clip(1 - turns/speed_ref, 0, 1). Default 0 = off (byte-identical). "
+        "Multiplicative + win-gated (a per-step time penalty would let the bot throw games). Lower "
+        "--gamma FIRST; add this only if that isn't punchy enough.",
+    )
+    p.add_argument(
+        "--speed-ref",
+        type=int,
+        default=None,
+        help="Turn-count reference T_ref (player-turns) for --terminal-speed-bonus; REQUIRED when "
+        "that is > 0. A win at turns >= T_ref earns no speed bonus; calibrate from the Conqueror "
+        "control's mean turns-to-win.",
+    )
     return p
 
 
 def _validate(args: argparse.Namespace) -> None:
     _train_common._validate_args(args)
     _train_common.resolve_from_scratch(args)
+    _train_common.validate_reward_args(args)
     if args.checkpoint_every <= 0:
         raise SystemExit(f"--checkpoint-every must be > 0 (got {args.checkpoint_every}).")
     if args.freeze_trunk and args.state_dir is not None:
@@ -367,9 +395,7 @@ def train(args: argparse.Namespace) -> Path:
         else:
             # Fresh run: reset_num_timesteps defaults True ⇒ num_timesteps starts at 0 and
             # --timesteps is the absolute budget.
-            model.learn(
-                total_timesteps=args.timesteps, progress_bar=False, callback=learn_callback
-            )
+            model.learn(total_timesteps=args.timesteps, progress_bar=False, callback=learn_callback)
     finally:
         # Always reap the env workers (each owns a Node child) even on error/HALT. Guard the close:
         # when learn() raised because a SubprocVecEnv worker already died (the common failure here),

--- a/ml/tests/test_ppo_env_unit.py
+++ b/ml/tests/test_ppo_env_unit.py
@@ -183,3 +183,49 @@ def test_step_terminal_rejects_won_and_truncated(golden_frame, monkeypatch):
     term = dataclasses.replace(golden_frame, terminal=1, winner=0, won=1, truncated=1)
     with pytest.raises(ValueError, match="both truncated and won"):
         _drive_step_with_terminal(monkeypatch, env, term)
+
+
+# --- step() terminal: the persona reward modes wired through the REAL step() body ------------
+# These pin the frame-field → terminal_reward-arg wiring (placement/turn_number/truncated +
+# the env's reward_mode/speed_bonus/speed_ref). The pure terminal_reward unit tests bypass
+# step(), so a miswire there (e.g. won into the placement slot) would pass them but fail here.
+
+
+def test_step_terminal_placement_mode_pays_scaled_rank(golden_frame, monkeypatch):
+    # Survivor: a genuine (non-truncated) loss pays the scaled rank, NOT 0 — proves step() feeds
+    # frame.placement into terminal_reward under reward_mode="placement".
+    env = _env(reward_mode="placement")
+    term = dataclasses.replace(
+        golden_frame, terminal=1, winner=0, won=0, truncated=0, placement=0.5
+    )
+    _obs, reward, terminated, trunc, _info = _drive_step_with_terminal(monkeypatch, env, term)
+    assert (terminated, trunc) == (True, False)  # a real loss is a genuine terminal (bootstrap 0)
+    assert reward == 0.5
+
+
+def test_step_terminal_placement_mode_truncation_pays_zero(golden_frame, monkeypatch):
+    # C1: a maxTurns CAP in placement mode must pay 0 (truncated → SB3 bootstraps V(s)), NOT the
+    # non-zero rank-at-cap on the wire — otherwise the survival signal is double-counted and the
+    # Survivor is biased toward stalling to the cap. Exercised through the real step() body.
+    env = _env(reward_mode="placement")
+    term = dataclasses.replace(
+        golden_frame, terminal=1, winner=0, won=0, truncated=1, placement=0.67
+    )
+    _obs, reward, terminated, trunc, _info = _drive_step_with_terminal(monkeypatch, env, term)
+    assert (terminated, trunc) == (False, True)  # truncation → bootstrap, not a genuine terminal
+    assert reward == 0.0
+
+
+def test_step_terminal_speed_bonus_scales_a_fast_win(golden_frame, monkeypatch):
+    # Blitz: step() must thread frame.turn_number + the env's speed_bonus/speed_ref into
+    # terminal_reward. A win at turn 50 of a 200-turn ref pays 1*(1 + 0.5*clip(1-50/200)) = 1.375.
+    # The turn_number is a DISTINCTIVE non-zero value (≠ winner/truncated/placement on this frame),
+    # so a miswire sourcing the turn_number kwarg from any other (zero-or-other-valued) field would
+    # produce a different reward and fail — uniquely pinning the frame.turn_number wire.
+    env = _env(terminal_speed_bonus=0.5, speed_ref=200)
+    term = dataclasses.replace(
+        golden_frame, terminal=1, winner=0, won=1, truncated=0, placement=1.0, turn_number=50
+    )
+    _obs, reward, terminated, trunc, _info = _drive_step_with_terminal(monkeypatch, env, term)
+    assert (terminated, trunc) == (True, False)
+    assert reward == pytest.approx(1.375)

--- a/ml/tests/test_reward_modes.py
+++ b/ml/tests/test_reward_modes.py
@@ -1,0 +1,135 @@
+"""Persona reward-shaping ([D-bite], docs/ml-bot/PERSONAS.md) — the wire-free terminal-reward modes.
+
+Lean tier (torch-free): exercises the pure ``terminal_reward`` math, the ``DiceWarsEnv`` constructor
+validation, and the launch-time ``validate_reward_args`` guard — none of which need torch, sb3, or a
+live Node env-server (``DiceWarsEnv`` connects lazily, so constructing one only sets attrs/spaces).
+The flags' parser wiring (train.py) is covered in the torch-gated test_train_args.py.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from dicewars_ppo._train_common import validate_reward_args
+from dicewars_ppo.env import REWARD_MODES, DiceWarsEnv, terminal_reward
+
+# --- terminal_reward: the pure objective math --------------------------------------------------
+
+
+def test_win_mode_is_sparse_terminal_win():
+    # Default mode reproduces [D-19] exactly: +1 on a win, 0 otherwise.
+    assert terminal_reward(won=1, placement=1.0, turn_number=50) == 1.0
+    assert terminal_reward(won=0, placement=0.5, turn_number=50) == 0.0
+    # placement is ignored in win mode even when it's high.
+    assert terminal_reward(won=0, placement=0.99, turn_number=50, reward_mode="win") == 0.0
+
+
+def test_placement_mode_returns_scaled_rank():
+    # Survivor: the reward IS the scaled finishing rank, independent of `won`.
+    assert terminal_reward(won=0, placement=0.5, turn_number=50, reward_mode="placement") == 0.5
+    assert terminal_reward(won=1, placement=1.0, turn_number=50, reward_mode="placement") == 1.0
+    assert terminal_reward(won=0, placement=0.0, turn_number=50, reward_mode="placement") == 0.0
+
+
+def test_speed_bonus_scales_a_faster_win_more():
+    # reward *= 1 + b*clip(1 - turns/ref, 0, 1). b=0.5, ref=200.
+    # turns=0   → factor 1 + 0.5*1   = 1.5
+    fast = terminal_reward(won=1, placement=1.0, turn_number=0, speed_bonus=0.5, speed_ref=200)
+    # turns=100 → factor 1 + 0.5*0.5 = 1.25
+    mid = terminal_reward(won=1, placement=1.0, turn_number=100, speed_bonus=0.5, speed_ref=200)
+    assert fast == pytest.approx(1.5)
+    assert mid == pytest.approx(1.25)
+    assert fast > mid  # the faster win is worth strictly more
+
+
+def test_speed_bonus_clips_to_zero_at_or_beyond_ref():
+    # turns >= ref → clip(1 - turns/ref, 0, 1) = 0 → no bonus (factor 1).
+    assert (
+        terminal_reward(won=1, placement=1.0, turn_number=200, speed_bonus=0.5, speed_ref=200)
+        == 1.0
+    )
+    assert (
+        terminal_reward(won=1, placement=1.0, turn_number=999, speed_bonus=0.5, speed_ref=200)
+        == 1.0
+    )
+
+
+def test_speed_bonus_never_rewards_a_loss():
+    # The bonus is win-gated: a loss is untouched no matter how fast it ended (a per-step time
+    # PENALTY would instead let the bot throw games — the failure mode [D-19] avoids).
+    assert (
+        terminal_reward(won=0, placement=0.0, turn_number=1, speed_bonus=0.5, speed_ref=200) == 0.0
+    )
+
+
+def test_speed_bonus_off_is_identical_to_plain_modes():
+    # speed_bonus=0 (the default) is byte-identical to the un-shaped objective.
+    assert (
+        terminal_reward(won=1, placement=1.0, turn_number=3, speed_bonus=0.0, speed_ref=None) == 1.0
+    )
+    assert (
+        terminal_reward(
+            won=1, placement=0.7, turn_number=3, reward_mode="placement", speed_bonus=0.0
+        )
+        == 0.7
+    )
+
+
+# --- DiceWarsEnv constructor validation (no server is started) ---------------------------------
+
+
+def test_env_defaults_to_sparse_win():
+    env = DiceWarsEnv()
+    assert env._reward_mode == "win"
+    assert env._speed_bonus == 0.0
+    assert env._speed_ref is None
+    assert "win" in REWARD_MODES and "placement" in REWARD_MODES
+
+
+def test_env_accepts_placement_and_speed_bonus():
+    env = DiceWarsEnv(reward_mode="placement", terminal_speed_bonus=0.5, speed_ref=200)
+    assert env._reward_mode == "placement"
+    assert env._speed_bonus == 0.5
+    assert env._speed_ref == 200
+
+
+@pytest.mark.parametrize(
+    "kwargs, match",
+    [
+        ({"reward_mode": "bogus"}, "reward_mode must be one of"),
+        ({"terminal_speed_bonus": -0.1}, "must be >= 0"),
+        ({"terminal_speed_bonus": 0.5}, "speed_ref must be a positive int"),  # ref omitted
+        ({"terminal_speed_bonus": 0.5, "speed_ref": 0}, "speed_ref must be a positive int"),
+    ],
+)
+def test_env_rejects_bad_reward_config(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        DiceWarsEnv(**kwargs)
+
+
+# --- validate_reward_args: the launch-time guard (front-runs the env ValueError) ---------------
+
+
+def test_validate_reward_args_accepts_valid_and_defaults():
+    # A valid speed-bonus config, a placement run, and a Namespace MISSING the flags (the tracer
+    # case — getattr falls back to the [D-19] defaults) all pass without raising.
+    validate_reward_args(SimpleNamespace(terminal_speed_bonus=0.5, speed_ref=200))
+    validate_reward_args(
+        SimpleNamespace(reward_mode="placement", terminal_speed_bonus=0.0, speed_ref=None)
+    )
+    validate_reward_args(SimpleNamespace())  # no reward attrs at all
+
+
+@pytest.mark.parametrize(
+    "ns, match",
+    [
+        (SimpleNamespace(terminal_speed_bonus=-1.0, speed_ref=None), "must be >= 0"),
+        (SimpleNamespace(terminal_speed_bonus=0.5, speed_ref=None), "must be a positive integer"),
+        (SimpleNamespace(terminal_speed_bonus=0.5, speed_ref=0), "must be a positive integer"),
+    ],
+)
+def test_validate_reward_args_rejects_bad_config(ns, match):
+    with pytest.raises(SystemExit, match=match):
+        validate_reward_args(ns)

--- a/ml/tests/test_reward_modes.py
+++ b/ml/tests/test_reward_modes.py
@@ -1,4 +1,4 @@
-"""Persona reward-shaping ([D-bite], docs/ml-bot/PERSONAS.md) — the wire-free terminal-reward modes.
+"""Persona reward-shaping (bite D, docs/ml-bot/PERSONAS.md) — the wire-free terminal-reward modes.
 
 Lean tier (torch-free): exercises the pure ``terminal_reward`` math, the ``DiceWarsEnv`` constructor
 validation, and the launch-time ``validate_reward_args`` guard — none of which need torch, sb3, or a
@@ -77,6 +77,48 @@ def test_speed_bonus_off_is_identical_to_plain_modes():
     )
 
 
+def test_truncation_pays_zero_in_placement_mode():
+    # A maxTurns stalemate CAP (truncated=1, won=0) is an artificial Gym truncation: step()
+    # bootstraps V(s) there. Paying the rank-at-cap `placement` reward on top would double-count
+    # the outcome and reward stalling to the cap — so the truncated terminal pays 0 in placement
+    # mode despite a non-zero `placement` on the wire. (The C1 fix; see the docstring.)
+    assert (
+        terminal_reward(
+            won=0, placement=0.67, turn_number=500, truncated=1, reward_mode="placement"
+        )
+        == 0.0
+    )
+    # Without the truncated flag, the same frame would (incorrectly) pay the rank — guards the fix.
+    assert (
+        terminal_reward(
+            won=0, placement=0.67, turn_number=500, truncated=0, reward_mode="placement"
+        )
+        == 0.67
+    )
+
+
+def test_truncation_is_zero_in_win_mode_too_and_default_off():
+    # win mode is already 0 on a cap (a cap can't be a win), so the truncated guard is a no-op
+    # there — the default path stays byte-identical. truncated defaults to 0 (off).
+    assert terminal_reward(won=0, placement=0.5, turn_number=500, truncated=1) == 0.0
+    assert terminal_reward(won=0, placement=0.5, turn_number=500) == 0.0  # default truncated=0
+
+
+def test_truncation_zeroes_even_a_would_be_speed_bonus():
+    # The truncated early-return dominates EVERY other field: even a bonus-eligible win (won=1 with
+    # a speed bonus configured) pays 0 on a cap, because the guard precedes the win-gated bonus.
+    # won=1+truncated=1 can't occur in production (step() rejects the pair), but feeding it to the
+    # pure helper pins its control-flow ordering so it never silently relies on that upstream guard.
+    # Without the early return this would compute 1*(1 + 0.5*clip(1 - 1/200)) ~= 1.4975, not 0 — so
+    # this test genuinely fails if the C1 guard is removed.
+    assert (
+        terminal_reward(
+            won=1, placement=1.0, turn_number=1, truncated=1, speed_bonus=0.5, speed_ref=200
+        )
+        == 0.0
+    )
+
+
 # --- DiceWarsEnv constructor validation (no server is started) ---------------------------------
 
 
@@ -113,8 +155,8 @@ def test_env_rejects_bad_reward_config(kwargs, match):
 
 
 def test_validate_reward_args_accepts_valid_and_defaults():
-    # A valid speed-bonus config, a placement run, and a Namespace MISSING the flags (the tracer
-    # case — getattr falls back to the [D-19] defaults) all pass without raising.
+    # A valid speed-bonus config, a placement run, and a Namespace MISSING the flags (a
+    # programmatic/test caller — getattr falls back to the [D-19] defaults) all pass, no raise.
     validate_reward_args(SimpleNamespace(terminal_speed_bonus=0.5, speed_ref=200))
     validate_reward_args(
         SimpleNamespace(reward_mode="placement", terminal_speed_bonus=0.0, speed_ref=None)
@@ -125,6 +167,9 @@ def test_validate_reward_args_accepts_valid_and_defaults():
 @pytest.mark.parametrize(
     "ns, match",
     [
+        # reward_mode is also front-run here (not only by argparse choices), so a non-CLI Namespace
+        # with a bad mode fails at launch instead of late inside a SubprocVecEnv worker.
+        (SimpleNamespace(reward_mode="bogus"), "reward-mode must be one of"),
         (SimpleNamespace(terminal_speed_bonus=-1.0, speed_ref=None), "must be >= 0"),
         (SimpleNamespace(terminal_speed_bonus=0.5, speed_ref=None), "must be a positive integer"),
         (SimpleNamespace(terminal_speed_bonus=0.5, speed_ref=0), "must be a positive integer"),

--- a/ml/tests/test_train_args.py
+++ b/ml/tests/test_train_args.py
@@ -49,6 +49,35 @@ def test_parser_adds_from_scratch_and_sentinels(tmp_path):
     assert a.checkpoint_every == 50_000
 
 
+def test_parser_reward_mode_defaults_and_parse(tmp_path):
+    # Reward shaping ([D-bite]) defaults to the [D-19] sparse win (byte-identical to before).
+    a = _args(tmp_path)
+    assert a.reward_mode == "win"
+    assert a.terminal_speed_bonus == 0.0
+    assert a.speed_ref is None
+    # A persona run sets the alternate objective + Blitz's optional speed bonus.
+    b = _args(
+        tmp_path,
+        extra=["--reward-mode", "placement", "--terminal-speed-bonus", "0.5", "--speed-ref", "200"],
+    )
+    assert b.reward_mode == "placement"
+    assert b.terminal_speed_bonus == 0.5
+    assert b.speed_ref == 200
+
+
+def test_validate_rejects_speed_bonus_without_ref(tmp_path):
+    a = _args(tmp_path, extra=["--terminal-speed-bonus", "0.5"])
+    with pytest.raises(SystemExit, match="speed-ref"):
+        tr._validate(a)
+
+
+def test_validate_accepts_speed_bonus_with_ref(tmp_path):
+    a = _args(tmp_path, extra=["--terminal-speed-bonus", "0.5", "--speed-ref", "200"])
+    tr._validate(a)  # no raise
+    assert a.terminal_speed_bonus == 0.5
+    assert a.speed_ref == 200
+
+
 def test_validate_rejects_from_scratch_with_freeze_trunk(tmp_path):
     a = _args(tmp_path, extra=["--from-scratch", "--freeze-trunk"])
     with pytest.raises(SystemExit, match="mutually exclusive"):
@@ -378,9 +407,12 @@ def test_resume_passes_remaining_and_skips_build_model(tmp_path, monkeypatch):
     a = _args(
         tmp_path,
         extra=[
-            "--state-dir", str(tmp_path / "state"),
-            "--timesteps", "1000",
-            "--out", str(tmp_path / "o.pt"),
+            "--state-dir",
+            str(tmp_path / "state"),
+            "--timesteps",
+            "1000",
+            "--out",
+            str(tmp_path / "o.pt"),
         ],
     )
     tr._validate(a)
@@ -414,9 +446,12 @@ def test_resume_zero_remaining_skips_learn_but_exports(tmp_path, monkeypatch):
     a = _args(
         tmp_path,
         extra=[
-            "--state-dir", str(tmp_path / "state"),
-            "--timesteps", "1000",
-            "--out", str(tmp_path / "o.pt"),
+            "--state-dir",
+            str(tmp_path / "state"),
+            "--timesteps",
+            "1000",
+            "--out",
+            str(tmp_path / "o.pt"),
         ],
     )
     tr._validate(a)
@@ -451,9 +486,12 @@ def test_fresh_run_when_state_dir_empty(tmp_path, monkeypatch):
     a = _args(
         tmp_path,
         extra=[
-            "--state-dir", str(tmp_path / "fresh-state"),
-            "--timesteps", "2048",
-            "--out", str(tmp_path / "o.pt"),
+            "--state-dir",
+            str(tmp_path / "fresh-state"),
+            "--timesteps",
+            "2048",
+            "--out",
+            str(tmp_path / "o.pt"),
         ],
     )
     tr._validate(a)  # state_dir is empty (no latest.json) ⇒ classify_latest_pointer reads ABSENT
@@ -473,9 +511,7 @@ def test_freeze_trunk_plus_state_dir_rejected_eagerly(tmp_path):
 
 @pytest.mark.parametrize("bad", ["0", "-1"])
 def test_validate_rejects_nonpositive_checkpoint_every(tmp_path, bad):
-    a = _args(
-        tmp_path, extra=["--state-dir", str(tmp_path / "state"), "--checkpoint-every", bad]
-    )
+    a = _args(tmp_path, extra=["--state-dir", str(tmp_path / "state"), "--checkpoint-every", bad])
     with pytest.raises(SystemExit, match="checkpoint-every"):
         tr._validate(a)
 
@@ -572,9 +608,12 @@ def test_both_callbacks_wrapped_in_callbacklist(tmp_path, monkeypatch):
     a = _args(
         tmp_path,
         extra=[
-            "--state-dir", str(tmp_path / "fresh-state"),
-            "--snapshot-dir", str(tmp_path / "league"),
-            "--out", str(tmp_path / "o.pt"),
+            "--state-dir",
+            str(tmp_path / "fresh-state"),
+            "--snapshot-dir",
+            str(tmp_path / "league"),
+            "--out",
+            str(tmp_path / "o.pt"),
         ],
     )
     tr._validate(a)

--- a/ml/tests/test_train_args.py
+++ b/ml/tests/test_train_args.py
@@ -50,7 +50,7 @@ def test_parser_adds_from_scratch_and_sentinels(tmp_path):
 
 
 def test_parser_reward_mode_defaults_and_parse(tmp_path):
-    # Reward shaping ([D-bite]) defaults to the [D-19] sparse win (byte-identical to before).
+    # Reward shaping (bite D) defaults to the [D-19] sparse win (byte-identical to before).
     a = _args(tmp_path)
     assert a.reward_mode == "win"
     assert a.terminal_speed_bonus == 0.0
@@ -76,6 +76,18 @@ def test_validate_accepts_speed_bonus_with_ref(tmp_path):
     tr._validate(a)  # no raise
     assert a.terminal_speed_bonus == 0.5
     assert a.speed_ref == 200
+
+
+@pytest.mark.parametrize("missing", ["reward_mode", "terminal_speed_bonus", "speed_ref"])
+def test_validate_rejects_missing_reward_attr_drift_guard(tmp_path, missing):
+    # train.py OWNS the reward flags, and _make_env_thunk/validate_reward_args read them via getattr
+    # (to tolerate flag-less tracer/test namespaces). A future rename that decoupled a flag from its
+    # getattr key would SILENTLY train sparse-win; the drift guard turns that into a launch
+    # SystemExit. Simulate the drift by deleting the attr the parser produced.
+    a = _args(tmp_path)
+    delattr(a, missing)
+    with pytest.raises(SystemExit, match=missing):
+        tr._validate(a)
 
 
 def test_validate_rejects_from_scratch_with_freeze_trunk(tmp_path):


### PR DESCRIPTION
## What & why

"Bite D" of the post-BEAT persona-roster plan (docs/ml-bot/PERSONAS.md). The PPO trainer's terminal reward was a single hard-coded line — `reward = float(frame.won)`. This makes the objective configurable so several PPO bots can be trained with deliberately different play-styles. **Every mode reads wire fields already on the terminal frame** (`placement`, `turn_number`), so there is **no `ENCODING_VERSION`/wire-contract change** (verified against `wire.py` + the env-server's terminal-frame construction).

## Changes

- **`dicewars_ppo.env.terminal_reward(...)`** — a pure, lean-testable helper:
  - `--reward-mode {win,placement}` — `win` = sparse terminal-win ([D-19] default, **Conqueror**); `placement` = scaled finishing rank in [0,1] (**Survivor**; the placement signal was on the wire but unused).
  - `--terminal-speed-bonus B` / `--speed-ref T` — **Blitz**'s optional secondary lever (lower `--gamma` first): `reward *= 1 + B·clip(1 − turn_number/T, 0, 1)`. **Multiplicative and win-gated** so a faster *win* is worth strictly more while a loss is untouched — an additive per-step time penalty would let the bot throw games to end them, exactly the failure mode [D-19] avoids.
- **Plumbing** — reward params on `DiceWarsEnv` (+ constructor validation); a torch-free launch-time `validate_reward_args` guard (front-runs the worker-side `ValueError` with a clean `SystemExit`); threaded through `_make_env_thunk` via `getattr` so the **tracer's parser and behavior stay byte-identical**. Defaults reproduce today's sparse win exactly.

Enables **Conqueror** (default), **Survivor** (`--reward-mode placement`), and **Blitz** (`--gamma` [+ speed bonus]) with no wire change. The dense **Expansionist**/**Predator** rewards still need the per-frame wire scalar — that's "bite G".

## Verification

- `ml/tests/test_reward_modes.py` (18 tests, lean/torch-free): the reward math (win/placement/speed-bonus clip + win-gating + off=identical), `DiceWarsEnv` constructor validation, and the launch guard. Runs in the lean `ml-test` tier.
- `test_train_args.py` gains the parser-defaults + `--reward-mode placement` parse + speed-bonus-requires-ref validate assertions (torch-gated tier — runs on CI/shodan).
- `ruff check` + `ruff format` clean. `PERSONAS.md` updated to mark the knob **built** (it previously described placement/speed personas as "free"/"costs nothing" — the *signals* were free, the consuming flags are this PR).

## Scope

Independent of #80 (eval-harness gating) — disjoint files (`ml/*` vs `scripts/*`), so the two can review/merge in parallel.