### PR TITLE
feat(ml): persona launcher — PERSONA knob wires bite-D reward + ppo-long warm-start (bite F)

### DIFF
--- a/docs/ml-bot/LOG.md
+++ b/docs/ml-bot/LOG.md
@@ -21,6 +21,72 @@ Entry template:
 
 ---
 
+## 2026-06-29 — Persona launcher: the `PERSONA` knob (bite F)
+
+**Phase:** persona-roster (training half) · **Who:** Ivan + Claude
+
+**Did:**
+
+- **Built the persona launcher** — the last thing blocking the persona _training_ track. Grounded
+  first: the bite-D reward flags (`--reward-mode`/`--terminal-speed-bonus`/`--speed-ref`) are already
+  wired + validated in `train.py`/`_train_common`/`env.py`, but the production shodan launcher
+  `scripts/shodan/ppo-train.sh` (committed pre-bite-D) did **not** forward them and was single-run.
+  Added a **`PERSONA={conqueror,blitz,survivor}`** knob (top of the launcher, before the `RUN_NAME`
+  default): each persona `:=`-defaults the reward objective (mode / `GAMMA` / optional speed bonus) +
+  a `RUN_NAME` + a warm-start `CHECKPOINT=runs/ppo-long/ppo.pt`. Factored the `python -m
+dicewars_ppo.train` argv into `build_train_argv` (now forwards the three reward flags) so a slim
+  `run_once` calls it. The `log` line records the persona/reward config; the USAGE header + RUNBOOK
+  §8 carry the batch recipe. `ppo-train.cmd` forwards `PERSONA` (+ per-run knobs) into WSL via
+  `WSLENV` so a per-persona schtask needs no file edit.
+- **Targeted the first batch at Conqueror + Blitz + Survivor** (Ivan's call) — the three personas
+  runnable with **no wire change** (bite D); Expansionist/Predator wait on the dense-reward wire
+  scalar ("bite G"). Conqueror is the matched control; Blitz lowers `GAMMA` to 0.99 (the tempo lever,
+  PERSONAS §5); Survivor uses `--reward-mode placement`.
+- **TDD:** 9 new lean-tier tests in `test_ppo_train_launcher.py` (source-and-inspect the resolved
+  config + the assembled argv, no python/torch/GPU): the byte-identical no-persona default, each
+  persona's reward objective + warm-start checkpoint, explicit-override-beats-preset, unknown-PERSONA
+  exit, conditional `--speed-ref`, from-scratch survives the refactor, and a `.cmd` WSLENV canary.
+  Launcher suite 6→15 green; `bash -n` clean; ruff clean; the `EXIT_POINTER_REJECTED` contract canary
+  still passes.
+- **Corrected a factual error in PERSONAS.md** found while grounding the warm-start: the "warm-start
+  critic note" claimed a Survivor inherits `ppo-long`'s win-trained value head. It does **not** —
+  `MaskableEdgePolicy._build` always makes a **fresh** scalar `value_net`, and the repacked actor
+  carries only `bc_net` (trunk + edge-head), never a critic. Rewrote the note: the PPO critic starts
+  uncalibrated for **every** warm-start (BC or PPO), Conqueror included.
+
+**Learned / decided:**
+
+- **The whole persona mechanism is the `PERSONA` knob + the existing env vars.** Because the launcher
+  was already fully env-parameterized (`RUN_NAME`/`GAMMA`/`CHECKPOINT`/…), and reward is computed
+  Python-side in `env.step()` (the wire is untouched), no new training code was needed — just
+  forwarding three flags and a preset table. Personas warm-start from `runs/ppo-long/ppo.pt` (a
+  repacked BC-format actor) exactly as `ppo-long` warm-started from `bc_model.pt`.
+- **Concurrency is collision-free for free:** each env-server binds an OS-assigned ephemeral port
+  (`--port=0`) — already true _within_ a run's N `SubprocVecEnv` workers — and every dir is keyed on
+  `RUN_NAME`, so 3 personas share only the GPU + the read-only BEAT actor. Three runs cost ≈ one.
+- **`set -e` gotcha (caught by the TDD):** a trailing `[ … ] && arr+=(…)` whose test is FALSE returns
+  non-zero, which made `build_train_argv` exit 1 and abort the launcher (4 tests caught it before any
+  shodan run). The original `run_once` was safe only because the `&&` wasn't its last statement.
+  Switched the conditional appends to `if` blocks.
+
+**Dead ends / surprises:**
+
+- The Windows/WSL schtasks-per-persona path can't be unit-tested locally (no cmd.exe); pinned the
+  `.cmd`↔launcher coupling statically (WSLENV-forwards-`PERSONA` grep canary) and documented the
+  realistic first-batch path as **3 backgrounded `nohup` runs in one WSL session** (the runs are
+  short specialization passes, same-day), with schtasks as the reboot-surviving upgrade.
+
+**Next:**
+
+- Open the PR; on merge, on shodan: confirm `runs/ppo-long/ppo.pt` is present, launch the 3-persona
+  batch (`TIMESTEPS≈3M`, a lower `LR` to protect the warm start — calibrate from the first run), then
+  gate (`ppo:gate`) **and** profile (`behavior:profile`, persona-named export) each, recording win% +
+  the behavioral signature in `RESULTS.md`. Ship the fun ones via the `ai_ppo` wiring pattern (PR #74).
+- Still separable: **bite G** (dense-reward wire scalar → Expansionist/Predator) and the Phase-2b
+  eval-harness follow-ups (Holm, determinism enforcement, `--melee`, `--csv`, curve/border axes).
+
+---
+
 ## 2026-06-29 — Behavioral-eval harness can gate a persona (PR #80, "bite E1") — MERGED
 
 **Phase:** persona-roster (eval half) · **Who:** Ivan + Claude

--- a/docs/ml-bot/PERSONAS.md
+++ b/docs/ml-bot/PERSONAS.md
@@ -172,11 +172,14 @@ can't be a win), so this only disciplines the placement path. Survivor still get
 signal from the decisive majority of games that end in a genuine `GAME_OVER`.
 
 **Warm-start critic note (corrected by the bite-F grounding).** The PPO critic is **always a fresh
-scalar `value_net`** — `MaskableEdgePolicy._build` constructs it at random init, separate from the
-BC value head, and the repacked actor (`repack_to_bc_checkpoint` → `bc_net.state_dict()`) carries
-**only** the trunk + per-edge head, never a critic. So a warm-start (BC _or_ `ppo-long`) never
-inherits a trained value function — the critic starts uncalibrated for **every** persona, Conqueror
-included (this is unchanged from how `ppo-long` itself trained). For Survivor the practical wrinkle is
+scalar `value_net`** — `MaskableEdgePolicy._build` constructs it at random init and
+`warm_start_from_bc` intentionally leaves it there, separate from the BC value head. The repacked
+actor (`repack_to_bc_checkpoint` → `bc_net.state_dict()`) carries the trunk, the per-edge head, **and
+the BC value head** (the `EdgePolicyNet`'s own `[won, placement]` head, which loads but PPO never
+trains or reads — no loss references it) — but it carries **no PPO critic**. So a warm-start (BC _or_
+`ppo-long`) never inherits a trained value function: the surviving BC value head is inert under PPO,
+and the PPO `value_net` starts uncalibrated for **every** persona, Conqueror included (this is
+unchanged from how `ppo-long` itself trained). For Survivor the practical wrinkle is
 just that `placement` is a denser target (mean ≈0.5 vs win's ~0.25 for 4p), so the fresh critic has
 more to fit early; PPO's per-batch advantage normalization absorbs most of it, but expect a noisier
 first stretch, and a short value-head warmup or a higher initial `value-coef` may speed convergence.

--- a/docs/ml-bot/PERSONAS.md
+++ b/docs/ml-bot/PERSONAS.md
@@ -19,6 +19,16 @@
 > **with no wire change**. The dense **Expansionist**/**Predator** rewards still need the per-frame
 > wire scalar ("bite G"). The eval-harness side ("bite E1") can already gate a persona's exported
 > weights. So the §2 "the reward is one line" framing below is now historical — see that knob.
+>
+> **Built since (2026-06-29, "bite F" — the persona launcher):** the shodan launcher
+> `scripts/shodan/ppo-train.sh` now has a **`PERSONA={conqueror,blitz,survivor}`** knob that wires the
+> bite-D reward objective + a default `RUN_NAME` + a warm-start from `runs/ppo-long/ppo.pt` (the BEAT
+> actor, **not** the BC net). All other HPs stay shared (set once for the batch) so the control is
+> matched on every axis but the reward. An unset `PERSONA` is byte-identical to the BEAT-run launcher.
+> Concurrency is collision-free (per-`RUN_NAME` dirs + OS-assigned ephemeral env-server ports), so the
+> three flag-only personas run together for ≈ the cost of one — see the RUNBOOK "persona" section. So
+> §8 steps 1–3 are now **executable**: the only thing left before a batch is the GPU time itself (plus
+> "bite G" for the two dense personas).
 
 ---
 
@@ -161,12 +171,18 @@ cap** — precisely the passivity failure §6 warns about. `win` mode is 0 on a 
 can't be a win), so this only disciplines the placement path. Survivor still gets a dense placement
 signal from the decisive majority of games that end in a genuine `GAME_OVER`.
 
-**Warm-start critic note.** A Survivor warm-started from `ppo-long`'s win-trained value head starts
-**miscalibrated**: that head predicts ≈win-rate (mostly 0, ~0.25 mean for 4p), but placement is a
-denser signal with mean ≈0.5. PPO's per-batch advantage normalization absorbs most of the shift,
-but expect a noisier first stretch; a short value-head warmup or a higher initial `value-coef` may
-speed convergence. Reward scale is otherwise comparable (both objectives top out at 1.0 pre-bonus),
-so shared `lr`/clip/`value-coef` stay reasonable — no normalization change is _required_.
+**Warm-start critic note (corrected by the bite-F grounding).** The PPO critic is **always a fresh
+scalar `value_net`** — `MaskableEdgePolicy._build` constructs it at random init, separate from the
+BC value head, and the repacked actor (`repack_to_bc_checkpoint` → `bc_net.state_dict()`) carries
+**only** the trunk + per-edge head, never a critic. So a warm-start (BC _or_ `ppo-long`) never
+inherits a trained value function — the critic starts uncalibrated for **every** persona, Conqueror
+included (this is unchanged from how `ppo-long` itself trained). For Survivor the practical wrinkle is
+just that `placement` is a denser target (mean ≈0.5 vs win's ~0.25 for 4p), so the fresh critic has
+more to fit early; PPO's per-batch advantage normalization absorbs most of it, but expect a noisier
+first stretch, and a short value-head warmup or a higher initial `value-coef` may speed convergence.
+Reward scale is otherwise comparable (both objectives top out at 1.0 pre-bonus), so shared
+`lr`/clip/`value-coef` stay reasonable — no normalization change is _required_. (The earlier draft of
+this note wrongly assumed `ppo-long`'s win-trained value head carries over; it does not.)
 
 ---
 
@@ -278,9 +294,11 @@ fun. The roster makes that filter _possible_; it doesn't automate it.
    Conqueror/Blitz/Survivor runnable with no wire change. **Still TODO (bite G):** add the per-frame
    territory/elim scalar to the env-server wire (Expansionist/Predator) behind a version bump, off by
    default (byte-identical to today when unset — the B5/B6 opt-in pattern).
-3. **One persona = one reward config + one schtask**, all **warm-started from `ppo-long`'s final
+3. **One persona = one reward config + one run**, all **warm-started from `ppo-long`'s final
    policy** (shared good initialization; reward shaping then specializes), running **concurrently**
-   on shodan (latency-bound, idle hardware). Re-run Conqueror as the matched control.
+   on shodan (latency-bound, idle hardware). Re-run Conqueror as the matched control. _(Bite F — done:
+   the `PERSONA` knob in `scripts/shodan/ppo-train.sh` + the RUNBOOK "persona" batch recipe make this a
+   one-line launch per persona; concurrency is collision-free.)_
 4. **Profile + gate each** (behavioral harness + `ppo:gate`), write results to `RESULTS.md`, log
    the framework decision (`D-27?`) and any wire-contract change (`D-28?`) to `DECISIONS.md`.
 5. **Ship the fun ones as selectable in-game bots** — the `ai_ppo` wiring (PR #74) generalizes:

--- a/ml/tests/test_ppo_train_launcher.py
+++ b/ml/tests/test_ppo_train_launcher.py
@@ -172,3 +172,173 @@ def test_transient_failure_then_success_exits_zero(tmp_path):
     r = _drive_main(tmp_path, scenario, max_fails=5)
     assert r.rc == 0
     assert r.attempts == 2  # failed once, relaunched, then succeeded
+
+
+# --- persona launcher (bite F) -------------------------------------------------------------------
+# The PERSONA preset + the bite-D reward-flag forwarding. These SOURCE the launcher (guarded main ⇒
+# not run) and inspect the resolved config / the assembled `python -m dicewars_ppo.train` argv, that
+# the launcher factors into `build_train_argv` precisely so this can be pinned in lean CI without
+# spawning python, torch, or a GPU. The contract under test: a persona only sets DEFAULTS (an
+# explicit env override always wins), and an UNSET persona is byte-identical to the BEAT-run reward.
+
+
+def _resolve(tmp_path, env=None, *, build_argv=True, snippet=None):
+    """Source the launcher with ``env``, then run an inspection ``snippet``; return ``(rc, out)``.
+
+    ``RUN_ROOT`` is pinned into ``tmp_path`` so the launcher's source-time ``mkdir -p`` can't touch
+    the real ``ml/runs`` tree. When ``build_argv`` (the default), ``build_train_argv`` runs first so
+    ``snippet`` can read ``TRAIN_ARGV``; the default snippet prints that argv one element per line.
+    """
+    run_root = tmp_path / "run"
+    lines = [
+        "set -euo pipefail",
+        f'export RUN_ROOT="{run_root}"',
+        'export DEVICE="cpu"',
+    ]
+    lines += [f'export {k}="{v}"' for k, v in (env or {}).items()]
+    lines.append(f'source "{LAUNCHER}"')
+    if build_argv:
+        lines.append("build_train_argv")
+    lines.append(snippet or 'printf "%s\\n" "${TRAIN_ARGV[@]}"')
+    script = tmp_path / "resolve.sh"
+    script.write_text("\n".join(lines) + "\n")
+    proc = subprocess.run(
+        ["bash", str(script)], capture_output=True, text=True, timeout=30, cwd=str(ML_DIR.parent)
+    )
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+def _argv_pairs(output: str) -> dict:
+    """Fold a printed ``--flag\\nvalue`` argv into a ``{flag: value}`` dict (last wins). Flags that
+    take no value map to '' (the next token is another flag or end)."""
+    toks = output.split("\n")
+    out = {}
+    i = 0
+    while i < len(toks):
+        t = toks[i]
+        if t.startswith("--"):
+            nxt = toks[i + 1] if i + 1 < len(toks) else ""
+            if nxt.startswith("--") or nxt == "":
+                out[t] = ""
+                i += 1
+            else:
+                out[t] = nxt
+                i += 2
+        else:
+            i += 1
+    return out
+
+
+def test_no_persona_is_byte_identical_to_the_beat_run(tmp_path):
+    # The KEY invariant: an unset PERSONA forwards the SAME training command as the pre-change
+    # BEAT/control launcher. Assert the WHOLE production flag set (not just the reward subset) so a
+    # future edit to build_train_argv that silently drops/alters a regime flag — e.g. removing
+    # `--snapshot-store disk` (reverting to a per-worker memory league), `--snapshot-dir` (PFSP
+    # off), or `--start-method forkserver` (the fork-after-threads hazard) — turns this test RED
+    # instead of letting a multi-day run train on a different regime under a "byte-identical" check.
+    rc, out = _resolve(tmp_path)
+    assert rc == 0
+    argv = _argv_pairs(out)
+    assert set(argv) == {
+        "--checkpoint", "--out", "--timesteps", "--n-envs", "--start-method", "--lr",
+        "--ent-coef", "--gamma", "--reward-mode", "--terminal-speed-bonus", "--device",
+        "--snapshot-dir", "--snapshot-every", "--snapshot-store", "--reserve-baselines",
+        "--league-state-dir", "--league-dump-every", "--state-dir", "--checkpoint-every",
+        "--log-dir",
+    }  # no production flag added or dropped; no --speed-ref / --from-scratch (both conditional)
+    # The [D-19] sparse terminal-win objective the BEAT run trained on:
+    assert argv["--reward-mode"] == "win"
+    assert argv["--terminal-speed-bonus"] == "0"
+    assert argv["--checkpoint"] == "checkpoints/v2-base/bc_model.pt"  # BC warm start, not a persona
+    # The regime-defining values a silent edit could flip under the multi-day run:
+    assert argv["--start-method"] == "forkserver"  # CUDA-after-fork / fork-after-threads guard
+    assert argv["--snapshot-store"] == "disk"  # cross-worker league, not per-worker memory
+    assert argv["--reserve-baselines"] == "3"  # R=3 turtle-equilibrium floor ([D-24])
+    assert argv["--snapshot-every"] == "100000"
+    assert argv["--checkpoint-every"] == "100000"
+    assert argv["--league-dump-every"] == "50"
+    # The task-A BEAT production HPs (NOT train.py's own protective defaults):
+    assert argv["--lr"] == "2.5e-4"
+    assert argv["--ent-coef"] == "0.01"
+    assert argv["--gamma"] == "0.999"
+    assert argv["--timesteps"] == "20000000"
+
+
+def test_persona_blitz_lowers_gamma_and_warm_starts_from_ppo_long(tmp_path):
+    rc, out = _resolve(
+        tmp_path,
+        {"PERSONA": "blitz"},
+        build_argv=False,
+        snippet='echo "$REWARD_MODE|$GAMMA|$RUN_NAME|$CHECKPOINT"',
+    )
+    assert rc == 0
+    reward, gamma, run_name, checkpoint = out.strip().split("|")
+    assert reward == "win"
+    assert gamma == "0.99"  # the tempo lever (PERSONAS §5) — distinct from the 0.999 default
+    assert run_name == "ppo-blitz"
+    assert checkpoint == "runs/ppo-long/ppo.pt"  # specialize the BEAT policy, not the BC net
+
+
+def test_persona_survivor_uses_placement_reward(tmp_path):
+    rc, out = _resolve(tmp_path, {"PERSONA": "survivor"})
+    assert rc == 0
+    argv = _argv_pairs(out)
+    assert argv["--reward-mode"] == "placement"
+    assert argv["--gamma"] == "0.999"
+    assert argv["--checkpoint"] == "runs/ppo-long/ppo.pt"
+
+
+def test_persona_conqueror_is_the_matched_control(tmp_path):
+    # The control re-runs today's objective (win / 0.999) but still warm-starts from ppo-long and
+    # gets its own run name, so its behavioral profile is a matched baseline for the others.
+    rc, out = _resolve(
+        tmp_path,
+        {"PERSONA": "conqueror"},
+        build_argv=False,
+        snippet='echo "$REWARD_MODE|$GAMMA|$RUN_NAME|$CHECKPOINT"',
+    )
+    assert rc == 0
+    assert out.strip() == "win|0.999|ppo-conqueror|runs/ppo-long/ppo.pt"
+
+
+def test_explicit_env_overrides_persona_preset(tmp_path):
+    # PERSONA sets DEFAULTS only (`:=`), so an explicit override always wins — needed to sweep e.g.
+    # Blitz's gamma floor without forking the launcher.
+    rc, out = _resolve(tmp_path, {"PERSONA": "blitz", "GAMMA": "0.97", "RUN_NAME": "blitz-v2"})
+    assert rc == 0
+    argv = _argv_pairs(out)
+    assert argv["--gamma"] == "0.97"
+
+
+def test_unknown_persona_exits_nonzero(tmp_path):
+    rc, out = _resolve(tmp_path, {"PERSONA": "wrecker"}, build_argv=False, snippet="echo unreached")
+    assert rc != 0
+    assert "unknown persona" in out.lower()
+    assert "unreached" not in out
+
+
+def test_speed_ref_forwarded_only_when_bonus_set(tmp_path):
+    rc, out = _resolve(
+        tmp_path, {"PERSONA": "blitz", "TERMINAL_SPEED_BONUS": "0.5", "SPEED_REF": "120"}
+    )
+    assert rc == 0
+    argv = _argv_pairs(out)
+    assert argv["--terminal-speed-bonus"] == "0.5"
+    assert argv["--speed-ref"] == "120"
+
+
+def test_from_scratch_still_appends_flag_after_refactor(tmp_path):
+    # The control run uses FROM_SCRATCH=1; pin that build_train_argv preserved it through the
+    # run_once → build_train_argv refactor.
+    rc, out = _resolve(tmp_path, {"FROM_SCRATCH": "1"})
+    assert rc == 0
+    assert "--from-scratch" in _argv_pairs(out)
+
+
+@pytest.mark.skipif(not CMD.is_file(), reason="needs ppo-train.cmd")
+def test_cmd_forwards_persona_into_wsl():
+    """The Windows→WSL bridge must export PERSONA (and the per-run knobs) into WSL via WSLENV so a
+    per-persona scheduled task can set them as Windows env vars without editing the .cmd."""
+    cmd_text = CMD.read_text()
+    assert "WSLENV" in cmd_text
+    assert re.search(r"PERSONA/u", cmd_text), "ppo-train.cmd must forward PERSONA into WSL (WSLENV)"

--- a/ml/tests/test_ppo_train_launcher.py
+++ b/ml/tests/test_ppo_train_launcher.py
@@ -317,7 +317,18 @@ def test_unknown_persona_exits_nonzero(tmp_path):
     assert "unreached" not in out
 
 
-def test_speed_ref_forwarded_only_when_bonus_set(tmp_path):
+def test_speed_ref_forwarded_iff_speed_ref_set(tmp_path):
+    # The launcher gates `--speed-ref` on `[ -n "$SPEED_REF" ]` — i.e. on SPEED_REF being non-empty,
+    # NOT on the bonus. Pin both that coupling and the footgun: SPEED_REF set with the bonus still 0
+    # STILL forwards `--speed-ref` (train.py then rejects bonus==0 + a ref, fail-loud — RUNBOOK §8).
+    # The absent-when-unset direction is covered by the byte-identical test's whole-flag-set assert
+    # (no --speed-ref there).
+    rc, out = _resolve(tmp_path, {"PERSONA": "blitz", "SPEED_REF": "120"})  # bonus left at 0
+    assert rc == 0
+    argv = _argv_pairs(out)
+    assert argv["--terminal-speed-bonus"] == "0"  # bonus untouched...
+    assert argv["--speed-ref"] == "120"  # ...yet --speed-ref forwarded purely because SPEED_REF set
+
     rc, out = _resolve(
         tmp_path, {"PERSONA": "blitz", "TERMINAL_SPEED_BONUS": "0.5", "SPEED_REF": "120"}
     )
@@ -337,8 +348,16 @@ def test_from_scratch_still_appends_flag_after_refactor(tmp_path):
 
 @pytest.mark.skipif(not CMD.is_file(), reason="needs ppo-train.cmd")
 def test_cmd_forwards_persona_into_wsl():
-    """The Windows→WSL bridge must export PERSONA (and the per-run knobs) into WSL via WSLENV so a
-    per-persona scheduled task can set them as Windows env vars without editing the .cmd."""
+    """The Windows→WSL bridge must export PERSONA AND every per-run knob into WSL via WSLENV so a
+    per-persona scheduled task can set them as Windows env vars without editing it. Assert each
+    `*/u` token (not just PERSONA): dropping e.g. REWARD_MODE/u or SPEED_REF/u would silently strand
+    the matching `:=`-override path (test_explicit_env_overrides_persona_preset) at the Windows→WSL
+    boundary with nothing to catch it."""
     cmd_text = CMD.read_text()
     assert "WSLENV" in cmd_text
-    assert re.search(r"PERSONA/u", cmd_text), "ppo-train.cmd must forward PERSONA into WSL (WSLENV)"
+    # Every launcher env var a scheduled task may set per-persona (RUNBOOK "persona" batch knobs).
+    for var in (
+        "PERSONA", "CHECKPOINT", "TIMESTEPS", "LR", "ENT_COEF", "GAMMA", "RUN_NAME",
+        "REWARD_MODE", "TERMINAL_SPEED_BONUS", "SPEED_REF", "N_ENVS", "RESERVE_BASELINES",
+    ):
+        assert re.search(rf"{var}/u", cmd_text), f"ppo-train.cmd must forward {var} via WSLENV"

--- a/scripts/shodan/RUNBOOK.md
+++ b/scripts/shodan/RUNBOOK.md
@@ -230,3 +230,94 @@ not want it to relaunch at next logon/boot).
 2. Update `docs/ml-bot/RESULTS.md` (win% table + the Lookahead pin) and `LOG.md`.
 3. Deferred test-hardening (env-server `main()` persistence integration test, live cross-worker
    `SharedDiskStore`, live forkserver two-half resume smoke) is **PR-7**, not part of this run.
+
+---
+
+## 8. Reward-persona batch (bite F) — the concurrent persona runs
+
+The headline BEAT run is done. This launches the **reward-persona roster**
+([docs/ml-bot/PERSONAS.md](../../docs/ml-bot/PERSONAS.md)): several PPO bots that share the BEAT
+policy as their starting point but specialize toward distinct play-styles via the reward objective.
+**Prerequisite:** `ml/runs/ppo-long/ppo.pt` (the BEAT actor) must exist on this box — each persona
+warm-starts from it (PERSONAS §8 step 3). Preflight HALTs if it is missing.
+
+The launcher's `PERSONA` knob is the whole mechanism: it sets the reward objective + a default
+`RUN_NAME` + warm-starts from `runs/ppo-long/ppo.pt`. **Everything else (TIMESTEPS / LR / N_ENVS / R)
+is shared — set it once for the batch** so the Conqueror control is matched on every axis but the
+reward (PERSONAS §3: vary reward XOR field, never both). The three flag-only personas:
+
+| `PERSONA`   | Reward objective                         | Run name        |
+| ----------- | ---------------------------------------- | --------------- |
+| `conqueror` | `win`, γ=0.999 — **the matched control** | `ppo-conqueror` |
+| `blitz`     | `win`, **γ=0.99** (tempo lever, §5)      | `ppo-blitz`     |
+| `survivor`  | **`placement`**, γ=0.999                 | `ppo-survivor`  |
+
+These are **specialization** runs from an already-strong policy, so the budget is far smaller than the
+20M from-scratch/BC run — start at **`TIMESTEPS=3000000`** (≈ a few hours each; calibrate from the
+first run's TensorBoard). Consider a **lower `LR`** than the BEAT `2.5e-4` so the reward shaping nudges
+rather than wrecks the warm start. (Expansionist/Predator need the per-frame territory/elim wire scalar
+— "bite G" — and are not in this batch.)
+
+### 8a. Launch concurrently (the simple path — one WSL session)
+
+The box is idle and the runs are latency-bound, so 3 concurrent runs cost ≈ the time of one
+(PERSONAS §1). For a same-day batch, background all three in one WSL session:
+
+```bash
+cd <repo> && source ml/.venv/bin/activate
+for P in conqueror blitz survivor; do
+  PERSONA=$P TIMESTEPS=3000000 LR=1e-4 nohup bash scripts/shodan/ppo-train.sh \
+      > ml/runs/ppo-$P.boot.log 2>&1 &
+done
+jobs -l   # 3 PIDs; each persona has its OWN runs/<name>/ tree (state/league/tb) — no collision
+```
+
+Each run is fully isolated: dirs are keyed on `RUN_NAME`, and every Node env-server binds an
+**OS-assigned ephemeral port** (`--port=0`), so nothing is shared but the read-only BEAT actor and the
+GPU. Monitor each at `ml/runs/<name>/launcher.log` + `ml/runs/<name>/tb/` (§6).
+
+### 8b. Launch via Task Scheduler (reboot-surviving — for longer runs)
+
+`ppo-train.cmd` forwards `PERSONA` (+ the per-run knobs) into WSL via `WSLENV`, so each var only has to
+be present in the **Windows process environment** when the task runs. But Task Scheduler's `<Exec>`
+action has no env-var field and `ppo-train.cmd` takes no arguments, and a single _global_ Windows
+`PERSONA` var can't differentiate three concurrent persona tasks — so set it **per task** one of two
+ways (clone `ppo-train-task.xml` per persona, each with a distinct `<URI>`/name):
+
+- **Wrapper command (no extra file):** point the task action at
+  `cmd.exe /c "set PERSONA=blitz&& set TIMESTEPS=3000000&& set LR=1e-4&& scripts\shodan\ppo-train.cmd"`
+  (the `set`s populate the process env that `WSLENV` then forwards).
+- **Per-persona .cmd copy:** copy `ppo-train.cmd` → `ppo-train-blitz.cmd` with `set PERSONA=blitz` (and
+  any per-run knobs) near the top, and point that persona's task at the copy.
+
+The auto-restart / HALT semantics (§6) apply per persona, independently.
+
+### 8c. Gate + profile each persona
+
+Each persona gets **two** measurements — strength **and** style:
+
+```bash
+# Export each persona's actor to the `.weights.js` / sibling `.fixture.json` convention. This naming
+# is LOAD-BEARING for step 2: behavior:profile has NO --fixture flag — it derives the parity fixture
+# from the weights path via siblingFixturePath (`*.weights.js` → `*.fixture.json`, same dir). Run from
+# ml/ (cd ml && source .venv/bin/activate); repeat for ppo-conqueror (the control) and ppo-survivor.
+python -m dicewars_bc.export_weights --ckpt runs/ppo-blitz/ppo.pt \
+    --out runs/ppo-blitz/blitz.weights.js --fixture runs/ppo-blitz/blitz.fixture.json
+
+# 1. Strength (does it still beat Lookahead, or how much win% did the persona cost?) — §5 gate.
+#    ppo:gate DOES take an explicit --fixture (unlike behavior:profile):
+cd .. && npm run ppo:gate -- --weights ml/runs/ppo-blitz/blitz.weights.js \
+    --fixture ml/runs/ppo-blitz/blitz.fixture.json --name Blitz
+
+# 2. Style (did a DISTINCT personality emerge?) — the behavioral-eval harness gates the persona's
+#    pre-registered signature. The bot's display NAME must match the PERSONA_SIGNATURES key (Blitz);
+#    the fixture is found as the weights file's `.fixture.json` sibling automatically.
+npm run behavior:profile -- --bots Blitz=ml/runs/ppo-blitz/blitz.weights.js \
+    --control Conqueror=ml/runs/ppo-conqueror/conqueror.weights.js \
+    --mde aggression:1.5,turnsToWin:8   # calibrate the MDEs from the pilot; see EVAL_HARNESS.md
+```
+
+Personas are **not** gated on beating Lookahead — a Blitz that trades win% for tempo is the
+deliverable (PERSONAS §9). Record each persona's win% **and** behavioral signature in
+`docs/ml-bot/RESULTS.md`. Ship the fun ones as in-game bots (a weights file + a thin `ai_<persona>.js`
+alias + an `aiConfig`/`builtInBots` entry — the `ai_ppo` wiring from PR #74 generalizes).

--- a/scripts/shodan/ppo-train.cmd
+++ b/scripts/shodan/ppo-train.cmd
@@ -22,6 +22,14 @@ if "%WSL_DISTRO%"==""    set "WSL_DISTRO=Ubuntu"
 if "%REPO_WSL_PATH%"=="" set "REPO_WSL_PATH=/home/%USERNAME%/dicewarsjs"
 if "%VENV_ACTIVATE%"=="" set "VENV_ACTIVATE=ml/.venv/bin/activate"
 
+REM Forward selected launcher knobs INTO WSL so a per-persona scheduled task can set them as Windows
+REM environment variables (e.g. PERSONA=blitz, TIMESTEPS=3000000) without editing this file — that is
+REM how the reward-persona batch (RUNBOOK "persona") runs each persona as its own schtask off this one
+REM bridge. `/u` passes each var from the Windows USER environment into WSL; an UNSET Windows var
+REM simply doesn't appear in WSL (the launcher then uses its own default), so this stays byte-identical
+REM to the BEAT run when none are set. Append to any existing WSLENV rather than clobbering it.
+if "%WSLENV%"=="" (set "WSLENV=PERSONA/u:CHECKPOINT/u:TIMESTEPS/u:LR/u:ENT_COEF/u:GAMMA/u:RUN_NAME/u:REWARD_MODE/u:TERMINAL_SPEED_BONUS/u:SPEED_REF/u") else (set "WSLENV=%WSLENV%:PERSONA/u:CHECKPOINT/u:TIMESTEPS/u:LR/u:ENT_COEF/u:GAMMA/u:RUN_NAME/u:REWARD_MODE/u:TERMINAL_SPEED_BONUS/u:SPEED_REF/u")
+
 REM -l = login shell so a conda/venv init in the user's profile is honored; then activate the [rl]
 REM venv explicitly (the launcher's preflight HALTS loudly if torch/sb3 are still missing).
 REM `cd ... || exit 1` so a misconfigured REPO_WSL_PATH fails with a clear error instead of running

--- a/scripts/shodan/ppo-train.cmd
+++ b/scripts/shodan/ppo-train.cmd
@@ -25,10 +25,12 @@ if "%VENV_ACTIVATE%"=="" set "VENV_ACTIVATE=ml/.venv/bin/activate"
 REM Forward selected launcher knobs INTO WSL so a per-persona scheduled task can set them as Windows
 REM environment variables (e.g. PERSONA=blitz, TIMESTEPS=3000000) without editing this file — that is
 REM how the reward-persona batch (RUNBOOK "persona") runs each persona as its own schtask off this one
-REM bridge. `/u` passes each var from the Windows USER environment into WSL; an UNSET Windows var
-REM simply doesn't appear in WSL (the launcher then uses its own default), so this stays byte-identical
-REM to the BEAT run when none are set. Append to any existing WSLENV rather than clobbering it.
-if "%WSLENV%"=="" (set "WSLENV=PERSONA/u:CHECKPOINT/u:TIMESTEPS/u:LR/u:ENT_COEF/u:GAMMA/u:RUN_NAME/u:REWARD_MODE/u:TERMINAL_SPEED_BONUS/u:SPEED_REF/u") else (set "WSLENV=%WSLENV%:PERSONA/u:CHECKPOINT/u:TIMESTEPS/u:LR/u:ENT_COEF/u:GAMMA/u:RUN_NAME/u:REWARD_MODE/u:TERMINAL_SPEED_BONUS/u:SPEED_REF/u")
+REM bridge. `/u` is the Win32->WSL DIRECTION flag (forward this var only when invoking WSL from
+REM Windows); an UNSET Windows var simply doesn't appear in WSL (the launcher then uses its own
+REM default), so this stays byte-identical to the BEAT run when none are set. The list covers every
+REM per-run knob the RUNBOOK "persona" batch describes as shared (incl. N_ENVS / RESERVE_BASELINES).
+REM Append to any existing WSLENV rather than clobbering it.
+if "%WSLENV%"=="" (set "WSLENV=PERSONA/u:CHECKPOINT/u:TIMESTEPS/u:LR/u:ENT_COEF/u:GAMMA/u:RUN_NAME/u:REWARD_MODE/u:TERMINAL_SPEED_BONUS/u:SPEED_REF/u:N_ENVS/u:RESERVE_BASELINES/u") else (set "WSLENV=%WSLENV%:PERSONA/u:CHECKPOINT/u:TIMESTEPS/u:LR/u:ENT_COEF/u:GAMMA/u:RUN_NAME/u:REWARD_MODE/u:TERMINAL_SPEED_BONUS/u:SPEED_REF/u:N_ENVS/u:RESERVE_BASELINES/u")
 
 REM -l = login shell so a conda/venv init in the user's profile is honored; then activate the [rl]
 REM venv explicitly (the launcher's preflight HALTS loudly if torch/sb3 are still missing).

--- a/scripts/shodan/ppo-train.sh
+++ b/scripts/shodan/ppo-train.sh
@@ -27,6 +27,9 @@
 #   bash scripts/shodan/ppo-train.sh                       # the long BEAT run (warm-started)
 #   FROM_SCRATCH=1 RUN_NAME=ppo-control TIMESTEPS=1000000 \
 #       bash scripts/shodan/ppo-train.sh                   # the [D-19] from-scratch control run
+#   PERSONA=blitz    TIMESTEPS=3000000 bash scripts/shodan/ppo-train.sh   # a reward-persona run: warm-
+#   PERSONA=survivor TIMESTEPS=3000000 bash scripts/shodan/ppo-train.sh   # starts from ppo-long's actor
+#   PERSONA=conqueror TIMESTEPS=3000000 bash scripts/shodan/ppo-train.sh  # (control). See RUNBOOK "persona".
 #
 set -euo pipefail
 
@@ -35,6 +38,24 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 ML_DIR="$REPO_ROOT/ml"
 ENCODE_JS="$REPO_ROOT/src/arena/encodeObservation.js"
+
+# --- reward-persona preset (bite F; docs/ml-bot/PERSONAS.md §8 step 3) -----------------------------
+# Each persona is the SAME warm-started run differing ONLY in the reward OBJECTIVE (mode / discount /
+# optional speed bonus). Every OTHER hyperparameter (TIMESTEPS/LR/ENT_COEF/N_ENVS/R) is shared, set
+# once for the batch, so the Conqueror control is matched on everything but the reward axis
+# (PERSONAS §3: vary reward XOR opponent field, never both). A persona only sets DEFAULTS (`:=`), so
+# an explicit env override always wins, and an UNSET persona is a pure no-op — byte-identical to the
+# BEAT-run launcher. Persona runs warm-start from ppo-long's repacked actor (PERSONAS §8 step 3), not
+# the BC net; preflight HALTs loudly if that actor isn't on this box. This block must precede the
+# RUN_NAME default below so a persona can name its own run.
+PERSONA="${PERSONA:-}"
+case "$PERSONA" in
+  "") ;;  # no persona → the long BEAT run / control behavior, unchanged (byte-identical)
+  conqueror) : "${CHECKPOINT:=runs/ppo-long/ppo.pt}"; : "${REWARD_MODE:=win}";       : "${GAMMA:=0.999}"; : "${RUN_NAME:=ppo-conqueror}" ;;
+  blitz)     : "${CHECKPOINT:=runs/ppo-long/ppo.pt}"; : "${REWARD_MODE:=win}";       : "${GAMMA:=0.99}";  : "${RUN_NAME:=ppo-blitz}" ;;
+  survivor)  : "${CHECKPOINT:=runs/ppo-long/ppo.pt}"; : "${REWARD_MODE:=placement}"; : "${GAMMA:=0.999}"; : "${RUN_NAME:=ppo-survivor}" ;;
+  *) echo "ppo-train: unknown PERSONA='$PERSONA' (expected: conqueror | blitz | survivor)" >&2; exit 1 ;;
+esac
 
 # --- run identity + paths -------------------------------------------------------------------------
 RUN_NAME="${RUN_NAME:-ppo-long}"
@@ -52,7 +73,13 @@ TIMESTEPS="${TIMESTEPS:-20000000}"                  # ABSOLUTE env-step budget f
 DEVICE="${DEVICE:-cuda}"                             # shodan GPU; "cpu" only for a smoke
 LR="${LR:-2.5e-4}"                                  # task-A BEAT config (production HP — NOT a default)
 ENT_COEF="${ENT_COEF:-0.01}"                        # task-A BEAT config (production HP)
-GAMMA="${GAMMA:-0.999}"
+GAMMA="${GAMMA:-0.999}"                             # a persona may have lowered this above (Blitz)
+
+# --- persona reward objective (bite D flags). Defaults reproduce the [D-19] sparse terminal-win the
+# BEAT run trained on, so an unset persona forwards a byte-identical objective. ----------------------
+REWARD_MODE="${REWARD_MODE:-win}"                   # 'win' = Conqueror/Blitz; 'placement' = Survivor
+TERMINAL_SPEED_BONUS="${TERMINAL_SPEED_BONUS:-0}"   # Blitz's optional secondary lever (0 = off)
+SPEED_REF="${SPEED_REF:-}"                          # turn-count ref; train.py REQUIRES it when bonus>0
 
 # --- parallelism ([D-26] Q4: SubprocVecEnv(forkserver), CUDA inits AFTER the fork) ----------------
 # Size to cores but leave headroom for the learner + the per-worker Node env-servers. n_steps*n_envs
@@ -145,30 +172,46 @@ check_commit_pinned() {
   fi
 }
 
+# Assemble the `python -m dicewars_ppo.train` argv into the global TRAIN_ARGV array. Factored out of
+# run_once so the launcher tests (ml/tests/test_ppo_train_launcher.py) can pin that the persona reward
+# flags (bite D) are forwarded WITHOUT spawning python/torch/a GPU. --reward-mode/--terminal-speed-
+# bonus are ALWAYS passed (their win/0 defaults are train.py's own, so an unset persona stays the
+# [D-19] sparse-win objective); --speed-ref is added only when set (train.py REQUIRES it iff the bonus
+# > 0, and rejects a bare flag), and --from-scratch only for the [D-19] control.
+build_train_argv() {
+  TRAIN_ARGV=(
+    --checkpoint "$CHECKPOINT"
+    --out "$OUT"
+    --timesteps "$TIMESTEPS"
+    --n-envs "$N_ENVS"
+    --start-method forkserver
+    --lr "$LR" --ent-coef "$ENT_COEF" --gamma "$GAMMA"
+    --reward-mode "$REWARD_MODE" --terminal-speed-bonus "$TERMINAL_SPEED_BONUS"
+    --device "$DEVICE"
+    --snapshot-dir "$SNAPSHOT_DIR" --snapshot-every "$SNAPSHOT_EVERY"
+    --snapshot-store disk
+    --reserve-baselines "$RESERVE_BASELINES"
+    --league-state-dir "$LEAGUE_STATE_DIR" --league-dump-every "$LEAGUE_DUMP_EVERY"
+    --state-dir "$STATE_DIR" --checkpoint-every "$CHECKPOINT_EVERY"
+    --log-dir "$LOG_DIR"
+  )
+  # `if` (not `[ … ] && …`): a trailing `&&` whose test is FALSE returns non-zero, which under
+  # `set -e` would make this function exit 1 and abort the launcher. `if` always returns 0 here.
+  if [ -n "$SPEED_REF" ]; then TRAIN_ARGV+=(--speed-ref "$SPEED_REF"); fi
+  if [ "${FROM_SCRATCH:-0}" = "1" ]; then TRAIN_ARGV+=(--from-scratch); fi
+}
+
 run_once() {
-  local extra=()
-  [ "${FROM_SCRATCH:-0}" = "1" ] && extra+=(--from-scratch)
-  ( cd "$ML_DIR" && python -m dicewars_ppo.train \
-      --checkpoint "$CHECKPOINT" \
-      --out "$OUT" \
-      --timesteps "$TIMESTEPS" \
-      --n-envs "$N_ENVS" \
-      --start-method forkserver \
-      --lr "$LR" --ent-coef "$ENT_COEF" --gamma "$GAMMA" \
-      --device "$DEVICE" \
-      --snapshot-dir "$SNAPSHOT_DIR" --snapshot-every "$SNAPSHOT_EVERY" \
-      --snapshot-store disk \
-      --reserve-baselines "$RESERVE_BASELINES" \
-      --league-state-dir "$LEAGUE_STATE_DIR" --league-dump-every "$LEAGUE_DUMP_EVERY" \
-      --state-dir "$STATE_DIR" --checkpoint-every "$CHECKPOINT_EVERY" \
-      --log-dir "$LOG_DIR" \
-      "${extra[@]}" )
+  build_train_argv
+  ( cd "$ML_DIR" && python -m dicewars_ppo.train "${TRAIN_ARGV[@]}" )
 }
 
 main() {
   preflight
-  log "run=$RUN_NAME root=$RUN_ROOT timesteps=$TIMESTEPS n_envs=$N_ENVS device=$DEVICE lr=$LR \
-ent_coef=$ENT_COEF R=$RESERVE_BASELINES from_scratch=${FROM_SCRATCH:-0}"
+  log "run=$RUN_NAME root=$RUN_ROOT persona=${PERSONA:-none} reward_mode=$REWARD_MODE gamma=$GAMMA \
+speed_bonus=$TERMINAL_SPEED_BONUS speed_ref=${SPEED_REF:-none} checkpoint=$CHECKPOINT \
+timesteps=$TIMESTEPS n_envs=$N_ENVS device=$DEVICE lr=$LR ent_coef=$ENT_COEF \
+R=$RESERVE_BASELINES from_scratch=${FROM_SCRATCH:-0}"
 
   local fails=0 prev_step=-1 attempt=0
   while true; do


### PR DESCRIPTION
## What & why

The shodan PPO launcher gains a **`PERSONA={conqueror,blitz,survivor}`** knob — the last thing blocking the **reward-persona roster's training track** ([docs/ml-bot/PERSONAS.md](docs/ml-bot/PERSONAS.md) §8 step 3). The bite-D reward flags (`--reward-mode`/`--terminal-speed-bonus`/`--speed-ref`) were already wired + validated in `train.py`; this **forwards** them and **warm-starts** each persona from `runs/ppo-long/ppo.pt` (the BEAT actor, not BC). The reward-persona roster is the post-BEAT initiative: train several PPO bots with deliberately different play-styles for variety/fun, measured (not vibes) by the bite-E1 behavioral-eval harness.

> Headline context: the 20M PPO run already **beat `ai_lookahead` (Δ +27.7)** and ships as `ai_ppo` (PR #78). Personas specialize that policy.

## Changes (6 files, +424 / −28)

| File | Change |
|---|---|
| `scripts/shodan/ppo-train.sh` | PERSONA preset that `:=`-defaults **only** the reward objective (mode / `GAMMA` / optional speed bonus) + a `RUN_NAME` + the ppo-long warm-start. Every other HP stays shared so **Conqueror is a matched control** (PERSONAS §3: vary reward XOR field). An **unset `PERSONA` is byte-identical** to the BEAT-run launcher. Factored the train argv into `build_train_argv` (forwards the reward flags); richer `launcher.log` line. |
| `scripts/shodan/ppo-train.cmd` | Forward `PERSONA` (+ per-run knobs) into WSL via `WSLENV` so a per-persona schtask needs no file edit. |
| `ml/tests/test_ppo_train_launcher.py` | **+9 lean-tier tests** (source-and-inspect the resolved config + the full assembled argv; no python/torch/GPU). Suite 6→15. The byte-identical test asserts the **whole** production flag set, so a silently-dropped regime flag (`--snapshot-store disk`, `--start-method forkserver`, …) goes RED instead of green. |
| `scripts/shodan/RUNBOOK.md` | §8 persona-batch recipe: concurrent launch (per-`RUN_NAME` dirs + ephemeral env-server ports = collision-free), per-persona strength gate (`ppo:gate`) + style gate (`behavior:profile`, `.weights.js`/`.fixture.json` sibling convention), schtasks env-forwarding. |
| `docs/ml-bot/PERSONAS.md` | bite F marked done; **corrected the "warm-start critic note"** — `MaskableEdgePolicy._build` always builds a **fresh** `value_net` and the repacked actor carries only `bc_net`, so `ppo-long`'s win-trained value head **never carries** (the earlier note's mechanism was wrong). |
| `docs/ml-bot/LOG.md` | Session entry. |

## How a persona launches

```bash
PERSONA=blitz TIMESTEPS=3000000 LR=1e-4 bash scripts/shodan/ppo-train.sh
```

Conqueror (`win`, γ=0.999, control) · Blitz (`win`, **γ=0.99** tempo lever) · Survivor (**`placement`**). Concurrency is collision-free, so 3 personas run together for ≈ the cost of one.

## Testing

- 15/15 launcher tests + 94 torch-free ml tests green · `bash -n` clean · ruff clean · prettier clean · `EXIT_POINTER_REJECTED` contract canary intact.
- **TDD caught a real bug:** a trailing `[ … ] && arr+=(…)` under `set -e` returned non-zero and aborted the launcher — fixed with `if` blocks.
- **4-lens adversarial review** (bash / regression / tests / docs) found **0 code bugs**; all 3 test/doc findings folded (the `behavior:profile` sibling-fixture recipe, the schtasks env mechanism, and the full-argv test strengthening).

## Scope / follow-ups (unchanged)

- This is the **mechanism**; the persona runs + their HP calibration (budget/LR) happen on shodan per the RUNBOOK.
- **bite G** (per-frame territory/elim wire scalar → Expansionist/Predator) and the Phase-2b eval-harness follow-ups remain separable.